### PR TITLE
fix: show V before F in matching question buttons

### DIFF
--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -225,7 +225,13 @@ function MatchingQuestion({
 }: QuestionCardProps) {
   const correctAnswer = question.correctAnswer as Record<string, string>;
   const items = Object.keys(correctAnswer);
-  const letters = [...new Set(Object.values(correctAnswer))].sort();
+  const letters = [...new Set(Object.values(correctAnswer))].sort(
+    (a, b) => {
+      if (a === "V" && b === "F") return -1;
+      if (a === "F" && b === "V") return 1;
+      return a.localeCompare(b);
+    },
+  );
   const [selected, setSelected] = useState<Record<string, string>>(() => {
     if (savedAnswer) {
       try {


### PR DESCRIPTION
In Spanish, the natural order is 'Verdadero y Falso' (true and false), but the alphabetical sort was rendering 'F' before 'V'.

Closes #1 