### PR TITLE
feat: add multi-theme support (system, light, dark, pink, catppuccin)

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,13 @@
     <link rel="manifest" href="/site.webmanifest?v=20260620" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#f9fafb" />
-    <meta name="color-scheme" content="light" />
+    <meta name="color-scheme" content="light dark" />
+    <script>
+      (function () {
+        var t = localStorage.getItem("theme") || "system";
+        document.documentElement.setAttribute("data-theme", t);
+      })();
+    </script>
     <title>Pásame Exámenes</title>
     <meta property="og:title" content="Pásame Exámenes" />
     <meta

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,14 +23,14 @@ function PageViewTracker() {
 function Footer() {
   const t = useT();
   return (
-    <footer className="bg-white border-t border-gray-200 py-6 text-sm text-gray-500">
+    <footer className="bg-surface-alt border-t border-border py-6 text-sm text-fg-muted">
       <div className="max-w-6xl mx-auto px-4 flex flex-col sm:flex-row items-center justify-between gap-4">
         <p className="font-medium">{t.footer.byline}</p>
         <a
           href="https://github.com/TeenBiscuits/Pasame-Examenes"
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center gap-2 text-gray-500 hover:text-gray-900 focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:outline-none rounded px-2 py-1 transition-colors"
+          className="inline-flex items-center gap-2 text-fg-muted hover:text-fg focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none rounded px-2 py-1 transition-colors"
           onClick={() => track("external_link_click", { target: "github" })}
         >
           <svg
@@ -57,7 +57,7 @@ function Footer() {
 export default function App() {
   return (
     <BrowserRouter>
-      <div className="min-h-screen min-h-svh flex flex-col bg-gray-50 text-gray-900 font-sans">
+      <div className="min-h-screen min-h-svh flex flex-col bg-surface text-fg font-sans">
         <PageViewTracker />
         <Header />
         <main className="flex-grow">

--- a/src/components/AddExamModal.tsx
+++ b/src/components/AddExamModal.tsx
@@ -41,7 +41,7 @@ export default function AddExamModal({
   return (
     <dialog
       ref={dialogRef}
-      className="animate-dialog m-auto max-w-sm rounded-2xl bg-white p-6 shadow-2xl backdrop:bg-black/50 backdrop:transition-[background-color,overlay,display] backdrop:duration-200"
+      className="animate-dialog m-auto max-w-sm rounded-2xl bg-surface-alt p-6 shadow-2xl backdrop:bg-black/50 backdrop:transition-[background-color,overlay,display] backdrop:duration-200"
       aria-labelledby="add-exam-title"
       onClick={(e) => {
         if (e.target === dialogRef.current) dialogRef.current?.close();
@@ -54,7 +54,7 @@ export default function AddExamModal({
         <div className="flex items-center justify-between mb-5">
           <h2
             id="add-exam-title"
-            className="text-lg font-semibold text-gray-900"
+            className="text-lg font-semibold text-fg"
           >
             {t.addExam.title}
           </h2>
@@ -64,7 +64,7 @@ export default function AddExamModal({
               track("add_exam_modal_close_btn", { subjectId });
               dialogRef.current?.close();
             }}
-            className="text-gray-400 hover:text-gray-600 transition-colors cursor-pointer"
+            className="text-fg-muted hover:text-fg-secondary transition-colors cursor-pointer"
             aria-label={t.addExam.close}
           >
             <svg
@@ -88,14 +88,14 @@ export default function AddExamModal({
             target="_blank"
             rel="noopener noreferrer"
             onClick={() => track("add_exam_open_issue", { subjectId })}
-            className="flex items-center gap-3 p-3 rounded-xl border-2 border-green-300 bg-green-50 hover:bg-green-100 hover:border-green-400 transition-colors cursor-pointer text-left no-underline text-inherit"
+            className="flex items-center gap-3 p-3 rounded-xl border-2 border-accent-border bg-accent-light hover:bg-accent-light hover:border-accent transition-colors cursor-pointer text-left no-underline text-inherit"
           >
             <span className="text-xl">📝</span>
             <div>
-              <div className="font-medium text-gray-900 text-sm">
+              <div className="font-medium text-fg text-sm">
                 {t.addExam.openIssue}
               </div>
-              <div className="text-xs text-gray-500">
+              <div className="text-xs text-fg-muted">
                 {t.addExam.openIssueDesc}
               </div>
             </div>
@@ -110,27 +110,27 @@ export default function AddExamModal({
           >
             <span className="text-xl">🚀</span>
             <div>
-              <div className="font-medium text-gray-900 text-sm">
+              <div className="font-medium text-fg text-sm">
                 {t.addExam.contribute}
               </div>
-              <div className="text-xs text-gray-500">
+              <div className="text-xs text-fg-muted">
                 {t.addExam.contributeDesc}
               </div>
             </div>
           </a>
 
-          <div className="pt-2 border-t border-gray-200">
+          <div className="pt-2 border-t border-border">
             <a
               href="mailto:pablo.portas@udc.es"
               onClick={() => track("add_exam_email", { subjectId })}
-              className="flex items-center gap-3 p-3 rounded-xl border-2 border-gray-200 bg-gray-50/50 hover:bg-gray-100 hover:border-gray-300 transition-colors cursor-pointer text-left no-underline text-inherit"
+              className="flex items-center gap-3 p-3 rounded-xl border-2 border-border bg-surface/50 hover:bg-surface hover:border-border transition-colors cursor-pointer text-left no-underline text-inherit"
             >
               <span className="text-xl">✉️</span>
               <div>
-                <div className="font-medium text-gray-600 text-sm">
+                <div className="font-medium text-fg-secondary text-sm">
                   {t.addExam.email}
                 </div>
-                <div className="text-xs text-gray-400">pablo.portas@udc.es</div>
+                <div className="text-xs text-fg-muted">pablo.portas@udc.es</div>
               </div>
             </a>
           </div>

--- a/src/components/AddSubjectModal.tsx
+++ b/src/components/AddSubjectModal.tsx
@@ -35,7 +35,7 @@ export default function AddSubjectModal({
   return (
     <dialog
       ref={dialogRef}
-      className="animate-dialog m-auto max-w-sm rounded-2xl bg-white p-6 shadow-2xl backdrop:bg-black/50 backdrop:transition-[background-color,overlay,display] backdrop:duration-200"
+      className="animate-dialog m-auto max-w-sm rounded-2xl bg-surface-alt p-6 shadow-2xl backdrop:bg-black/50 backdrop:transition-[background-color,overlay,display] backdrop:duration-200"
       aria-labelledby="add-subject-title"
       onClick={(e) => {
         if (e.target === dialogRef.current) dialogRef.current?.close();
@@ -48,7 +48,7 @@ export default function AddSubjectModal({
         <div className="flex items-center justify-between mb-5">
           <h2
             id="add-subject-title"
-            className="text-lg font-semibold text-gray-900"
+            className="text-lg font-semibold text-fg"
           >
             {t.addSubject.title}
           </h2>
@@ -58,7 +58,7 @@ export default function AddSubjectModal({
               track("add_subject_modal_close_btn");
               dialogRef.current?.close();
             }}
-            className="text-gray-400 hover:text-gray-600 transition-colors cursor-pointer"
+            className="text-fg-muted hover:text-fg-secondary transition-colors cursor-pointer"
             aria-label={t.addSubject.close}
           >
             <svg
@@ -82,14 +82,14 @@ export default function AddSubjectModal({
             target="_blank"
             rel="noopener noreferrer"
             onClick={() => track("add_subject_open_issue")}
-            className="flex items-center gap-3 p-3 rounded-xl border-2 border-green-300 bg-green-50 hover:bg-green-100 hover:border-green-400 transition-colors cursor-pointer text-left no-underline text-inherit"
+            className="flex items-center gap-3 p-3 rounded-xl border-2 border-accent-border bg-accent-light hover:bg-accent-light hover:border-accent transition-colors cursor-pointer text-left no-underline text-inherit"
           >
             <span className="text-xl">📝</span>
             <div>
-              <div className="font-medium text-gray-900 text-sm">
+              <div className="font-medium text-fg text-sm">
                 {t.addSubject.openIssue}
               </div>
-              <div className="text-xs text-gray-500">
+              <div className="text-xs text-fg-muted">
                 {t.addSubject.openIssueDesc}
               </div>
             </div>
@@ -104,27 +104,27 @@ export default function AddSubjectModal({
           >
             <span className="text-xl">🚀</span>
             <div>
-              <div className="font-medium text-gray-900 text-sm">
+              <div className="font-medium text-fg text-sm">
                 {t.addSubject.contribute}
               </div>
-              <div className="text-xs text-gray-500">
+              <div className="text-xs text-fg-muted">
                 {t.addSubject.contributeDesc}
               </div>
             </div>
           </a>
 
-          <div className="pt-2 border-t border-gray-200">
+          <div className="pt-2 border-t border-border">
             <a
               href="mailto:pablo.portas@udc.es"
               onClick={() => track("add_subject_email")}
-              className="flex items-center gap-3 p-3 rounded-xl border-2 border-gray-200 bg-gray-50/50 hover:bg-gray-100 hover:border-gray-300 transition-colors cursor-pointer text-left no-underline text-inherit"
+              className="flex items-center gap-3 p-3 rounded-xl border-2 border-border bg-surface/50 hover:bg-surface hover:border-border transition-colors cursor-pointer text-left no-underline text-inherit"
             >
               <span className="text-xl">✉️</span>
               <div>
-                <div className="font-medium text-gray-600 text-sm">
+                <div className="font-medium text-fg-secondary text-sm">
                   {t.addSubject.email}
                 </div>
-                <div className="text-xs text-gray-400">pablo.portas@udc.es</div>
+                <div className="text-xs text-fg-muted">pablo.portas@udc.es</div>
               </div>
             </a>
           </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,6 +3,7 @@ import { getSubject } from "../subjects";
 import { useT, useLang } from "../i18n/hooks";
 import { track } from "../lib/umami";
 import { triggerLight } from "../lib/haptics";
+import ThemeToggle from "../theme/ThemeToggle";
 
 export default function Header() {
   const location = useLocation();
@@ -12,11 +13,11 @@ export default function Header() {
   const subject = subjectId ? getSubject(subjectId) : null;
 
   return (
-    <header className="bg-white border-b border-gray-200 sticky top-0 z-50">
+    <header className="bg-surface-alt border-b border-border sticky top-0 z-50">
       <div className="max-w-6xl mx-auto px-4 h-14 flex items-center justify-between">
         <Link
           to="/"
-          className="font-bold text-lg text-gray-900 hover:text-green-600 focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:outline-none rounded-md transition-colors flex items-center gap-2.5"
+          className="font-bold text-lg text-fg hover:text-accent focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none rounded-md transition-colors flex items-center gap-2.5"
           onClick={() => {
             triggerLight();
             track("nav_click", { target: "home" });
@@ -37,10 +38,10 @@ export default function Header() {
             <nav className="flex items-center gap-2 sm:gap-4 text-sm">
               <Link
                 to={`/${subjectId}`}
-                className={`px-3 py-1.5 rounded-md focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:outline-none transition-colors ${
+                className={`px-3 py-1.5 rounded-md focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none transition-colors ${
                   location.pathname === `/${subjectId}`
-                    ? "bg-green-50 text-green-700"
-                    : "text-gray-600 hover:text-gray-900"
+                    ? "bg-accent-light text-accent-fg"
+                    : "text-fg-secondary hover:text-fg"
                 }`}
                 onClick={() => {
                   triggerLight();
@@ -54,10 +55,10 @@ export default function Header() {
               </Link>
               <Link
                 to={`/${subjectId}/practice`}
-                className={`px-3 py-1.5 rounded-md focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:outline-none transition-colors ${
+                className={`px-3 py-1.5 rounded-md focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none transition-colors ${
                   location.pathname.startsWith(`/${subjectId}/practice`)
-                    ? "bg-green-50 text-green-700"
-                    : "text-gray-600 hover:text-gray-900"
+                    ? "bg-accent-light text-accent-fg"
+                    : "text-fg-secondary hover:text-fg"
                 }`}
                 onClick={() => {
                   triggerLight();
@@ -71,8 +72,9 @@ export default function Header() {
               </Link>
             </nav>
           )}
+          <ThemeToggle />
           <button
-            className="px-2 py-1 text-xs font-medium rounded border border-gray-200 hover:bg-gray-100 active:scale-95 transition"
+            className="px-2 py-1 text-xs font-medium rounded border border-border hover:bg-surface active:scale-95 transition"
             onClick={() => {
               triggerLight();
               const nextLang = lang === "en" ? "es" : "en";

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -62,15 +62,15 @@ function MCQuestion({
         const isSelected = savedAnswer === letter;
         const isCorrect = question.correctAnswer === letter;
         let className =
-          "w-full p-3 rounded-lg border-2 cursor-pointer active:scale-[0.98] focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:outline-none transition duration-150 text-left text-sm flex items-start gap-3";
+          "w-full p-3 rounded-lg border-2 cursor-pointer active:scale-[0.98] focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none transition duration-150 text-left text-sm flex items-start gap-3";
         if (showResult && isCorrect) {
-          className += " bg-green-50 border-green-400";
+          className += " bg-accent-light border-accent";
         } else if (showResult && isSelected && !isCorrect) {
           className += " bg-red-50 border-red-400";
         } else if (isSelected) {
-          className += " bg-green-50 border-green-400";
+          className += " bg-accent-light border-accent";
         } else {
-          className += " border-gray-200 hover:border-gray-300 bg-white";
+          className += " border-border hover:border-border bg-surface-alt";
         }
 
         return (
@@ -90,7 +90,7 @@ function MCQuestion({
             disabled={!!showResult}
           >
             <span
-              className={`font-mono font-bold text-xs w-5 h-5 rounded-full bg-gray-100 flex items-center justify-center shrink-0 mt-0.5 ${isSelected ? "animate-pop" : ""}`}
+              className={`font-mono font-bold text-xs w-5 h-5 rounded-full bg-code flex items-center justify-center shrink-0 mt-0.5 ${isSelected ? "animate-pop" : ""}`}
             >
               {letter}
             </span>
@@ -122,7 +122,7 @@ function TextQuestion({
       </label>
       <textarea
         id={`answer-${question.id}`}
-        className="w-full p-3 border-2 border-gray-200 rounded-lg focus:border-green-400 focus-visible:ring-2 focus-visible:ring-green-400 focus-visible:outline-none resize-y min-h-[120px] text-sm"
+        className="w-full p-3 border-2 border-border rounded-lg focus:border-accent focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none resize-y min-h-[120px] text-sm"
         placeholder="Type your answer…"
         autoComplete="off"
         spellCheck={false}
@@ -134,7 +134,7 @@ function TextQuestion({
         <div className="mt-3 space-y-3">
           <button
             type="button"
-            className="text-sm text-green-600 hover:text-green-700 font-medium active:scale-95 focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:outline-none rounded-md px-1.5 py-0.5 border border-transparent hover:border-green-200 transition"
+            className="text-sm text-accent hover:text-accent-fg font-medium active:scale-95 focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none rounded-md px-1.5 py-0.5 border border-transparent hover:border-accent-border transition"
             onClick={() => {
               triggerLight();
               const next = !isOpen;
@@ -151,22 +151,22 @@ function TextQuestion({
           </button>
 
           {isOpen && (
-            <div className="p-4 bg-gray-50 rounded-lg border border-gray-200 space-y-3">
-              <h4 className="text-xs font-bold uppercase tracking-wider text-gray-400">
+            <div className="p-4 bg-surface rounded-lg border border-border space-y-3">
+              <h4 className="text-xs font-bold uppercase tracking-wider text-fg-muted">
                 {t.questionCard.modelSolution}
               </h4>
-              <Markdown className="text-xs whitespace-pre-wrap font-sans text-gray-700">
+              <Markdown className="text-xs whitespace-pre-wrap font-sans text-fg-secondary">
                 {typeof question.correctAnswer === "string"
                   ? question.correctAnswer
                   : JSON.stringify(question.correctAnswer, null, 2)}
               </Markdown>
-              <Markdown className="text-xs text-gray-500 italic">
+              <Markdown className="text-xs text-fg-muted italic">
                 {question.explanation}
               </Markdown>
 
               {onSelfGrade && (
-                <div className="pt-2 border-t border-gray-200">
-                  <p className="text-xs font-semibold text-gray-700 mb-2">
+                <div className="pt-2 border-t border-border">
+                  <p className="text-xs font-semibold text-fg-secondary mb-2">
                     {t.questionCard.gradeAnswer}
                   </p>
                   <div className="flex gap-2">
@@ -180,10 +180,10 @@ function TextQuestion({
                         });
                         onSelfGrade(question.id, "correct");
                       }}
-                      className={`px-3 py-1.5 text-xs font-medium rounded-md border-2 active:scale-95 transition focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:outline-none ${
+                      className={`px-3 py-1.5 text-xs font-medium rounded-md border-2 active:scale-95 transition focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none ${
                         selfGrade === "correct"
-                          ? "bg-green-50 border-green-500 text-green-700"
-                          : "bg-white border-gray-200 text-gray-600 hover:bg-green-50/50 hover:border-green-300"
+                          ? "bg-accent-light border-accent text-accent-fg"
+                          : "bg-surface-alt border-border text-fg-secondary hover:bg-accent-light/50 hover:border-accent-border"
                       }`}
                     >
                       {t.questionCard.correct}
@@ -201,7 +201,7 @@ function TextQuestion({
                       className={`px-3 py-1.5 text-xs font-medium rounded-md border-2 active:scale-95 transition focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:outline-none ${
                         selfGrade === "incorrect"
                           ? "bg-red-50 border-red-500 text-red-700"
-                          : "bg-white border-gray-200 text-gray-600 hover:bg-red-50/50 hover:border-red-300"
+                          : "bg-surface-alt border-border text-fg-secondary hover:bg-red-50/50 hover:border-red-300"
                       }`}
                     >
                       {t.questionCard.incorrect}
@@ -257,10 +257,10 @@ function MatchingQuestion({
 
         return (
           <div key={i} className="flex items-center gap-3 text-sm">
-            <span className="w-6 text-center font-mono text-xs text-gray-400">
+            <span className="w-6 text-center font-mono text-xs text-fg-muted">
               {i + 1}.
             </span>
-            <span className="flex-1 text-gray-700">
+            <span className="flex-1 text-fg-secondary">
               <InlineMarkdown>{item}</InlineMarkdown>
             </span>
             <div className="flex gap-1">
@@ -268,16 +268,16 @@ function MatchingQuestion({
                 const chosen = userAnswer === letter;
                 const real = correctAnswer[item] === letter;
                 let cls =
-                  "w-8 h-8 rounded-md border-2 text-xs font-bold font-mono active:scale-90 focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:outline-none transition flex items-center justify-center";
+                  "w-8 h-8 rounded-md border-2 text-xs font-bold font-mono active:scale-90 focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none transition flex items-center justify-center";
                 if (showResult && real) {
-                  cls += " bg-green-50 border-green-400 text-green-700";
+                  cls += " bg-accent-light border-accent text-accent-fg";
                 } else if (showResult && chosen && !real) {
                   cls += " bg-red-50 border-red-400 text-red-700";
                 } else if (chosen) {
-                  cls += " bg-green-50 border-green-400 text-green-700";
+                  cls += " bg-accent-light border-accent text-accent-fg";
                 } else {
                   cls +=
-                    " border-gray-200 text-gray-500 hover:border-gray-400 bg-white";
+                    " border-border text-fg-muted hover:border-fg-muted bg-surface-alt";
                 }
                 return (
                   <button
@@ -321,22 +321,22 @@ export default function QuestionCard(props: QuestionCardProps) {
 
   return (
     <div
-      className={`bg-white rounded-xl border border-gray-200 p-6 shadow-sm ${slideClass}`}
+      className={`bg-surface-alt rounded-xl border border-border p-6 shadow-sm ${slideClass}`}
     >
       <div className="flex items-center gap-2 mb-4">
-        <span className="text-xs font-mono bg-gray-100 text-gray-600 px-2 py-0.5 rounded">
+        <span className="text-xs font-mono bg-code text-fg-secondary px-2 py-0.5 rounded">
           Q{props.index + 1}/{props.total}
         </span>
-        <span className="text-xs font-mono bg-green-50 text-green-700 px-2 py-0.5 rounded">
+        <span className="text-xs font-mono bg-accent-light text-accent-fg px-2 py-0.5 rounded">
           {question.points}p
         </span>
-        <span className="text-xs text-gray-400">
+        <span className="text-xs text-fg-muted">
           {props.megatopicLabel
             ? `${props.megatopicLabel} › ${props.topicLabel}`
             : props.topicLabel}
         </span>
         {props.examDate && (
-          <span className="text-xs text-gray-400 ml-auto">
+          <span className="text-xs text-fg-muted ml-auto">
             {props.examDate}
           </span>
         )}
@@ -346,11 +346,11 @@ export default function QuestionCard(props: QuestionCardProps) {
           </span>
         )}
       </div>
-      <Markdown className="text-sm text-gray-900 font-medium mb-4">
+      <Markdown className="text-sm text-fg font-medium mb-4">
         {question.question}
       </Markdown>
       {question.subquestions && (
-        <ul className="list-disc list-inside text-sm text-gray-600 mb-4 space-y-1">
+        <ul className="list-disc list-inside text-sm text-fg-secondary mb-4 space-y-1">
           {question.subquestions.map((sq, i) => (
             <li key={i}>
               <InlineMarkdown>{sq}</InlineMarkdown>
@@ -359,7 +359,7 @@ export default function QuestionCard(props: QuestionCardProps) {
         </ul>
       )}
       {question.image && (
-        <div className="mb-4 rounded-lg overflow-hidden border border-gray-100 max-w-full flex justify-center bg-gray-50 p-2">
+        <div className="mb-4 rounded-lg overflow-hidden border border-border max-w-full flex justify-center bg-surface p-2">
           <img
             src={question.image}
             alt={`Illustration for ${question.id}`}
@@ -371,28 +371,28 @@ export default function QuestionCard(props: QuestionCardProps) {
         </div>
       )}
       {question.table && (
-        <div className="mb-4 overflow-x-auto rounded-lg border border-gray-200">
-          <table className="min-w-full divide-y divide-gray-200 text-sm">
-            <thead className="bg-gray-50">
+        <div className="mb-4 overflow-x-auto rounded-lg border border-border">
+          <table className="min-w-full divide-y divide-border text-sm">
+            <thead className="bg-surface">
               <tr>
                 {question.table.headers.map((h, i) => (
                   <th
                     key={i}
                     scope="col"
-                    className="px-4 py-2 text-left font-semibold text-gray-900 whitespace-nowrap"
+                    className="px-4 py-2 text-left font-semibold text-fg whitespace-nowrap"
                   >
                     <InlineMarkdown>{h}</InlineMarkdown>
                   </th>
                 ))}
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-200 bg-white">
+            <tbody className="divide-y divide-border bg-surface-alt">
               {question.table.rows.map((row, ri) => (
-                <tr key={ri} className="hover:bg-gray-50/50 transition-colors">
+                <tr key={ri} className="hover:bg-surface/50 transition-colors">
                   {row.map((cell, ci) => (
                     <td
                       key={ci}
-                      className="px-4 py-2 text-gray-700 whitespace-nowrap"
+                      className="px-4 py-2 text-fg-secondary whitespace-nowrap"
                     >
                       <InlineMarkdown>{cell}</InlineMarkdown>
                     </td>
@@ -408,15 +408,15 @@ export default function QuestionCard(props: QuestionCardProps) {
         <TextQuestion {...props} />
       )}
       {question.type === "matching" && <MatchingQuestion {...props} />}
-      <div className="mt-4 pt-4 border-t border-gray-100 flex items-center justify-end gap-2">
-        <span className="text-[10px] font-mono text-gray-300 select-all">
+      <div className="mt-4 pt-4 border-t border-border flex items-center justify-end gap-2">
+        <span className="text-[10px] font-mono text-fg-muted select-all">
           {question.id}
         </span>
         <a
           href={buildReportUrl(question, props.subjectId)}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center gap-1 text-xs text-gray-400 hover:text-red-500 transition-colors focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:outline-none rounded px-2 py-1 -mr-2"
+          className="inline-flex items-center gap-1 text-xs text-fg-muted hover:text-red-500 transition-colors focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:outline-none rounded px-2 py-1 -mr-2"
           onClick={() => {
             triggerLight();
             track("report_issue", {

--- a/src/components/SubjectCard.tsx
+++ b/src/components/SubjectCard.tsx
@@ -16,7 +16,7 @@ export default function SubjectCard({ subject }: SubjectCardProps) {
   return (
     <Link
       to={`/${subject.id}`}
-      className="block p-5 rounded-xl border-2 border-gray-200 hover:border-green-400 bg-white hover:bg-green-50/30 hover:scale-[1.02] hover:shadow-md focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:outline-none transition-colors transition-transform duration-200"
+      className="block p-5 rounded-xl border-2 border-border hover:border-accent bg-surface-alt hover:bg-accent-light/30 hover:scale-[1.02] hover:shadow-md focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none transition-colors transition-transform duration-200"
       onClick={() => {
         triggerLight();
         track("subject_card_click", { subjectId: subject.id });
@@ -26,15 +26,15 @@ export default function SubjectCard({ subject }: SubjectCardProps) {
         <span className="text-2xl" role="img" aria-hidden="true">
           {subject.icon}
         </span>
-        <span className="text-xs font-mono font-semibold bg-gray-100 text-gray-600 px-2 py-0.5 rounded">
+        <span className="text-xs font-mono font-semibold bg-code text-fg-secondary px-2 py-0.5 rounded">
           {subject.courseCode}
         </span>
       </div>
-      <h3 className="font-semibold text-gray-900 text-base mb-1">
+      <h3 className="font-semibold text-fg text-base mb-1">
         {subject.name}
       </h3>
-      <p className="text-sm text-gray-500 mb-4">{subject.university}</p>
-      <div className="text-xs text-gray-400 flex items-center gap-2">
+      <p className="text-sm text-fg-muted mb-4">{subject.university}</p>
+      <div className="text-xs text-fg-muted flex items-center gap-2">
         <span>
           {qs.length} {t.subjectCard.questions}
         </span>

--- a/src/components/TopicCard.tsx
+++ b/src/components/TopicCard.tsx
@@ -40,7 +40,7 @@ export default function TopicCard({
   return (
     <Link
       to={`/${subjectId}/practice/${topic.key}`}
-      className={`block p-5 rounded-xl border-2 hover:scale-[1.02] hover:shadow-md focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:outline-none transition-colors transition-transform duration-200 ${colorMap[topic.color] || colorMap.blue}`}
+      className={`block p-5 rounded-xl border-2 hover:scale-[1.02] hover:shadow-md focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none transition-colors transition-transform duration-200 ${colorMap[topic.color] || colorMap.blue}`}
       onClick={() => {
         triggerLight();
         track("topic_card_click", { subjectId, topic: topic.key });
@@ -50,19 +50,19 @@ export default function TopicCard({
         <span className="text-2xl" role="img" aria-hidden="true">
           {topic.icon}
         </span>
-        <span className="text-xs text-gray-500 font-medium">
+        <span className="text-xs text-fg-muted font-medium">
           {questionCount} {t.subjectCard.questions} &middot; {pointsCount}{" "}
           {t.subjectCard.points}
         </span>
       </div>
-      <h3 className="font-semibold text-gray-900 text-sm mb-2">
+      <h3 className="font-semibold text-fg text-sm mb-2">
         {topic.label}
       </h3>
       {progress !== undefined && (
         <div className="mt-2">
-          <div className="h-1.5 bg-gray-200 rounded-full overflow-hidden">
+          <div className="h-1.5 bg-surface rounded-full overflow-hidden">
             <div
-              className="h-full bg-green-500 rounded-full transition-all duration-500"
+              className="h-full bg-accent rounded-full transition-all duration-500"
               style={{ width: `${Math.min(progress, 100)}%` }}
             />
           </div>

--- a/src/components/TopicCard.tsx
+++ b/src/components/TopicCard.tsx
@@ -13,20 +13,20 @@ interface TopicCardProps {
 }
 
 const colorMap: Record<string, string> = {
-  blue: "border-blue-200 hover:border-blue-400 bg-blue-50/50 hover:bg-blue-50",
+  blue: "border-t-blue-border hover:border-t-blue-hover bg-t-blue-bg/50 hover:bg-t-blue-bg",
   indigo:
-    "border-indigo-200 hover:border-indigo-400 bg-indigo-50/50 hover:bg-indigo-50",
+    "border-t-indigo-border hover:border-t-indigo-hover bg-t-indigo-bg/50 hover:bg-t-indigo-bg",
   green:
-    "border-green-200 hover:border-green-400 bg-green-50/50 hover:bg-green-50",
+    "border-t-green-border hover:border-t-green-hover bg-t-green-bg/50 hover:bg-t-green-bg",
   purple:
-    "border-purple-200 hover:border-purple-400 bg-purple-50/50 hover:bg-purple-50",
-  pink: "border-pink-200 hover:border-pink-400 bg-pink-50/50 hover:bg-pink-50",
+    "border-t-purple-border hover:border-t-purple-hover bg-t-purple-bg/50 hover:bg-t-purple-bg",
+  pink: "border-t-pink-border hover:border-t-pink-hover bg-t-pink-bg/50 hover:bg-t-pink-bg",
   amber:
-    "border-amber-200 hover:border-amber-400 bg-amber-50/50 hover:bg-amber-50",
-  red: "border-red-200 hover:border-red-400 bg-red-50/50 hover:bg-red-50",
-  cyan: "border-cyan-200 hover:border-cyan-400 bg-cyan-50/50 hover:bg-cyan-50",
+    "border-t-amber-border hover:border-t-amber-hover bg-t-amber-bg/50 hover:bg-t-amber-bg",
+  red: "border-t-red-border hover:border-t-red-hover bg-t-red-bg/50 hover:bg-t-red-bg",
+  cyan: "border-t-cyan-border hover:border-t-cyan-hover bg-t-cyan-bg/50 hover:bg-t-cyan-bg",
   orange:
-    "border-orange-200 hover:border-orange-400 bg-orange-50/50 hover:bg-orange-50",
+    "border-t-orange-border hover:border-t-orange-hover bg-t-orange-bg/50 hover:bg-t-orange-bg",
 };
 
 export default function TopicCard({

--- a/src/components/TopicCard.tsx
+++ b/src/components/TopicCard.tsx
@@ -60,7 +60,7 @@ export default function TopicCard({
       </h3>
       {progress !== undefined && (
         <div className="mt-2">
-          <div className="h-1.5 bg-surface rounded-full overflow-hidden">
+          <div className="h-1.5 bg-border rounded-full overflow-hidden">
             <div
               className="h-full bg-accent rounded-full transition-all duration-500"
               style={{ width: `${Math.min(progress, 100)}%` }}

--- a/src/index.css
+++ b/src/index.css
@@ -16,6 +16,34 @@
   --color-accent-border: #bbf7d0;
   --color-code: #f3f4f6;
   --color-code-block: #111827;
+  /* Topic card colors */
+  --color-t-blue-bg: #eff6ff;
+  --color-t-blue-border: #bfdbfe;
+  --color-t-blue-hover: #60a5fa;
+  --color-t-indigo-bg: #eef2ff;
+  --color-t-indigo-border: #c7d2fe;
+  --color-t-indigo-hover: #818cf8;
+  --color-t-green-bg: #f0fdf4;
+  --color-t-green-border: #bbf7d0;
+  --color-t-green-hover: #4ade80;
+  --color-t-purple-bg: #faf5ff;
+  --color-t-purple-border: #e9d5ff;
+  --color-t-purple-hover: #c084fc;
+  --color-t-pink-bg: #fdf2f8;
+  --color-t-pink-border: #fbcfe8;
+  --color-t-pink-hover: #f472b6;
+  --color-t-amber-bg: #fffbeb;
+  --color-t-amber-border: #fde68a;
+  --color-t-amber-hover: #fbbf24;
+  --color-t-red-bg: #fef2f2;
+  --color-t-red-border: #fecaca;
+  --color-t-red-hover: #f87171;
+  --color-t-cyan-bg: #ecfeff;
+  --color-t-cyan-border: #a5f3fc;
+  --color-t-cyan-hover: #22d3ee;
+  --color-t-orange-bg: #fff7ed;
+  --color-t-orange-border: #fed7aa;
+  --color-t-orange-hover: #fb923c;
 }
 
 /* ── Dark theme ── */
@@ -33,6 +61,34 @@ html[data-theme="dark"] {
   --color-accent-border: #166534;
   --color-code: #374151;
   --color-code-block: #030712;
+  /* Topic cards – darker saturated shades */
+  --color-t-blue-bg: #172554;
+  --color-t-blue-border: #1e3a8a;
+  --color-t-blue-hover: #3b82f6;
+  --color-t-indigo-bg: #1e1b4b;
+  --color-t-indigo-border: #312e81;
+  --color-t-indigo-hover: #6366f1;
+  --color-t-green-bg: #052e16;
+  --color-t-green-border: #14532d;
+  --color-t-green-hover: #22c55e;
+  --color-t-purple-bg: #3b0764;
+  --color-t-purple-border: #581c87;
+  --color-t-purple-hover: #a855f7;
+  --color-t-pink-bg: #500724;
+  --color-t-pink-border: #831843;
+  --color-t-pink-hover: #ec4899;
+  --color-t-amber-bg: #451a03;
+  --color-t-amber-border: #78350f;
+  --color-t-amber-hover: #f59e0b;
+  --color-t-red-bg: #450a0a;
+  --color-t-red-border: #7f1d1d;
+  --color-t-red-hover: #ef4444;
+  --color-t-cyan-bg: #083344;
+  --color-t-cyan-border: #164e63;
+  --color-t-cyan-hover: #06b6d4;
+  --color-t-orange-bg: #431407;
+  --color-t-orange-border: #7c2d12;
+  --color-t-orange-hover: #f97316;
 }
 
 /* ── Pink theme ── */
@@ -67,6 +123,34 @@ html[data-theme="catppuccin"] {
   --color-accent-border: #45475a;
   --color-code: #313244;
   --color-code-block: #11111b;
+  /* Topic cards – catppuccin palette */
+  --color-t-blue-bg: #313244;
+  --color-t-blue-border: #45475a;
+  --color-t-blue-hover: #89b4fa;
+  --color-t-indigo-bg: #313244;
+  --color-t-indigo-border: #45475a;
+  --color-t-indigo-hover: #b4befe;
+  --color-t-green-bg: #313244;
+  --color-t-green-border: #45475a;
+  --color-t-green-hover: #a6e3a1;
+  --color-t-purple-bg: #313244;
+  --color-t-purple-border: #45475a;
+  --color-t-purple-hover: #cba6f7;
+  --color-t-pink-bg: #313244;
+  --color-t-pink-border: #45475a;
+  --color-t-pink-hover: #f5c2e7;
+  --color-t-amber-bg: #313244;
+  --color-t-amber-border: #45475a;
+  --color-t-amber-hover: #f9e2af;
+  --color-t-red-bg: #313244;
+  --color-t-red-border: #45475a;
+  --color-t-red-hover: #f38ba8;
+  --color-t-cyan-bg: #313244;
+  --color-t-cyan-border: #45475a;
+  --color-t-cyan-hover: #94e2d5;
+  --color-t-orange-bg: #313244;
+  --color-t-orange-border: #45475a;
+  --color-t-orange-hover: #fab387;
 }
 
 /* ── System: follow OS preference ── */
@@ -85,6 +169,34 @@ html[data-theme="catppuccin"] {
     --color-accent-border: #166534;
     --color-code: #374151;
     --color-code-block: #030712;
+    /* Topic cards */
+    --color-t-blue-bg: #172554;
+    --color-t-blue-border: #1e3a8a;
+    --color-t-blue-hover: #3b82f6;
+    --color-t-indigo-bg: #1e1b4b;
+    --color-t-indigo-border: #312e81;
+    --color-t-indigo-hover: #6366f1;
+    --color-t-green-bg: #052e16;
+    --color-t-green-border: #14532d;
+    --color-t-green-hover: #22c55e;
+    --color-t-purple-bg: #3b0764;
+    --color-t-purple-border: #581c87;
+    --color-t-purple-hover: #a855f7;
+    --color-t-pink-bg: #500724;
+    --color-t-pink-border: #831843;
+    --color-t-pink-hover: #ec4899;
+    --color-t-amber-bg: #451a03;
+    --color-t-amber-border: #78350f;
+    --color-t-amber-hover: #f59e0b;
+    --color-t-red-bg: #450a0a;
+    --color-t-red-border: #7f1d1d;
+    --color-t-red-hover: #ef4444;
+    --color-t-cyan-bg: #083344;
+    --color-t-cyan-border: #164e63;
+    --color-t-cyan-hover: #06b6d4;
+    --color-t-orange-bg: #431407;
+    --color-t-orange-border: #7c2d12;
+    --color-t-orange-hover: #f97316;
   }
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,116 @@
 @import "tailwindcss";
 @import "tailwind-animations";
 
+/* ── Theme tokens (light defaults) ── */
+@theme {
+  --color-surface: #f9fafb;
+  --color-surface-alt: #ffffff;
+  --color-fg: #111827;
+  --color-fg-secondary: #4b5563;
+  --color-fg-muted: #6b7280;
+  --color-border: #e5e7eb;
+  --color-accent: #16a34a;
+  --color-accent-light: #f0fdf4;
+  --color-accent-fg: #15803d;
+  --color-accent-hover: #15803d;
+  --color-accent-border: #bbf7d0;
+  --color-code: #f3f4f6;
+  --color-code-block: #111827;
+}
+
+/* ── Dark theme ── */
+html[data-theme="dark"] {
+  --color-surface: #111827;
+  --color-surface-alt: #1f2937;
+  --color-fg: #f9fafb;
+  --color-fg-secondary: #9ca3af;
+  --color-fg-muted: #6b7280;
+  --color-border: #374151;
+  --color-accent: #22c55e;
+  --color-accent-light: #052e16;
+  --color-accent-fg: #86efac;
+  --color-accent-hover: #4ade80;
+  --color-accent-border: #166534;
+  --color-code: #374151;
+  --color-code-block: #030712;
+}
+
+/* ── Pink theme ── */
+html[data-theme="pink"] {
+  --color-surface: #fdf2f8;
+  --color-surface-alt: #ffffff;
+  --color-fg: #111827;
+  --color-fg-secondary: #4b5563;
+  --color-fg-muted: #6b7280;
+  --color-border: #fbcfe8;
+  --color-accent: #db2777;
+  --color-accent-light: #fce7f3;
+  --color-accent-fg: #be185d;
+  --color-accent-hover: #be185d;
+  --color-accent-border: #fbcfe8;
+  --color-code: #f3f4f6;
+  --color-code-block: #111827;
+}
+
+/* ── Catppuccin Mocha theme ── */
+html[data-theme="catppuccin"] {
+  --color-surface: #1e1e2e;
+  --color-surface-alt: #313244;
+  --color-fg: #cdd6f4;
+  --color-fg-secondary: #a6adc8;
+  --color-fg-muted: #6c7086;
+  --color-border: #45475a;
+  --color-accent: #a6e3a1;
+  --color-accent-light: #313244;
+  --color-accent-fg: #a6e3a1;
+  --color-accent-hover: #a6e3a1;
+  --color-accent-border: #45475a;
+  --color-code: #313244;
+  --color-code-block: #11111b;
+}
+
+/* ── System: follow OS preference ── */
+@media (prefers-color-scheme: dark) {
+  html[data-theme="system"] {
+    --color-surface: #111827;
+    --color-surface-alt: #1f2937;
+    --color-fg: #f9fafb;
+    --color-fg-secondary: #9ca3af;
+    --color-fg-muted: #6b7280;
+    --color-border: #374151;
+    --color-accent: #22c55e;
+    --color-accent-light: #052e16;
+    --color-accent-fg: #86efac;
+    --color-accent-hover: #4ade80;
+    --color-accent-border: #166534;
+    --color-code: #374151;
+    --color-code-block: #030712;
+  }
+}
+
+/* ── View transition animation ── */
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation-duration: 0.25s;
+}
+
+/* ── Theme icon transition ── */
+@keyframes theme-icon-in {
+  from {
+    opacity: 0;
+    transform: rotate(-90deg) scale(0.5);
+  }
+  to {
+    opacity: 1;
+    transform: rotate(0deg) scale(1);
+  }
+}
+
+.theme-icon {
+  animation: theme-icon-in 0.3s ease-out;
+}
+
+/* ── Dialog animations ── */
 .animate-dialog {
   opacity: 0;
   transform: scale(0.95);

--- a/src/lib/markdown.tsx
+++ b/src/lib/markdown.tsx
@@ -27,7 +27,7 @@ function parseInline(text: string): ReactNode[] {
       return (
         <code
           key={i}
-          className="font-mono text-[0.85em] bg-gray-100 text-pink-600 px-1.5 py-0.5 rounded"
+          className="font-mono text-[0.85em] bg-code text-pink-600 px-1.5 py-0.5 rounded"
         >
           {part.slice(1, -1)}
         </code>
@@ -45,7 +45,7 @@ function renderBlocks(text: string): ReactNode[] {
       return [
         <div
           key={`cb-${i}`}
-          className="my-3 rounded-lg border border-gray-200 bg-gray-900 overflow-hidden"
+          className="my-3 rounded-lg border border-border bg-code-block overflow-hidden"
         >
           <pre className="p-4 overflow-x-auto text-xs leading-relaxed">
             <code className="text-gray-100 font-mono whitespace-pre">

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,11 +3,14 @@ import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.tsx";
 import { I18nProvider } from "./i18n/context";
+import { ThemeProvider } from "./theme/context";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <I18nProvider>
-      <App />
-    </I18nProvider>
+    <ThemeProvider>
+      <I18nProvider>
+        <App />
+      </I18nProvider>
+    </ThemeProvider>
   </StrictMode>,
 );

--- a/src/pages/ExamSimulation.tsx
+++ b/src/pages/ExamSimulation.tsx
@@ -275,10 +275,10 @@ export default function ExamSimulation() {
   if (questions.length === 0 || !subject || !examInfo) {
     return (
       <div className="max-w-3xl mx-auto px-4 py-16 text-center">
-        <p className="text-gray-500">{t.exam.noQuestions}</p>
+        <p className="text-fg-muted">{t.exam.noQuestions}</p>
         <Link
           to={subject ? `/${subject.id}` : "/"}
-          className="text-green-600 hover:underline mt-4 inline-block"
+          className="text-accent hover:underline mt-4 inline-block"
           onClick={() => triggerLight()}
         >
           {t.exam.backToHome}
@@ -293,35 +293,35 @@ export default function ExamSimulation() {
         <div className="mb-6">
           <Link
             to={`/${subject.id}`}
-            className="text-sm text-green-600 hover:underline focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:outline-none rounded-md px-1"
+            className="text-sm text-accent hover:underline focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none rounded-md px-1"
           >
             {t.exam.backToSubject}
           </Link>
         </div>
         <div className="text-center">
-          <h1 className="text-3xl font-bold text-gray-900 mb-2">
+          <h1 className="text-3xl font-bold text-fg mb-2">
             {examInfo.title}
           </h1>
-          <p className="text-gray-500 mb-8">
+          <p className="text-fg-muted mb-8">
             {subject.name} ({subject.courseCode})
           </p>
         </div>
-        <div className="bg-white rounded-xl border border-gray-200 p-8 shadow-sm space-y-4">
+        <div className="bg-surface-alt rounded-xl border border-border p-8 shadow-sm space-y-4">
           <div className="grid grid-cols-2 gap-4 text-sm">
             <div>
-              <span className="text-gray-500">{t.exam.questions}</span>
+              <span className="text-fg-muted">{t.exam.questions}</span>
               <p className="font-semibold">{questions.length}</p>
             </div>
             <div>
-              <span className="text-gray-500">{t.exam.totalPoints}</span>
+              <span className="text-fg-muted">{t.exam.totalPoints}</span>
               <p className="font-semibold">{totalPoints}p</p>
             </div>
             <div>
-              <span className="text-gray-500">{t.exam.pass}</span>
+              <span className="text-fg-muted">{t.exam.pass}</span>
               <p className="font-semibold">{examInfo.passPoints}p</p>
             </div>
             <div>
-              <span className="text-gray-500">{t.exam.timeLimit}</span>
+              <span className="text-fg-muted">{t.exam.timeLimit}</span>
               <p className="font-semibold">
                 {examInfo.durationMinutes} {t.exam.minutes}
               </p>
@@ -331,7 +331,7 @@ export default function ExamSimulation() {
             {t.exam.simulationNote}
           </div>
           <button
-            className="w-full py-3 bg-green-600 text-white rounded-lg hover:bg-green-700 active:scale-[0.98] focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:outline-none transition font-medium animate-pulse"
+            className="w-full py-3 bg-accent text-white rounded-lg hover:bg-accent-hover active:scale-[0.98] focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none transition font-medium animate-pulse"
             onClick={handleStart}
           >
             {t.exam.startExam}
@@ -366,31 +366,31 @@ export default function ExamSimulation() {
               e.preventDefault();
             }
           }}
-          className="text-sm text-green-600 hover:underline focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:outline-none rounded-md px-1"
+          className="text-sm text-accent hover:underline focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none rounded-md px-1"
         >
           {t.exam.backToSubject}
         </Link>
       </div>
-      <div className="flex items-center justify-between mb-6 sticky top-14 bg-gray-50 py-3 -mx-4 px-4 z-40 border-b border-gray-200">
+      <div className="flex items-center justify-between mb-6 sticky top-14 bg-surface py-3 -mx-4 px-4 z-40 border-b border-border">
         <div>
-          <span className="text-lg font-bold text-gray-900">
+          <span className="text-lg font-bold text-fg">
             {examInfo.title}
           </span>
-          <span className="text-sm text-gray-500 ml-3">
+          <span className="text-sm text-fg-muted ml-3">
             {totalPoints}p {t.exam.total}
           </span>
         </div>
         <div className="flex items-center gap-4">
           {!submitted && (
             <span
-              className={`font-mono text-sm font-bold ${timeLeft < 600 ? "text-red-600 animate-pulse" : "text-gray-700"}`}
+              className={`font-mono text-sm font-bold ${timeLeft < 600 ? "text-red-600 animate-pulse" : "text-fg-secondary"}`}
             >
               {formatTime(timeLeft)}
             </span>
           )}
           {submitted && (
             <span
-              className={`text-sm font-bold px-3 py-1 rounded animate-fade-in ${score >= examInfo.passPoints ? "bg-green-50 text-green-700" : "bg-red-50 text-red-700"}`}
+              className={`text-sm font-bold px-3 py-1 rounded animate-fade-in ${score >= examInfo.passPoints ? "bg-accent-light text-accent-fg" : "bg-red-50 text-red-700"}`}
             >
               {score}/{totalPoints}p{" "}
               {score >= examInfo.passPoints ? t.exam.pass_ : t.exam.fail}
@@ -400,13 +400,13 @@ export default function ExamSimulation() {
       </div>
 
       {submitted && (
-        <div className="mb-6 p-4 rounded-lg bg-green-50 border border-green-200 text-sm animate-fade-in-up">
-          <p className="font-semibold text-green-900 mb-1">
+        <div className="mb-6 p-4 rounded-lg bg-accent-light border border-accent-border text-sm animate-fade-in-up">
+          <p className="font-semibold text-fg mb-1">
             {t.exam.submitted} {t.exam.score}: {score}
             {t.exam.outOf}
             {totalPoints} ({Math.round((score / totalPoints) * 100)}%)
           </p>
-          <p className="text-green-700">
+          <p className="text-accent-fg">
             {t.exam.passThreshold}: {examInfo.passPoints}p. {t.exam.reviewNote}
           </p>
         </div>
@@ -430,11 +430,11 @@ export default function ExamSimulation() {
           const isAnswered = answers[q.id] && answers[q.id].trim() !== "";
           const isCurrent = i === currentIndex;
           let cls =
-            "w-8 h-8 rounded-md text-xs font-mono flex items-center justify-center border shrink-0 active:scale-90 focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:outline-none transition cursor-pointer";
-          if (isCurrent) cls += " bg-green-600 text-white border-green-600";
+            "w-8 h-8 rounded-md text-xs font-mono flex items-center justify-center border shrink-0 active:scale-90 focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none transition cursor-pointer";
+          if (isCurrent) cls += " bg-accent text-white border-accent";
           else if (isAnswered)
-            cls += " bg-green-50 border-green-300 text-green-700";
-          else cls += " border-gray-200 text-gray-500 hover:border-gray-400";
+            cls += " bg-accent-light border-accent-border text-accent-fg";
+          else cls += " border-border text-fg-muted hover:border-fg-muted";
           return (
             <button
               key={q.id}
@@ -476,7 +476,7 @@ export default function ExamSimulation() {
 
       <div className="flex justify-between mt-6">
         <button
-          className="px-4 py-2 text-sm rounded-lg border border-gray-200 text-gray-600 hover:bg-gray-50 active:scale-95 focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:outline-none disabled:opacity-30 transition"
+          className="px-4 py-2 text-sm rounded-lg border border-border text-fg-secondary hover:bg-surface active:scale-95 focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none disabled:opacity-30 transition"
           onClick={() => {
             triggerLight();
             const nextIndex = Math.max(0, currentIndex - 1);
@@ -503,7 +503,7 @@ export default function ExamSimulation() {
           )}
         </div>
         <button
-          className="px-4 py-2 text-sm rounded-lg border border-gray-200 text-gray-600 hover:bg-gray-50 active:scale-95 focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:outline-none disabled:opacity-30 transition"
+          className="px-4 py-2 text-sm rounded-lg border border-border text-fg-secondary hover:bg-surface active:scale-95 focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none disabled:opacity-30 transition"
           onClick={() => {
             triggerLight();
             const nextIndex = Math.min(questions.length - 1, currentIndex + 1);

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -10,8 +10,8 @@ export default function Home() {
 
   return (
     <div className="max-w-6xl mx-auto px-4 py-8 text-center animate-fade-in animate-duration-fast">
-      <h1 className="text-3xl font-bold text-gray-900 mb-3">{t.home.title}</h1>
-      <p className="text-gray-600 max-w-xl mx-auto mb-10">{t.home.subtitle}</p>
+      <h1 className="text-3xl font-bold text-fg mb-3">{t.home.title}</h1>
+      <p className="text-fg-secondary max-w-xl mx-auto mb-10">{t.home.subtitle}</p>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 text-left">
         {subjects.map((subject) => (
@@ -20,7 +20,7 @@ export default function Home() {
         <button
           type="button"
           onClick={() => setModalOpen(true)}
-          className="block w-full p-5 rounded-xl border-2 border-dashed border-gray-300 text-gray-400 hover:text-green-600 hover:border-green-400 hover:bg-green-50/30 hover:scale-[1.02] transition-colors transition-transform duration-200 cursor-pointer"
+          className="block w-full p-5 rounded-xl border-2 border-dashed border-border text-fg-muted hover:text-accent hover:border-accent hover:bg-accent-light/30 hover:scale-[1.02] transition-colors transition-transform duration-200 cursor-pointer"
         >
           <div className="flex flex-col items-center justify-center h-full min-h-[120px] gap-2">
             <span className="text-4xl font-light leading-none">+</span>

--- a/src/pages/PracticeHome.tsx
+++ b/src/pages/PracticeHome.tsx
@@ -13,10 +13,10 @@ export default function PracticeHome() {
 
   return (
     <div className="max-w-6xl mx-auto px-4 py-8 animate-fade-in animate-duration-fast">
-      <h1 className="text-2xl font-bold text-gray-900 mb-2">
+      <h1 className="text-2xl font-bold text-fg mb-2">
         {t.practiceHome.title}
       </h1>
-      <p className="text-gray-500 mb-8">{t.practiceHome.subtitle}</p>
+      <p className="text-fg-muted mb-8">{t.practiceHome.subtitle}</p>
 
       {subject.megatopics ? (
         <>
@@ -27,7 +27,7 @@ export default function PracticeHome() {
             if (mtTopics.length === 0) return null;
             return (
               <div key={mt.key} className="mb-8">
-                <h3 className="text-md font-medium text-gray-700 mt-2 mb-3">
+                <h3 className="text-md font-medium text-fg-secondary mt-2 mb-3">
                   {mt.label}
                 </h3>
                 <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -37,7 +37,7 @@ export default function PracticeHome() {
                       <Link
                         key={topic.key}
                         to={`/${subject.id}/practice/${topic.key}`}
-                        className="block p-5 rounded-xl border-2 border-gray-200 hover:border-green-400 bg-white hover:bg-green-50/30 hover:scale-[1.02] hover:shadow-md focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:outline-none transition-colors transition-transform duration-200"
+                        className="block p-5 rounded-xl border-2 border-border hover:border-accent bg-surface-alt hover:bg-accent-light/30 hover:scale-[1.02] hover:shadow-md focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none transition-colors transition-transform duration-200"
                         onClick={() => {
                           triggerLight();
                           track("practice_topic_click", {
@@ -53,10 +53,10 @@ export default function PracticeHome() {
                         >
                           {topic.icon}
                         </div>
-                        <h3 className="font-semibold text-gray-900 text-sm">
+                        <h3 className="font-semibold text-fg text-sm">
                           {topic.label}
                         </h3>
-                        <p className="text-xs text-gray-500 mt-1">
+                        <p className="text-xs text-fg-muted mt-1">
                           {qs.length} {t.subjectCard.questions} &middot;{" "}
                           {qs.reduce((s, q) => s + q.points, 0)}{" "}
                           {t.subjectCard.points}
@@ -84,7 +84,7 @@ export default function PracticeHome() {
                     <Link
                       key={topic.key}
                       to={`/${subject.id}/practice/${topic.key}`}
-                      className="block p-5 rounded-xl border-2 border-gray-200 hover:border-green-400 bg-white hover:bg-green-50/30 hover:scale-[1.02] hover:shadow-md focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:outline-none transition-colors transition-transform duration-200"
+                      className="block p-5 rounded-xl border-2 border-border hover:border-accent bg-surface-alt hover:bg-accent-light/30 hover:scale-[1.02] hover:shadow-md focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none transition-colors transition-transform duration-200"
                       onClick={() => {
                         triggerLight();
                         track("practice_topic_click", {
@@ -100,10 +100,10 @@ export default function PracticeHome() {
                       >
                         {topic.icon}
                       </div>
-                      <h3 className="font-semibold text-gray-900 text-sm">
+                      <h3 className="font-semibold text-fg text-sm">
                         {topic.label}
                       </h3>
-                      <p className="text-xs text-gray-500 mt-1">
+                      <p className="text-xs text-fg-muted mt-1">
                         {qs.length} {t.subjectCard.questions} &middot;{" "}
                         {qs.reduce((s, q) => s + q.points, 0)}{" "}
                         {t.subjectCard.points}
@@ -125,7 +125,7 @@ export default function PracticeHome() {
               <Link
                 key={topic.key}
                 to={`/${subject.id}/practice/${topic.key}`}
-                className="block p-5 rounded-xl border-2 border-gray-200 hover:border-green-400 bg-white hover:bg-green-50/30 hover:scale-[1.02] hover:shadow-md focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:outline-none transition-colors transition-transform duration-200"
+                className="block p-5 rounded-xl border-2 border-border hover:border-accent bg-surface-alt hover:bg-accent-light/30 hover:scale-[1.02] hover:shadow-md focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none transition-colors transition-transform duration-200"
                 onClick={() => {
                   triggerLight();
                   track("practice_topic_click", {
@@ -137,10 +137,10 @@ export default function PracticeHome() {
                 <div className="text-2xl mb-2" role="img" aria-hidden="true">
                   {topic.icon}
                 </div>
-                <h3 className="font-semibold text-gray-900 text-sm">
+                <h3 className="font-semibold text-fg text-sm">
                   {topic.label}
                 </h3>
-                <p className="text-xs text-gray-500 mt-1">
+                <p className="text-xs text-fg-muted mt-1">
                   {qs.length} {t.subjectCard.questions} &middot;{" "}
                   {qs.reduce((s, q) => s + q.points, 0)} {t.subjectCard.points}
                 </p>

--- a/src/pages/PracticeTopic.tsx
+++ b/src/pages/PracticeTopic.tsx
@@ -238,10 +238,10 @@ export default function PracticeTopic() {
   if (questions.length === 0 || !subject) {
     return (
       <div className="max-w-3xl mx-auto px-4 py-16 text-center">
-        <p className="text-gray-500">{t.practice.noQuestions}</p>
+        <p className="text-fg-muted">{t.practice.noQuestions}</p>
         <Link
           to={subject ? `/${subject.id}` : "/"}
-          className="text-green-600 hover:underline mt-4 inline-block"
+          className="text-accent hover:underline mt-4 inline-block"
           onClick={() => triggerLight()}
         >
           {t.practice.backToHome}
@@ -265,26 +265,26 @@ export default function PracticeTopic() {
       <div className="mb-6">
         <Link
           to={`/${subject.id}`}
-          className="text-sm text-green-600 hover:underline focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:outline-none rounded-md px-1"
+          className="text-sm text-accent hover:underline focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none rounded-md px-1"
         >
           {t.practice.backToTopics}
         </Link>
-        <h1 className="text-2xl font-bold text-gray-900 mt-2">
+        <h1 className="text-2xl font-bold text-fg mt-2">
           {topicInfo?.icon} {topicInfo?.label || topic}
         </h1>
-        <p className="text-sm text-gray-500 mt-1">
+        <p className="text-sm text-fg-muted mt-1">
           {questions.length} {t.subjectCard.questions} &middot; {totalPoints}{" "}
           {t.practice.pointsTotal}
         </p>
       </div>
 
       {(submitted || Object.keys(checkedQuestions).length > 0) && (
-        <div className="mb-6 p-4 rounded-lg bg-green-50 border border-green-200 animate-fade-in-up">
-          <p className="font-semibold text-green-900">
+        <div className="mb-6 p-4 rounded-lg bg-accent-light border border-accent-border animate-fade-in-up">
+          <p className="font-semibold text-fg">
             {submitted ? t.practice.score : t.practice.runningScore}:{" "}
             {getScore()} {t.exam.outOf} {totalPoints} {t.practice.points}
           </p>
-          <p className="text-sm text-green-700 mt-1">
+          <p className="text-sm text-accent-fg mt-1">
             {submitted
               ? textQuestionCount > 0
                 ? `${Object.values(selfGrades).filter(Boolean).length} ${t.exam.outOf} ${textQuestionCount} ${t.practice.openEnded}`
@@ -313,13 +313,13 @@ export default function PracticeTopic() {
           const isChecked = !!checkedQuestions[q.id];
           const isCurrent = i === currentIndex;
           let cls =
-            "w-8 h-8 rounded-md text-xs font-mono flex items-center justify-center border shrink-0 active:scale-90 focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:outline-none transition cursor-pointer";
-          if (isCurrent) cls += " bg-green-600 text-white border-green-600";
+            "w-8 h-8 rounded-md text-xs font-mono flex items-center justify-center border shrink-0 active:scale-90 focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none transition cursor-pointer";
+          if (isCurrent) cls += " bg-accent text-white border-accent";
           else if (isChecked)
             cls += " bg-blue-50 border-blue-300 text-blue-700";
           else if (isAnswered)
-            cls += " bg-green-50 border-green-300 text-green-700";
-          else cls += " border-gray-200 text-gray-500 hover:border-gray-400";
+            cls += " bg-accent-light border-accent-border text-accent-fg";
+          else cls += " border-border text-fg-muted hover:border-fg-muted";
           return (
             <button
               key={q.id}
@@ -361,7 +361,7 @@ export default function PracticeTopic() {
 
       <div className="flex justify-between mt-6">
         <button
-          className="px-4 py-2 text-sm rounded-lg border border-gray-200 text-gray-600 hover:bg-gray-50 active:scale-95 focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:outline-none disabled:opacity-30 transition"
+          className="px-4 py-2 text-sm rounded-lg border border-border text-fg-secondary hover:bg-surface active:scale-95 focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none disabled:opacity-30 transition"
           onClick={() => {
             triggerLight();
             const nextIndex = Math.max(0, currentIndex - 1);
@@ -383,7 +383,7 @@ export default function PracticeTopic() {
             !checkedQuestions[currentQuestion.id] && (
               <>
                 <button
-                  className="px-4 py-2 text-sm rounded-lg border border-gray-200 text-gray-400 hover:text-gray-600 hover:bg-gray-50 active:scale-95 focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:outline-none transition"
+                  className="px-4 py-2 text-sm rounded-lg border border-border text-fg-muted hover:text-fg-secondary hover:bg-surface active:scale-95 focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none transition"
                   onClick={() => {
                     triggerLight();
                     track("practice_clear_answer", {
@@ -413,7 +413,7 @@ export default function PracticeTopic() {
             )}
           {!submitted && (
             <button
-              className="px-4 py-2 text-sm rounded-lg bg-green-600 text-white hover:bg-green-700 active:scale-95 focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:outline-none transition"
+              className="px-4 py-2 text-sm rounded-lg bg-accent text-white hover:bg-accent-hover active:scale-95 focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none transition"
               onClick={handleSubmit}
             >
               {t.practice.submit}
@@ -421,7 +421,7 @@ export default function PracticeTopic() {
           )}
         </div>
         <button
-          className="px-4 py-2 text-sm rounded-lg border border-gray-200 text-gray-600 hover:bg-gray-50 active:scale-95 focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:outline-none disabled:opacity-30 transition"
+          className="px-4 py-2 text-sm rounded-lg border border-border text-fg-secondary hover:bg-surface active:scale-95 focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none disabled:opacity-30 transition"
           onClick={() => {
             triggerLight();
             const nextIndex = Math.min(questions.length - 1, currentIndex + 1);

--- a/src/pages/SubjectHome.tsx
+++ b/src/pages/SubjectHome.tsx
@@ -18,12 +18,12 @@ export default function SubjectHome() {
   if (!subject) {
     return (
       <div className="max-w-6xl mx-auto px-4 py-16 text-center">
-        <h1 className="text-2xl font-bold text-gray-900 mb-4">
+        <h1 className="text-2xl font-bold text-fg mb-4">
           {t.subjectHome.notFound}
         </h1>
         <Link
           to="/"
-          className="text-green-600 hover:underline"
+          className="text-accent hover:underline"
           onClick={() => triggerLight()}
         >
           {t.subjectHome.returnHome}
@@ -69,16 +69,16 @@ export default function SubjectHome() {
   return (
     <div className="max-w-6xl mx-auto px-4 py-8 animate-fade-in animate-duration-fast">
       <div className="text-center mb-10">
-        <p className="text-xs font-mono uppercase tracking-widest text-gray-400 mb-3">
+        <p className="text-xs font-mono uppercase tracking-widest text-fg-muted mb-3">
           {subject.courseCode} &middot; {subject.university}
         </p>
-        <h1 className="text-3xl font-bold text-gray-900 mb-3">
+        <h1 className="text-3xl font-bold text-fg mb-3">
           {subject.name}
         </h1>
-        <p className="text-gray-600 max-w-xl mx-auto">{description}</p>
+        <p className="text-fg-secondary max-w-xl mx-auto">{description}</p>
       </div>
 
-      <h2 className="text-lg font-semibold text-gray-900 mb-4">
+      <h2 className="text-lg font-semibold text-fg mb-4">
         {t.subjectHome.practiceByTopic}
       </h2>
       
@@ -91,7 +91,7 @@ export default function SubjectHome() {
             if (mtTopics.length === 0) return null;
             return (
               <div key={mt.key} className="mb-8">
-                <h3 className="text-md font-medium text-gray-700 mt-2 mb-3">
+                <h3 className="text-md font-medium text-fg-secondary mt-2 mb-3">
                   {mt.label}
                 </h3>
                 <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -125,7 +125,7 @@ export default function SubjectHome() {
         </div>
       )}
 
-      <h2 className="text-lg font-semibold text-gray-900 mb-4">
+      <h2 className="text-lg font-semibold text-fg mb-4">
         {t.subjectHome.examSimulations}
       </h2>
       <div
@@ -135,7 +135,7 @@ export default function SubjectHome() {
           <Link
             key={exam.year}
             to={`/${subject.id}/exam/${exam.year}`}
-            className="block p-6 rounded-xl border-2 border-gray-200 hover:border-green-400 bg-white hover:bg-green-50/30 hover:scale-[1.02] hover:shadow-md focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:outline-none transition-colors transition-transform duration-200"
+            className="block p-6 rounded-xl border-2 border-border hover:border-accent bg-surface-alt hover:bg-accent-light/30 hover:scale-[1.02] hover:shadow-md focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none transition-colors transition-transform duration-200"
             onClick={() => {
               triggerLight();
               track("exam_card_click", {
@@ -147,8 +147,8 @@ export default function SubjectHome() {
             <div className="text-2xl mb-2" role="img" aria-hidden="true">
               📝
             </div>
-            <h3 className="font-semibold text-gray-900">{exam.title}</h3>
-            <p className="text-sm text-gray-500 mt-1">{exam.description}</p>
+            <h3 className="font-semibold text-fg">{exam.title}</h3>
+            <p className="text-sm text-fg-muted mt-1">{exam.description}</p>
           </Link>
         ))}
         <button
@@ -157,7 +157,7 @@ export default function SubjectHome() {
             triggerLight();
             setExamModalOpen(true);
           }}
-          className="block w-full p-6 rounded-xl border-2 border-dashed border-gray-300 text-gray-400 hover:text-green-600 hover:border-green-400 hover:bg-green-50/30 hover:scale-[1.02] hover:shadow-md transition-colors transition-transform duration-200"
+          className="block w-full p-6 rounded-xl border-2 border-dashed border-border text-fg-muted hover:text-accent hover:border-accent hover:bg-accent-light/30 hover:scale-[1.02] hover:shadow-md transition-colors transition-transform duration-200"
         >
           <div className="flex flex-col items-center justify-center gap-2">
             <span className="text-4xl font-light leading-none">+</span>
@@ -176,11 +176,11 @@ export default function SubjectHome() {
       />
 
       {subject.exams.some((exam) => exam.hasPdf !== false) && (
-        <div className="bg-gray-50 rounded-xl p-6 border border-gray-200 mb-10">
-          <h3 className="font-semibold text-gray-900 mb-2">
+        <div className="bg-surface rounded-xl p-6 border border-border mb-10">
+          <h3 className="font-semibold text-fg mb-2">
             {t.subjectHome.originalExams}
           </h3>
-          <p className="text-sm text-gray-600 mb-4">
+          <p className="text-sm text-fg-secondary mb-4">
             {t.subjectHome.examDocsDescription}
           </p>
           <div className="flex flex-wrap gap-4">
@@ -192,7 +192,7 @@ export default function SubjectHome() {
                   href={`/exams/${subject.id}/Exam-${exam.year}.pdf`}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-green-700 bg-green-50 border border-green-200 rounded-lg hover:bg-green-100 active:scale-95 focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:outline-none transition duration-150"
+                  className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-accent-fg bg-accent-light border border-accent-border rounded-lg hover:bg-accent-light active:scale-95 focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none transition duration-150"
                   onClick={() => {
                     triggerLight();
                     track("pdf_download", {
@@ -212,8 +212,8 @@ export default function SubjectHome() {
       )}
 
       {subject.acknowledgments && (
-        <div className="text-right text-sm text-gray-400 mt-10">
-          <p className="font-semibold text-gray-500 mb-1">
+        <div className="text-right text-sm text-fg-muted mt-10">
+          <p className="font-semibold text-fg-muted mb-1">
             {t.subjectHome.acknowledgments}
           </p>
           <p>{subject.acknowledgments}</p>

--- a/src/theme/ThemeToggle.tsx
+++ b/src/theme/ThemeToggle.tsx
@@ -1,0 +1,143 @@
+import { useTheme } from "./hooks";
+import { themeLabels } from "./types";
+import type { Theme } from "./types";
+
+function ThemeIcon({ theme }: { theme: Theme }) {
+  switch (theme) {
+    case "system":
+      return (
+        <svg
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <circle cx="12" cy="12" r="4" />
+          <path d="M12 2v2" />
+          <path d="M12 20v2" />
+          <path d="m4.93 4.93 1.41 1.41" />
+          <path d="m17.66 17.66 1.41 1.41" />
+          <path d="M2 12h2" />
+          <path d="M20 12h2" />
+          <path d="m6.34 17.66-1.41 1.41" />
+          <path d="m19.07 4.93-1.41 1.41" />
+          <clipPath id="moon-clip">
+            <path d="M16 8a6 6 0 0 1-8 8 6 6 0 0 0 8-8Z" />
+          </clipPath>
+          <circle
+            cx="14"
+            cy="10"
+            r="7"
+            fill="currentColor"
+            clipPath="url(#moon-clip)"
+          />
+        </svg>
+      );
+    case "light":
+      return (
+        <svg
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <circle cx="12" cy="12" r="4" />
+          <path d="M12 2v2" />
+          <path d="M12 20v2" />
+          <path d="m4.93 4.93 1.41 1.41" />
+          <path d="m17.66 17.66 1.41 1.41" />
+          <path d="M2 12h2" />
+          <path d="M20 12h2" />
+          <path d="m6.34 17.66-1.41 1.41" />
+          <path d="m19.07 4.93-1.41 1.41" />
+        </svg>
+      );
+    case "dark":
+      return (
+        <svg
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+        </svg>
+      );
+    case "pink":
+      return (
+        <svg
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <circle cx="12" cy="12" r="3" />
+          <path d="M12 1v3" />
+          <path d="M12 20v3" />
+          <path d="M4.2 4.2l2.1 2.1" />
+          <path d="M17.7 17.7l2.1 2.1" />
+          <path d="M1 12h3" />
+          <path d="M20 12h3" />
+          <path d="M4.2 19.8l2.1-2.1" />
+          <path d="M17.7 6.3l2.1-2.1" />
+          <path d="M12 6c1.1 0 2 .9 2 2s-.9 2-2 2-2-.9-2-2 .9-2 2-2z" />
+          <path d="M9 9c.2-.7.8-1.4 1.5-1.7" />
+          <path d="M13.5 10.3c.7.3 1.3.9 1.5 1.7" />
+          <path d="M15 15c-.2.7-.8 1.4-1.5 1.7" />
+          <path d="M10.5 13.7c-.7-.3-1.3-.9-1.5-1.7" />
+        </svg>
+      );
+    case "catppuccin":
+      return (
+        <svg
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M17 8h1a4 4 0 1 1 0 8h-1" />
+          <path d="M3 8h14v9a4 4 0 0 1-4 4H7a4 4 0 0 1-4-4Z" />
+          <line x1="6" y1="2" x2="6" y2="4" />
+          <line x1="10" y1="2" x2="10" y2="4" />
+          <line x1="14" y1="2" x2="14" y2="4" />
+        </svg>
+      );
+  }
+}
+
+export default function ThemeToggle() {
+  const { theme, cycleTheme } = useTheme();
+
+  return (
+    <button
+      className="px-2 py-1 rounded border border-border hover:bg-surface active:scale-95 transition cursor-pointer"
+      onClick={cycleTheme}
+      aria-label={`Theme: ${themeLabels[theme]}`}
+      title={themeLabels[theme]}
+    >
+      <span className="theme-icon block" key={theme}>
+        <ThemeIcon theme={theme} />
+      </span>
+    </button>
+  );
+}

--- a/src/theme/ThemeToggle.tsx
+++ b/src/theme/ThemeToggle.tsx
@@ -16,25 +16,9 @@ function ThemeIcon({ theme }: { theme: Theme }) {
           strokeLinecap="round"
           strokeLinejoin="round"
         >
-          <circle cx="12" cy="12" r="4" />
-          <path d="M12 2v2" />
-          <path d="M12 20v2" />
-          <path d="m4.93 4.93 1.41 1.41" />
-          <path d="m17.66 17.66 1.41 1.41" />
-          <path d="M2 12h2" />
-          <path d="M20 12h2" />
-          <path d="m6.34 17.66-1.41 1.41" />
-          <path d="m19.07 4.93-1.41 1.41" />
-          <clipPath id="moon-clip">
-            <path d="M16 8a6 6 0 0 1-8 8 6 6 0 0 0 8-8Z" />
-          </clipPath>
-          <circle
-            cx="14"
-            cy="10"
-            r="7"
-            fill="currentColor"
-            clipPath="url(#moon-clip)"
-          />
+          <rect x="2" y="3" width="20" height="14" rx="2" ry="2" />
+          <line x1="8" y1="21" x2="16" y2="21" />
+          <line x1="12" y1="17" x2="12" y2="21" />
         </svg>
       );
     case "light":
@@ -87,20 +71,8 @@ function ThemeIcon({ theme }: { theme: Theme }) {
           strokeLinecap="round"
           strokeLinejoin="round"
         >
-          <circle cx="12" cy="12" r="3" />
-          <path d="M12 1v3" />
-          <path d="M12 20v3" />
-          <path d="M4.2 4.2l2.1 2.1" />
-          <path d="M17.7 17.7l2.1 2.1" />
-          <path d="M1 12h3" />
-          <path d="M20 12h3" />
-          <path d="M4.2 19.8l2.1-2.1" />
-          <path d="M17.7 6.3l2.1-2.1" />
-          <path d="M12 6c1.1 0 2 .9 2 2s-.9 2-2 2-2-.9-2-2 .9-2 2-2z" />
-          <path d="M9 9c.2-.7.8-1.4 1.5-1.7" />
-          <path d="M13.5 10.3c.7.3 1.3.9 1.5 1.7" />
-          <path d="M15 15c-.2.7-.8 1.4-1.5 1.7" />
-          <path d="M10.5 13.7c-.7-.3-1.3-.9-1.5-1.7" />
+          <path d="M2 4l3 12h14l3-12-6 7-4-7-4 7-6-7z" />
+          <path d="M2 17h20" />
         </svg>
       );
     case "catppuccin":

--- a/src/theme/context.tsx
+++ b/src/theme/context.tsx
@@ -1,0 +1,73 @@
+/* eslint-disable react-refresh/only-export-components */
+import {
+  createContext,
+  useState,
+  useCallback,
+  useEffect,
+  type ReactNode,
+} from "react";
+import type { Theme } from "./types";
+import { themeOrder } from "./types";
+
+export interface ThemeContextType {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  cycleTheme: () => void;
+}
+
+export const ThemeContext = createContext<ThemeContextType>({
+  theme: "system",
+  setTheme: () => {},
+  cycleTheme: () => {},
+});
+
+function getInitialTheme(): Theme {
+  try {
+    const stored = localStorage.getItem("theme");
+    if (stored && themeOrder.includes(stored as Theme)) return stored as Theme;
+  } catch {
+    /* localStorage unavailable */
+  }
+  return "system";
+}
+
+function applyTheme(theme: Theme): Theme {
+  if (typeof document === "undefined") return theme;
+  try {
+    localStorage.setItem("theme", theme);
+  } catch {
+    /* localStorage unavailable */
+  }
+  document.documentElement.setAttribute("data-theme", theme);
+  return theme;
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(getInitialTheme);
+
+  useEffect(() => {
+    applyTheme(theme);
+  }, [theme]);
+
+  const setTheme = useCallback((next: Theme) => {
+    if (!document.startViewTransition) {
+      setThemeState(applyTheme(next));
+      return;
+    }
+    document.startViewTransition(() => {
+      setThemeState(applyTheme(next));
+    });
+  }, []);
+
+  const cycleTheme = useCallback(() => {
+    const idx = themeOrder.indexOf(theme);
+    const next = themeOrder[(idx + 1) % themeOrder.length];
+    setTheme(next);
+  }, [theme, setTheme]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme, cycleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}

--- a/src/theme/hooks.ts
+++ b/src/theme/hooks.ts
@@ -1,0 +1,6 @@
+import { useContext } from "react";
+import { ThemeContext } from "./context";
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -1,0 +1,18 @@
+export const themes = ["system", "light", "dark", "pink", "catppuccin"] as const;
+export type Theme = (typeof themes)[number];
+
+export const themeOrder: Theme[] = [
+  "system",
+  "light",
+  "dark",
+  "pink",
+  "catppuccin",
+];
+
+export const themeLabels: Record<Theme, string> = {
+  system: "System",
+  light: "Light",
+  dark: "Dark",
+  pink: "Pink",
+  catppuccin: "Catppuccin",
+};


### PR DESCRIPTION
## Summary

Adds support for 5 color themes with animated transitions:

- **System** — follows OS preference (light/dark)
- **Light** — the current light theme
- **Dark** — dark mode  
- **Pink** — light with pink/pastel accents
- **Catppuccin** — Catppuccin Mocha palette

## Changes

### New files
- `src/theme/types.ts` — Theme type definitions
- `src/theme/context.tsx` — ThemeProvider with localStorage + View Transition API
- `src/theme/hooks.ts` — useTheme hook
- `src/theme/ThemeToggle.tsx` — Animated SVG icon toggle in header

### Modified files
- `src/index.css` — Theme CSS variables via Tailwind v4 `@theme`, dark/pink/catppuccin overrides, system media query, View Transition animations
- `src/main.tsx` — Wrapped app in ThemeProvider
- `index.html` — Anti-flicker inline script, `color-scheme: light dark`
- All components — Replaced hardcoded Tailwind color utilities with semantic tokens

### Color token mapping
| Token | Usage |
|---|---|
| `surface` / `surface-alt` | Page/card backgrounds |
| `fg` / `fg-secondary` / `fg-muted` | Text hierarchy |
| `border` | Borders and dividers |
| `accent` / `accent-light` / `accent-fg` / `accent-border` | Primary accent |
| `code` / `code-block` | Inline code and code blocks |

### How it works
- Click the theme icon (sun/moon/flower/coffee) in the header to cycle themes
- Theme preference persists in localStorage
- Transition animations via View Transition API
- Anti-flicker script prevents flash on page load