### PR TITLE
feat: responsive images with vite-imagetools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,9 +144,7 @@ export const questions: Question[] = [
 
 **Optional fields:**
 
-- `image?: string` — imported image: `import myImage from "./assets/figure.png"`
-- `imageWidth?: number` — native width in px
-- `imageHeight?: number` — native height in px
+- `image?: Picture | string` — imported image using vite-imagetools: `import myImage from "./assets/figure.png?w=400;800;1200&format=avif;webp;png&as=picture"`. For JPEG: use `jpeg` instead of `png`. For broken/corrupt images, use a plain import without query params.
 - `table?: { headers: string[], rows: string[][] }` — data table
 - `subquestions?: string[]` — list of sub-question text
 - `options?: string[]` — required for `mc` type

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ export const questions: Question[] = [
 ];
 ```
 
-Campos opcionales: `image`, `imageWidth`, `imageHeight`, `table`, `subquestions`, `repeated`.
+Campos opcionales: `image`, `table`, `subquestions`, `repeated`.
 
 - `repeated?: boolean` — por defecto `false`. Marca como `true` cuando la misma pregunta aparece en varios exámenes. Se muestra una etiqueta "Repetida" en la interfaz.
 
@@ -166,13 +166,11 @@ Si alguna pregunta referencia figuras o gráficos:
 3. Impórtala y referénciala en `questions.ts`:
 
 ```ts
-import figura1 from "./assets/figura-1.png";
+import figura1 from "./assets/figura-1.png?w=400;800;1200&format=avif;webp;png&as=picture";
 
 {
   // ...
   image: figura1,
-  imageWidth: 800,
-  imageHeight: 400,
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "tailwindcss": "^4.3.0",
     "typescript": "~6.0.2",
     "typescript-eslint": "^8.59.2",
-    "vite": "^8.0.12"
+    "vite": "^8.0.12",
+    "vite-imagetools": "^10.0.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       vite:
         specifier: ^8.0.12
         version: 8.0.16(@types/node@24.13.2)(jiti@2.7.0)
+      vite-imagetools:
+        specifier: ^10.0.1
+        version: 10.0.1(vite@8.0.16(@types/node@24.13.2)(jiti@2.7.0))
 
 packages:
 
@@ -145,6 +148,9 @@ packages:
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
@@ -206,6 +212,168 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.35.1':
+    resolution: {integrity: sha512-T15JRWOubQ3f5+GxnWeIvo47u5qV0M9HBgJhT+f2gE1e9e6OhR6K73Re52Hm80qWcu1DNb3GweKmpr/MnuP2Ow==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.35.1':
+    resolution: {integrity: sha512-t1CPD0cr7XCHjwUj6tQ5MC0pCi866I+gUW6zbUX4aFPnKd1DFBtk0M+gWcjX8VeEzgfCNiSiNTVFZ6b7kvdbnQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-freebsd-wasm32@0.35.1':
+    resolution: {integrity: sha512-MBSQXqNPThW9EcZ905H6N4sEdX5EwZEYzGx5EBq9ncDCGJALMiY1xPFJxNdzuB1iBjLOpIfxajM6YxdvwmQSLA==}
+    engines: {node: '>=20.9.0'}
+    os: [freebsd]
+
+  '@img/sharp-libvips-darwin-arm64@1.3.0':
+    resolution: {integrity: sha512-EKbmBKtyTH+GPFDRw2TgK2oV6hyxxlJVIar4hoTYSNmIwipgMFdxPQqR392GmfdsPGWga0mCFN1cCKjRb9cljw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.3.0':
+    resolution: {integrity: sha512-Pl2OmOvrJ42adUllESxBsG54PfXLo1OYg9i3c5/5Ln/qJ0gZuTM9YMhQJPIbXqwidLRc/c2zuHt4RsrymmNv7A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.3.0':
+    resolution: {integrity: sha512-C0SqjoFKnszqa44EQ7xoaT48nnO0lOyXEULfXMWi8krrjOPGYkeK30Okzla6ATbBYsyZ0ySinK0FVkpv3DwzfQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.3.0':
+    resolution: {integrity: sha512-A8UpHoUDW4DwnXoV6+q3C1s7QLRAHtPDEjWuNZjwHMyoCNZnm0GeNN8ls9f/bsEYTRQRW96C/n34XJQHJ2fT7A==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.3.0':
+    resolution: {integrity: sha512-WOpkVxAjFd369iaIzEgNRreFD+gWdUMIGD5zplhNKNeqS6mm5dac3q2AFyCBmzYoAdouzZvRBgxy4z8QHZb4/A==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.3.0':
+    resolution: {integrity: sha512-DRWw0mOHusrCCuw2rqP87oLg6PGlkomVDFqw2hIwsSfwWpu4k3XLcBPaKKl6ct/GtL/cwNkgwjV/tc0Mqht3VA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.3.0':
+    resolution: {integrity: sha512-9APy+nFWhHS+kzLgWZfLcyrUd7YqnAQVa4BPOo4xkoHpdoktOAPG4cEr9+Jpl0TtqfVmcMJimNL5qNTyyOHZNA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.3.0':
+    resolution: {integrity: sha512-y9RNUYDe2A1UAdhLyfeOodGRszQdaEoe4nfOpp/sNVPl2CWIcUyFaDoCh4vPLPxu19803j2naLqZup2WxDXCLA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.0':
+    resolution: {integrity: sha512-cC1wkC0Mlucd0KSiGrLkJnB/ZqPvZCntc/Lk7ZnYO5ZSbF2euNek4Xvxafojq+wN1q/W0eprdpUIjUr/EV2PBg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.0':
+    resolution: {integrity: sha512-LiYMhUZicB1QG//+RvmYZpXJO8fYRENfp+MZUCnG9aw+AKvGAy9gPaCnuwsPcBFs8EV66M0NNxj9VHcNklE8zw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.35.1':
+    resolution: {integrity: sha512-ErCRyGU7LeoaFBZ0xW8hhLlXzhAg80sc4vxePB86qvtEvW1jEhhmbiNBP4oEzZfPMnu6HwHXfzD2W2kBU+RnCw==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.35.1':
+    resolution: {integrity: sha512-jygmR02PpCYypt7xB7nst1vqjZp/BpRA/Kf9nK7qRponJ/KrLPaZWEG4G15z1d2FZ6XqI+T0350ha3RSnKx24A==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.35.1':
+    resolution: {integrity: sha512-LUWZ2+r2UoLCd8j0RLCwQ4gL6w47+Y7igxtVnPIDXOOEjV86LpBkAHq5VpJeg+GHbw0KN/JWlPJOdZjyZnFqFQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.35.1':
+    resolution: {integrity: sha512-i7x6J3mwF4JgT0sM4V4WlAWdJ0bucPtA9rzO1bTji1n5qgBq/W5nn87RvOQPleuuxahNoLdTngByD8/vDDLArw==}
+    engines: {node: '>=20.9.0'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.35.1':
+    resolution: {integrity: sha512-0zSaTUjTF0kIWTSYxD4EG/nvCU4jez53+3RdURtoY3HvbXtIQ98W90JnrGz/oLRFuEnfIy9+7xeq883euc0ZWw==}
+    engines: {node: '>=20.9.0'}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.35.1':
+    resolution: {integrity: sha512-NbJD4mWdeyrNQKluO/tR/wBDOelcowSVGNBWxI0e3ZtlXc6F/UOVKDj1MLD4zl3oHTuvKW3s+MA9N54YTldAYw==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.35.1':
+    resolution: {integrity: sha512-VoW2sQCWI+0YIKQEmWJ8vzaQjTg9wIyfkFpvEfAS2h43X6iHu7GTk1hhOgB4IpSzCHe8UwQZIcx7b81VTaOrJA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.35.1':
+    resolution: {integrity: sha512-LjBoSd/c5JU0/K5MwzDMlgsSRP2bPn98JQGFFQAOLQ0bU/1z4ekxUdSKY9BmlwSh/cA+OrvpgsWqfZyYfVHBRw==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.35.1':
+    resolution: {integrity: sha512-PCQUoQdZyE8tp3HpbevuihfUmgSP4qWI0FGEPWoeXqaS+cUrFfemabHQiebUmUmlUhCuNnQMxGrQ+CPqK4hnxg==}
+    engines: {node: '>=20.9.0'}
+
+  '@img/sharp-webcontainers-wasm32@0.35.1':
+    resolution: {integrity: sha512-xU2ml2bU2OPxYVvW2A6ae4M1g5QKyhKG06P4FAt+YEaFQQO0919Qx+XxIZEUuWTMoDViLpMws2/dQwoe/VcA6A==}
+    engines: {node: '>=20.9.0'}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.35.1':
+    resolution: {integrity: sha512-IkmHwuFhYpd3bTsN5SAahjwhiAcyXPooBt8vEUgxY3T0IP70sSJ0nU1xiPzZY8AH/OB1XpV3j8aZSVSOSfTbdA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.35.1':
+    resolution: {integrity: sha512-wQahqCi9MD8Yxzg4gVM4fNrZxh+r6vD55PyIg+WJPaM5ZRUyF35iQpwJCuma3r6viU9/8Pxlc+XHV+woVa6nCQ==}
+    engines: {node: ^20.9.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.35.1':
+    resolution: {integrity: sha512-WzBtkYtZHATLPe8XRharxZXxQ9cdLrQWHiwxt+BJ5rBsisQrKeeV86ErxPSVhcG6xCEuNhs0SqLpWr7XDa2k6w==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [win32]
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -329,6 +497,15 @@ packages:
 
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
+  '@rollup/pluginutils@5.4.0':
+    resolution: {integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
 
   '@tailwindcss/node@4.3.1':
     resolution: {integrity: sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==}
@@ -647,6 +824,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -717,6 +897,10 @@ packages:
   ignore@7.0.5:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
+
+  imagetools-core@10.0.0:
+    resolution: {integrity: sha512-wirG+oESU1QTORt+fqR6DAsVMgW5CXgrRaGgf1lo4hu/3q6269GfHBmYpVWzmMIuHM/H01QcaWrHR6kHCC7bOw==}
+    engines: {node: '>=22.0.0'}
 
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -959,6 +1143,10 @@ packages:
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
+  sharp@0.35.1:
+    resolution: {integrity: sha512-lW979AMi+ESidzMv/Lnv+F9bknzLyxLqFI05Sm433vOeRcltgxQmXpnfOOFIAlKtwXU/ksupm2srQoFCkR214g==}
+    engines: {node: '>=20.9.0'}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -1023,6 +1211,12 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  vite-imagetools@10.0.1:
+    resolution: {integrity: sha512-JfM1rUSLQoPAA+8RB9TFxxpfSjmBpLTkU5zaSFPlWYlgfc3g2gFfYH+u+HghqNy+6HCw6zJBmq+2exx6pMJFOg==}
+    engines: {node: '>=22.0.0'}
+    peerDependencies:
+      vite: '>=7.0.0'
 
   vite@8.0.16:
     resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
@@ -1222,6 +1416,11 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
@@ -1276,6 +1475,112 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.35.1':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.3.0
+    optional: true
+
+  '@img/sharp-darwin-x64@0.35.1':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.3.0
+    optional: true
+
+  '@img/sharp-freebsd-wasm32@0.35.1':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.1
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.3.0':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.3.0':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.3.0':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.3.0':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.3.0':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.3.0':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.3.0':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.3.0':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.0':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.0':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.35.1':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.3.0
+    optional: true
+
+  '@img/sharp-linux-arm@0.35.1':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.3.0
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.35.1':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.3.0
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.35.1':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.3.0
+    optional: true
+
+  '@img/sharp-linux-s390x@0.35.1':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.3.0
+    optional: true
+
+  '@img/sharp-linux-x64@0.35.1':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.3.0
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.35.1':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.0
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.35.1':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.0
+    optional: true
+
+  '@img/sharp-wasm32@0.35.1':
+    dependencies:
+      '@emnapi/runtime': 1.11.1
+    optional: true
+
+  '@img/sharp-webcontainers-wasm32@0.35.1':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.1
+    optional: true
+
+  '@img/sharp-win32-arm64@0.35.1':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.35.1':
+    optional: true
+
+  '@img/sharp-win32-x64@0.35.1':
+    optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -1355,6 +1660,12 @@ snapshots:
     optional: true
 
   '@rolldown/pluginutils@1.0.1': {}
+
+  '@rollup/pluginutils@5.4.0':
+    dependencies:
+      '@types/estree': 1.0.9
+      estree-walker: 2.0.2
+      picomatch: 4.0.4
 
   '@tailwindcss/node@4.3.1':
     dependencies:
@@ -1684,6 +1995,8 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@2.0.2: {}
+
   esutils@2.0.3: {}
 
   fast-deep-equal@3.1.3: {}
@@ -1734,6 +2047,8 @@ snapshots:
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
+
+  imagetools-core@10.0.0: {}
 
   imurmurhash@0.1.4: {}
 
@@ -1928,6 +2243,38 @@ snapshots:
 
   set-cookie-parser@2.7.2: {}
 
+  sharp@0.35.1:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.4
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.35.1
+      '@img/sharp-darwin-x64': 0.35.1
+      '@img/sharp-freebsd-wasm32': 0.35.1
+      '@img/sharp-libvips-darwin-arm64': 1.3.0
+      '@img/sharp-libvips-darwin-x64': 1.3.0
+      '@img/sharp-libvips-linux-arm': 1.3.0
+      '@img/sharp-libvips-linux-arm64': 1.3.0
+      '@img/sharp-libvips-linux-ppc64': 1.3.0
+      '@img/sharp-libvips-linux-riscv64': 1.3.0
+      '@img/sharp-libvips-linux-s390x': 1.3.0
+      '@img/sharp-libvips-linux-x64': 1.3.0
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.0
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.0
+      '@img/sharp-linux-arm': 0.35.1
+      '@img/sharp-linux-arm64': 0.35.1
+      '@img/sharp-linux-ppc64': 0.35.1
+      '@img/sharp-linux-riscv64': 0.35.1
+      '@img/sharp-linux-s390x': 0.35.1
+      '@img/sharp-linux-x64': 0.35.1
+      '@img/sharp-linuxmusl-arm64': 0.35.1
+      '@img/sharp-linuxmusl-x64': 0.35.1
+      '@img/sharp-webcontainers-wasm32': 0.35.1
+      '@img/sharp-win32-arm64': 0.35.1
+      '@img/sharp-win32-ia32': 0.35.1
+      '@img/sharp-win32-x64': 0.35.1
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -1984,6 +2331,15 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  vite-imagetools@10.0.1(vite@8.0.16(@types/node@24.13.2)(jiti@2.7.0)):
+    dependencies:
+      '@rollup/pluginutils': 5.4.0
+      imagetools-core: 10.0.0
+      sharp: 0.35.1
+      vite: 8.0.16(@types/node@24.13.2)(jiti@2.7.0)
+    transitivePeerDependencies:
+      - rollup
 
   vite@8.0.16(@types/node@24.13.2)(jiti@2.7.0):
     dependencies:

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -361,18 +361,32 @@ export default function QuestionCard(props: QuestionCardProps) {
           ))}
         </ul>
       )}
-      {question.image && (
+      {question.image && typeof question.image === "object" ? (
+        <div className="mb-4 rounded-lg overflow-hidden border border-border max-w-full flex justify-center bg-surface p-2">
+          <picture>
+            {Object.entries(question.image.sources).map(([format, srcset]) => (
+              <source key={format} srcSet={srcset} type={`image/${format}`} />
+            ))}
+            <img
+              src={question.image.img.src}
+              alt={`Illustration for ${question.id}`}
+              width={question.image.img.w}
+              height={question.image.img.h}
+              className="max-h-[400px] object-contain w-auto h-auto"
+              loading="lazy"
+            />
+          </picture>
+        </div>
+      ) : question.image ? (
         <div className="mb-4 rounded-lg overflow-hidden border border-border max-w-full flex justify-center bg-surface p-2">
           <img
             src={question.image}
             alt={`Illustration for ${question.id}`}
-            width={question.imageWidth || 800}
-            height={question.imageHeight || 400}
             className="max-h-[400px] object-contain w-auto h-auto"
             loading="lazy"
           />
         </div>
-      )}
+      ) : null}
       {question.table && (
         <div className="mb-4 overflow-x-auto rounded-lg border border-border">
           <table className="min-w-full divide-y divide-border text-sm">

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -372,7 +372,8 @@ export default function QuestionCard(props: QuestionCardProps) {
               alt={`Illustration for ${question.id}`}
               width={question.image.img.w}
               height={question.image.img.h}
-              className="max-h-[400px] object-contain w-auto h-auto"
+              style={{ aspectRatio: `${question.image.img.w} / ${question.image.img.h}` }}
+              className="max-h-[400px] max-w-full object-contain"
               loading="lazy"
             />
           </picture>
@@ -382,7 +383,7 @@ export default function QuestionCard(props: QuestionCardProps) {
           <img
             src={question.image}
             alt={`Illustration for ${question.id}`}
-            className="max-h-[400px] object-contain w-auto h-auto"
+            className="max-h-[400px] max-w-full object-contain"
             loading="lazy"
           />
         </div>

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -1,3 +1,5 @@
+import type { Picture } from "vite-imagetools";
+
 export type QuestionType = "mc" | "text" | "matching" | "calculation";
 
 export interface QuestionTable {
@@ -16,9 +18,7 @@ export interface Question {
   options?: string[];
   correctAnswer: string | string[] | Record<string, string>;
   explanation: string;
-  image?: string;
-  imageWidth?: number;
-  imageHeight?: number;
+  image?: Picture | string;
   table?: QuestionTable;
   repeated?: boolean;
 }

--- a/src/subjects/_template/questions.ts
+++ b/src/subjects/_template/questions.ts
@@ -1,7 +1,7 @@
 import type { Question } from "../../data/types";
 
 // To use images, create an assets/ folder and import them:
-// import myImage from "./assets/figure.png";
+// import myImage from "./assets/figure.png?w=400;800;1200&format=avif;webp;png&as=picture";
 
 export const questions: Question[] = [
   // ================================================================
@@ -217,9 +217,7 @@ Hint: remember that \`foo()\` calls itself recursively.`,
   //   type: "text",
   //   points: 10,
   //   question: "Describe what the following diagram represents:",
-  //   image: myImage,       // import from ./assets/
-  //   imageWidth: 800,      // optional, native width in px
-  //   imageHeight: 400,     // optional, native height in px
+  //   image: myImage,       // import from ./assets/ with ?w=...&format=...&as=picture
   //   correctAnswer: "The diagram shows...",
   //   explanation: "Key elements to identify: ...",
   // },

--- a/src/subjects/cepe/questions.ts
+++ b/src/subjects/cepe/questions.ts
@@ -1,6 +1,6 @@
 import type { Question } from "../../data/types";
-import taskGraphImg from "./assets/task-graph-2025-07.jpeg";
-import stdevAlgAImg from "./assets/stdev-algorithm-a-2024-06.jpeg";
+import taskGraphImg from "./assets/task-graph-2025-07.jpeg?w=400;800;1200&format=avif;webp;jpeg&as=picture";
+import stdevAlgAImg from "./assets/stdev-algorithm-a-2024-06.jpeg?w=400;800;1200&format=avif;webp;jpeg&as=picture";
 import pipeline201907Img from "./assets/pipeline-2019-07.jpeg";
 import tree202006Img from "./assets/tree-2020-06.jpeg";
 import tree202007Img from "./assets/tree-2020-07.jpeg";

--- a/src/subjects/emeele/questions.ts
+++ b/src/subjects/emeele/questions.ts
@@ -1,10 +1,10 @@
 import type { Question } from "../../data/types";
-import fig1_2025 from "./assets/Figure 1 2025.png";
-import fig1_2024 from "./assets/Figure 1 Exam 2024.png";
-import fig2_2024 from "./assets/Figure 2 Exam 2024.png";
-import fig3_2024 from "./assets/Figure 3 Exam 2024.png";
-import fig4_2024 from "./assets/Figure 4 Exam 2024.png";
-import fig5_4_2025 from "./assets/Figure 5.4 2025.png";
+import fig1_2025 from "./assets/Figure 1 2025.png?w=400;800;1200&format=avif;webp;png&as=picture";
+import fig1_2024 from "./assets/Figure 1 Exam 2024.png?w=400;800;1200&format=avif;webp;png&as=picture";
+import fig2_2024 from "./assets/Figure 2 Exam 2024.png?w=400;800;1200&format=avif;webp;png&as=picture";
+import fig3_2024 from "./assets/Figure 3 Exam 2024.png?w=400;800;1200&format=avif;webp;png&as=picture";
+import fig4_2024 from "./assets/Figure 4 Exam 2024.png?w=400;800;1200&format=avif;webp;png&as=picture";
+import fig5_4_2025 from "./assets/Figure 5.4 2025.png?w=400;800;1200&format=avif;webp;png&as=picture";
 
 export const questions: Question[] = [
   {
@@ -44,8 +44,6 @@ The resulting regression plot is a step-like, piecewise constant function that i
     explanation:
       "kNN regression at any point averages the target values of the k nearest neighbors. With k=3, the curve is smoother than k=1 but captures local trends.",
     image: fig1_2024,
-    imageWidth: 788,
-    imageHeight: 740,
   },
   {
     id: "2025_q1_1",
@@ -428,8 +426,6 @@ Give examples of inputs (x1,x2) ≠ (0,0) such that the output is 0 and 1 respec
     explanation:
       "Work through the network forward. ReLU zeros out negative values. The step output is 1 iff the weighted sum ≥ 0.",
     image: fig2_2024,
-    imageWidth: 1392,
-    imageHeight: 676,
   },
   {
     id: "2024_q5b",
@@ -454,8 +450,6 @@ y = step(W2 · h + b2)`,
     explanation:
       "W1 is 2×2 (two hidden nodes from two inputs). W2 is 1×2 (one output from two hidden nodes). Include bias vectors.",
     image: fig2_2024,
-    imageWidth: 1392,
-    imageHeight: 676,
   },
   {
     id: "2025_q5_1",
@@ -525,8 +519,6 @@ More powerful than perceptron because: multiple hidden layers with non-linear ac
     explanation:
       "Depth + non-linearity = ability to learn complex, hierarchical representations that a perceptron cannot capture.",
     image: fig5_4_2025,
-    imageWidth: 706,
-    imageHeight: 534,
   },
   {
     id: "2024_q6",
@@ -640,8 +632,6 @@ S1 is preferred (higher purity gain: 0.2813 > 0.0898).`,
     explanation:
       "Even with linear separability, non-linear kernels can provide larger margins and better generalization to unseen data.",
     image: fig3_2024,
-    imageWidth: 948,
-    imageHeight: 838,
   },
   {
     id: "2024_q7b",
@@ -662,8 +652,6 @@ Points like x1, x2 (circles) and x9, x10 (squares) are far from the decision bou
     explanation:
       "Support vectors are the points closest to the margin/decision boundary. They define where the boundary is placed.",
     image: fig3_2024,
-    imageWidth: 948,
-    imageHeight: 838,
   },
   {
     id: "2025_q7_1",
@@ -891,8 +879,6 @@ Summary of when to use:
     explanation:
       "This highlights the trade-off between maximizing variance (PCA) and maximizing class separability (LDA) when projecting high-dimensional data.",
     image: fig4_2024,
-    imageWidth: 1882,
-    imageHeight: 848,
   },
   {
     id: "2025_q9a",
@@ -909,8 +895,6 @@ Key difference: PCA is variance-maximizing (global), Sammon is distance-preservi
     explanation:
       "PCA finds orthogonal directions of max variance via eigendecomposition. Sammon minimizes a stress function via gradient descent, weighting small distances more.",
     image: fig1_2025,
-    imageWidth: 1812,
-    imageHeight: 832,
   },
   {
     id: "2025_q9b",

--- a/src/subjects/esei/questions.ts
+++ b/src/subjects/esei/questions.ts
@@ -1,10 +1,10 @@
 import type { Question } from "../../data/types";
-import grafo2023 from "./assets/grafo-astar-2023.png";
-import arbol2023 from "./assets/arbol-hill-climbing-2023.png";
-import hill2024 from "./assets/hill-climbing-2024.png";
-import grafo2025 from "./assets/grafo-espacio-estados-2025.png";
-import arbolPG from "./assets/arbol-programacion-genetica-2025.png";
-import grafo2026 from "./assets/grafo-astar-2026.png";
+import grafo2023 from "./assets/grafo-astar-2023.png?w=400;800;1200&format=avif;webp;png&as=picture";
+import arbol2023 from "./assets/arbol-hill-climbing-2023.png?w=400;800;1200&format=avif;webp;png&as=picture";
+import hill2024 from "./assets/hill-climbing-2024.png?w=400;800;1200&format=avif;webp;png&as=picture";
+import grafo2025 from "./assets/grafo-espacio-estados-2025.png?w=400;800;1200&format=avif;webp;png&as=picture";
+import arbolPG from "./assets/arbol-programacion-genetica-2025.png?w=400;800;1200&format=avif;webp;png&as=picture";
+import grafo2026 from "./assets/grafo-astar-2026.png?w=400;800;1200&format=avif;webp;png&as=picture";
 
 export const questions: Question[] = [
   // ============================================================

--- a/src/vite-imagetools.d.ts
+++ b/src/vite-imagetools.d.ts
@@ -1,0 +1,4 @@
+declare module "*&as=picture" {
+  const picture: import("vite-imagetools").Picture;
+  export default picture;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,11 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
+import { imagetools } from "vite-imagetools";
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [react(), tailwindcss(), imagetools()],
   define: {
     __VERCEL_PRODUCTION__: JSON.stringify(
       process.env.VERCEL_ENV === "production",


### PR DESCRIPTION
## Summary

Replace plain `<img>` tags with responsive `<picture>` elements using [vite-imagetools](https://github.com/JonasKruckenberg/imagetools) to generate AVIF, WebP, and resized variants at build time.

## Changes

- **Install** `vite-imagetools` v10 and configure in `vite.config.ts`
- **Image imports** now use query params: `?w=400;800;1200&format=avif;webp;png&as=picture`
- **QuestionCard** renders `<picture>` with `<source>` tags for AVIF/WebP + PNG fallback
- **Plain `<img>` fallback** for non-optimized images (corrupt JPEGs handled gracefully)
- **Remove** `imageWidth`/`imageHeight` — dimensions come from the picture import
- **Update** AGENTS.md and CONTRIBUTING.md documentation

## Impact

Build output now generates AVIF (~5-15 KB) and WebP (~5-30 KB) variants per image, with browsers automatically selecting the most efficient format. Original PNGs remain as fallback for older browsers.

### Example size comparison

| Image | Original | AVIF (400w) | WebP (400w) |
|-------|----------|-------------|-------------|
| Figure 1 2025.png | 485 KB | 6.5 KB | 9.5 KB |
| arbol-hill-climbing-2023.png | 215 KB | 4.4 KB | 6.0 KB |
| Figure 4 Exam 2024.png | 433 KB | 6.5 KB | 9.4 KB |

## Verification

- [x] `pnpm build` succeeds
- [x] `pnpm lint` passes