### PR TITLE
feat: generate sitemap.xml at build time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+public/sitemap.xml

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from "typescript-eslint";
 import { defineConfig, globalIgnores } from "eslint/config";
 
 export default defineConfig([
-  globalIgnores(["dist"]),
+  globalIgnores(["dist", "scripts"]),
   {
     files: ["**/*.{ts,tsx}"],
     extends: [

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && tsx scripts/generate-sitemap.ts && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
     "format": "prettier . --write",
@@ -33,6 +33,7 @@
     "tailwindcss": "^4.3.0",
     "typescript": "~6.0.2",
     "typescript-eslint": "^8.59.2",
+    "tsx": "^4.22.4",
     "vite": "^8.0.12"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         version: 10.0.1(eslint@10.5.0(jiti@2.7.0))
       '@tailwindcss/vite':
         specifier: ^4.3.0
-        version: 4.3.1(vite@8.0.16(@types/node@24.13.2)(jiti@2.7.0))
+        version: 4.3.1(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
       '@types/node':
         specifier: ^24
         version: 24.13.2
@@ -41,7 +41,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.2(vite@8.0.16(@types/node@24.13.2)(jiti@2.7.0))
+        version: 6.0.2(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
       eslint:
         specifier: ^10.3.0
         version: 10.5.0(jiti@2.7.0)
@@ -60,6 +60,9 @@ importers:
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.1
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
       typescript:
         specifier: ~6.0.2
         version: 6.0.3
@@ -68,7 +71,7 @@ importers:
         version: 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
       vite:
         specifier: ^8.0.12
-        version: 8.0.16(@types/node@24.13.2)(jiti@2.7.0)
+        version: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)
 
 packages:
 
@@ -147,6 +150,162 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -590,6 +749,11 @@ packages:
     resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
     engines: {node: '>=10.13.0'}
 
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -996,6 +1160,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.22.4:
+    resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -1227,6 +1396,84 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
+    optional: true
+
   '@eslint-community/eslint-utils@4.9.1(eslint@10.5.0(jiti@2.7.0))':
     dependencies:
       eslint: 10.5.0(jiti@2.7.0)
@@ -1417,12 +1664,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.1
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.1
 
-  '@tailwindcss/vite@4.3.1(vite@8.0.16(@types/node@24.13.2)(jiti@2.7.0))':
+  '@tailwindcss/vite@4.3.1(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))':
     dependencies:
       '@tailwindcss/node': 4.3.1
       '@tailwindcss/oxide': 4.3.1
       tailwindcss: 4.3.1
-      vite: 8.0.16(@types/node@24.13.2)(jiti@2.7.0)
+      vite: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)
 
   '@tybys/wasm-util@0.10.2':
     dependencies:
@@ -1538,10 +1785,10 @@ snapshots:
       '@typescript-eslint/types': 8.61.1
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@24.13.2)(jiti@2.7.0))':
+  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.0.16(@types/node@24.13.2)(jiti@2.7.0)
+      vite: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)
 
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
@@ -1600,6 +1847,35 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
 
@@ -1956,6 +2232,12 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
+  tsx@4.22.4:
+    dependencies:
+      esbuild: 0.28.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -1985,7 +2267,7 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite@8.0.16(@types/node@24.13.2)(jiti@2.7.0):
+  vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -1994,8 +2276,10 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 24.13.2
+      esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 2.7.0
+      tsx: 4.22.4
 
   web-haptics@0.0.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,6 @@
 packages: []
+allowBuilds:
+  esbuild: true
 minimumReleaseAge: 10080
 trustPolicy: no-downgrade
 trustPolicyExclude:

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,5 @@
 User-agent: *
 Allow: /
 Disallow:
+
+Sitemap: https://pe.pablopl.dev/sitemap.xml

--- a/scripts/generate-sitemap.ts
+++ b/scripts/generate-sitemap.ts
@@ -1,0 +1,104 @@
+import { readdirSync, writeFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "..");
+const subjectsDir = resolve(root, "src", "subjects");
+
+const BASE_URL = process.env.SITE_URL || "https://pe.pablopl.dev";
+
+interface SitemapEntry {
+  loc: string;
+  priority: number;
+  changefreq:
+    | "always"
+    | "hourly"
+    | "daily"
+    | "weekly"
+    | "monthly"
+    | "yearly"
+    | "never";
+}
+
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+async function main() {
+  const urls: SitemapEntry[] = [];
+
+  urls.push({ loc: "/", priority: 1.0, changefreq: "weekly" });
+
+  const entries = readdirSync(subjectsDir, { withFileTypes: true });
+  const subjectDirs = entries.filter(
+    (e) => e.isDirectory() && e.name !== "_template",
+  );
+
+  for (const dir of subjectDirs) {
+    const subjectId = dir.name;
+    const metaPath = resolve(subjectsDir, subjectId, "meta.ts");
+
+    const { meta } = await import(metaPath);
+
+    urls.push({
+      loc: `/${subjectId}`,
+      priority: 0.9,
+      changefreq: "weekly",
+    });
+
+    urls.push({
+      loc: `/${subjectId}/practice`,
+      priority: 0.7,
+      changefreq: "monthly",
+    });
+
+    for (const topic of meta.topics) {
+      urls.push({
+        loc: `/${subjectId}/practice/${topic.key}`,
+        priority: 0.6,
+        changefreq: "monthly",
+      });
+    }
+
+    for (const exam of meta.exams) {
+      urls.push({
+        loc: `/${subjectId}/exam/${exam.year}`,
+        priority: 0.8,
+        changefreq: "monthly",
+      });
+    }
+  }
+
+  const today = new Date().toISOString().split("T")[0];
+
+  const xml = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    ...urls.map(
+      (u) =>
+        `  <url>\n` +
+        `    <loc>${escapeXml(BASE_URL + u.loc)}</loc>\n` +
+        `    <lastmod>${today}</lastmod>\n` +
+        `    <changefreq>${u.changefreq}</changefreq>\n` +
+        `    <priority>${u.priority}</priority>\n` +
+        `  </url>`,
+    ),
+    "</urlset>",
+    "",
+  ].join("\n");
+
+  const outPath = resolve(root, "public", "sitemap.xml");
+  writeFileSync(outPath, xml, "utf-8");
+  console.log(`Generated sitemap with ${urls.length} URLs → ${outPath}`);
+}
+
+main().catch((err) => {
+  console.error("Failed to generate sitemap:", err);
+  process.exit(1);
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -80,7 +80,10 @@ export default function App() {
                 path="/:subjectId/practice/:topic"
                 element={<PracticeTopic />}
               />
-              <Route path="/:subjectId/exam/:year" element={<ExamSimulation />} />
+              <Route
+                path="/:subjectId/exam/:year"
+                element={<ExamSimulation />}
+              />
             </Routes>
           </Suspense>
         </main>

--- a/src/components/AddExamModal.tsx
+++ b/src/components/AddExamModal.tsx
@@ -14,129 +14,132 @@ interface AddExamModalProps {
   ref: Ref<AddExamModalHandle>;
 }
 
-function AddExamModal({ onClose, subjectId, subjectName, ref }: AddExamModalProps) {
-    const t = useT();
-    const dialogRef = useRef<HTMLDialogElement>(null);
+function AddExamModal({
+  onClose,
+  subjectId,
+  subjectName,
+  ref,
+}: AddExamModalProps) {
+  const t = useT();
+  const dialogRef = useRef<HTMLDialogElement>(null);
 
-    useImperativeHandle(ref, () => ({
-      open: () => dialogRef.current?.showModal(),
-      close: () => dialogRef.current?.close(),
-    }));
+  useImperativeHandle(ref, () => ({
+    open: () => dialogRef.current?.showModal(),
+    close: () => dialogRef.current?.close(),
+  }));
 
-    useEffect(() => {
-      const dialog = dialogRef.current;
-      if (!dialog) return;
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
 
-      const handleClose = () => onClose();
-      const handleBackdropClick = (e: MouseEvent) => {
-        if (e.target === dialog) dialog.close();
-      };
-      dialog.addEventListener("close", handleClose);
-      dialog.addEventListener("click", handleBackdropClick);
-      return () => {
-        dialog.removeEventListener("close", handleClose);
-        dialog.removeEventListener("click", handleBackdropClick);
-      };
-    }, [onClose]);
+    const handleClose = () => onClose();
+    const handleBackdropClick = (e: MouseEvent) => {
+      if (e.target === dialog) dialog.close();
+    };
+    dialog.addEventListener("close", handleClose);
+    dialog.addEventListener("click", handleBackdropClick);
+    return () => {
+      dialog.removeEventListener("close", handleClose);
+      dialog.removeEventListener("click", handleBackdropClick);
+    };
+  }, [onClose]);
 
-    const issueUrl = `${t.addExam.openIssueUrl}&title=${encodeURIComponent(`${subjectName}`)}`;
+  const issueUrl = `${t.addExam.openIssueUrl}&title=${encodeURIComponent(`${subjectName}`)}`;
 
-    return (
-      <dialog
-        ref={dialogRef}
-        className="animate-dialog m-auto max-w-sm rounded-2xl bg-surface-alt p-6 shadow-2xl backdrop:bg-black/50 backdrop:transition-[background-color,overlay,display] backdrop:duration-200"
-        aria-labelledby="add-exam-title"
-        onClose={() => {
-          track("add_exam_modal_close", { subjectId });
-        }}
-      >
-        <div>
-          <div className="flex items-center justify-between mb-5">
-            <h2 id="add-exam-title" className="text-lg font-semibold text-fg">
-              {t.addExam.title}
-            </h2>
-            <button
-              type="button"
-              onClick={() => {
-                track("add_exam_modal_close_btn", { subjectId });
-                dialogRef.current?.close();
-              }}
-              className="text-fg-muted hover:text-fg-secondary transition-colors cursor-pointer"
-              aria-label={t.addExam.close}
+  return (
+    <dialog
+      ref={dialogRef}
+      className="animate-dialog m-auto max-w-sm rounded-2xl bg-surface-alt p-6 shadow-2xl backdrop:bg-black/50 backdrop:transition-[background-color,overlay,display] backdrop:duration-200"
+      aria-labelledby="add-exam-title"
+      onClose={() => {
+        track("add_exam_modal_close", { subjectId });
+      }}
+    >
+      <div>
+        <div className="flex items-center justify-between mb-5">
+          <h2 id="add-exam-title" className="text-lg font-semibold text-fg">
+            {t.addExam.title}
+          </h2>
+          <button
+            type="button"
+            onClick={() => {
+              track("add_exam_modal_close_btn", { subjectId });
+              dialogRef.current?.close();
+            }}
+            className="text-fg-muted hover:text-fg-secondary transition-colors cursor-pointer"
+            aria-label={t.addExam.close}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-5 w-5"
+              viewBox="0 0 20 20"
+              fill="currentColor"
             >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                className="h-5 w-5"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-              >
-                <path
-                  fillRule="evenodd"
-                  d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
-                  clipRule="evenodd"
-                />
-              </svg>
-            </button>
-          </div>
+              <path
+                fillRule="evenodd"
+                d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </button>
+        </div>
 
-          <div className="space-y-3">
-            <a
-              href={issueUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={() => track("add_exam_open_issue", { subjectId })}
-              className="flex items-center gap-3 p-3 rounded-xl border-2 border-accent-border bg-accent-light hover:bg-accent-light hover:border-accent transition-colors cursor-pointer text-left no-underline text-inherit"
-            >
-              <span className="text-xl">📝</span>
-              <div>
-                <div className="font-medium text-fg text-sm">
-                  {t.addExam.openIssue}
-                </div>
-                <div className="text-xs text-fg-muted">
-                  {t.addExam.openIssueDesc}
-                </div>
+        <div className="space-y-3">
+          <a
+            href={issueUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => track("add_exam_open_issue", { subjectId })}
+            className="flex items-center gap-3 p-3 rounded-xl border-2 border-accent-border bg-accent-light hover:bg-accent-light hover:border-accent transition-colors cursor-pointer text-left no-underline text-inherit"
+          >
+            <span className="text-xl">📝</span>
+            <div>
+              <div className="font-medium text-fg text-sm">
+                {t.addExam.openIssue}
               </div>
-            </a>
-
-            <a
-              href="https://github.com/TeenBiscuits/Pasame-Examenes/blob/main/CONTRIBUTING.md"
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={() => track("add_exam_contribute", { subjectId })}
-              className="flex items-center gap-3 p-3 rounded-xl border-2 border-blue-300 bg-blue-50 hover:bg-blue-100 hover:border-blue-400 transition-colors cursor-pointer text-left no-underline text-inherit"
-            >
-              <span className="text-xl">🚀</span>
-              <div>
-                <div className="font-medium text-fg text-sm">
-                  {t.addExam.contribute}
-                </div>
-                <div className="text-xs text-fg-muted">
-                  {t.addExam.contributeDesc}
-                </div>
+              <div className="text-xs text-fg-muted">
+                {t.addExam.openIssueDesc}
               </div>
-            </a>
-
-            <div className="pt-2 border-t border-border">
-              <a
-                href="mailto:pablo.portas@udc.es"
-                onClick={() => track("add_exam_email", { subjectId })}
-                className="flex items-center gap-3 p-3 rounded-xl border-2 border-border bg-surface/50 hover:bg-surface hover:border-border transition-colors cursor-pointer text-left no-underline text-inherit"
-              >
-                <span className="text-xl">✉️</span>
-                <div>
-                  <div className="font-medium text-fg-secondary text-sm">
-                    {t.addExam.email}
-                  </div>
-                  <div className="text-xs text-fg-muted">
-                    pablo.portas@udc.es
-                  </div>
-                </div>
-              </a>
             </div>
+          </a>
+
+          <a
+            href="https://github.com/TeenBiscuits/Pasame-Examenes/blob/main/CONTRIBUTING.md"
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => track("add_exam_contribute", { subjectId })}
+            className="flex items-center gap-3 p-3 rounded-xl border-2 border-blue-300 bg-blue-50 hover:bg-blue-100 hover:border-blue-400 transition-colors cursor-pointer text-left no-underline text-inherit"
+          >
+            <span className="text-xl">🚀</span>
+            <div>
+              <div className="font-medium text-fg text-sm">
+                {t.addExam.contribute}
+              </div>
+              <div className="text-xs text-fg-muted">
+                {t.addExam.contributeDesc}
+              </div>
+            </div>
+          </a>
+
+          <div className="pt-2 border-t border-border">
+            <a
+              href="mailto:pablo.portas@udc.es"
+              onClick={() => track("add_exam_email", { subjectId })}
+              className="flex items-center gap-3 p-3 rounded-xl border-2 border-border bg-surface/50 hover:bg-surface hover:border-border transition-colors cursor-pointer text-left no-underline text-inherit"
+            >
+              <span className="text-xl">✉️</span>
+              <div>
+                <div className="font-medium text-fg-secondary text-sm">
+                  {t.addExam.email}
+                </div>
+                <div className="text-xs text-fg-muted">pablo.portas@udc.es</div>
+              </div>
+            </a>
           </div>
         </div>
-      </dialog>
-    );
+      </div>
+    </dialog>
+  );
 }
 
 export default AddExamModal;

--- a/src/components/AddSubjectModal.tsx
+++ b/src/components/AddSubjectModal.tsx
@@ -13,129 +13,124 @@ interface AddSubjectModalProps {
 }
 
 function AddSubjectModal({ onClose, ref }: AddSubjectModalProps) {
-    const t = useT();
-    const dialogRef = useRef<HTMLDialogElement>(null);
+  const t = useT();
+  const dialogRef = useRef<HTMLDialogElement>(null);
 
-    useImperativeHandle(ref, () => ({
-      open: () => dialogRef.current?.showModal(),
-      close: () => dialogRef.current?.close(),
-    }));
+  useImperativeHandle(ref, () => ({
+    open: () => dialogRef.current?.showModal(),
+    close: () => dialogRef.current?.close(),
+  }));
 
-    useEffect(() => {
-      const dialog = dialogRef.current;
-      if (!dialog) return;
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
 
-      const handleClose = () => onClose();
-      const handleBackdropClick = (e: MouseEvent) => {
-        if (e.target === dialog) dialog.close();
-      };
-      dialog.addEventListener("close", handleClose);
-      dialog.addEventListener("click", handleBackdropClick);
-      return () => {
-        dialog.removeEventListener("close", handleClose);
-        dialog.removeEventListener("click", handleBackdropClick);
-      };
-    }, [onClose]);
+    const handleClose = () => onClose();
+    const handleBackdropClick = (e: MouseEvent) => {
+      if (e.target === dialog) dialog.close();
+    };
+    dialog.addEventListener("close", handleClose);
+    dialog.addEventListener("click", handleBackdropClick);
+    return () => {
+      dialog.removeEventListener("close", handleClose);
+      dialog.removeEventListener("click", handleBackdropClick);
+    };
+  }, [onClose]);
 
-    return (
-      <dialog
-        ref={dialogRef}
-        className="animate-dialog m-auto max-w-sm rounded-2xl bg-surface-alt p-6 shadow-2xl backdrop:bg-black/50 backdrop:transition-[background-color,overlay,display] backdrop:duration-200"
-        aria-labelledby="add-subject-title"
-        onClose={() => {
-          track("add_subject_modal_close");
-        }}
-      >
-        <div>
-          <div className="flex items-center justify-between mb-5">
-            <h2
-              id="add-subject-title"
-              className="text-lg font-semibold text-fg"
+  return (
+    <dialog
+      ref={dialogRef}
+      className="animate-dialog m-auto max-w-sm rounded-2xl bg-surface-alt p-6 shadow-2xl backdrop:bg-black/50 backdrop:transition-[background-color,overlay,display] backdrop:duration-200"
+      aria-labelledby="add-subject-title"
+      onClose={() => {
+        track("add_subject_modal_close");
+      }}
+    >
+      <div>
+        <div className="flex items-center justify-between mb-5">
+          <h2 id="add-subject-title" className="text-lg font-semibold text-fg">
+            {t.addSubject.title}
+          </h2>
+          <button
+            type="button"
+            onClick={() => {
+              track("add_subject_modal_close_btn");
+              dialogRef.current?.close();
+            }}
+            className="text-fg-muted hover:text-fg-secondary transition-colors cursor-pointer"
+            aria-label={t.addSubject.close}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-5 w-5"
+              viewBox="0 0 20 20"
+              fill="currentColor"
             >
-              {t.addSubject.title}
-            </h2>
-            <button
-              type="button"
-              onClick={() => {
-                track("add_subject_modal_close_btn");
-                dialogRef.current?.close();
-              }}
-              className="text-fg-muted hover:text-fg-secondary transition-colors cursor-pointer"
-              aria-label={t.addSubject.close}
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                className="h-5 w-5"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-              >
-                <path
-                  fillRule="evenodd"
-                  d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
-                  clipRule="evenodd"
-                />
-              </svg>
-            </button>
-          </div>
+              <path
+                fillRule="evenodd"
+                d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </button>
+        </div>
 
-          <div className="space-y-3">
-            <a
-              href={t.addSubject.openIssueUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={() => track("add_subject_open_issue")}
-              className="flex items-center gap-3 p-3 rounded-xl border-2 border-accent-border bg-accent-light hover:bg-accent-light hover:border-accent transition-colors cursor-pointer text-left no-underline text-inherit"
-            >
-              <span className="text-xl">📝</span>
-              <div>
-                <div className="font-medium text-fg text-sm">
-                  {t.addSubject.openIssue}
-                </div>
-                <div className="text-xs text-fg-muted">
-                  {t.addSubject.openIssueDesc}
-                </div>
+        <div className="space-y-3">
+          <a
+            href={t.addSubject.openIssueUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => track("add_subject_open_issue")}
+            className="flex items-center gap-3 p-3 rounded-xl border-2 border-accent-border bg-accent-light hover:bg-accent-light hover:border-accent transition-colors cursor-pointer text-left no-underline text-inherit"
+          >
+            <span className="text-xl">📝</span>
+            <div>
+              <div className="font-medium text-fg text-sm">
+                {t.addSubject.openIssue}
               </div>
-            </a>
-
-            <a
-              href="https://github.com/TeenBiscuits/Pasame-Examenes/blob/main/CONTRIBUTING.md"
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={() => track("add_subject_contribute")}
-              className="flex items-center gap-3 p-3 rounded-xl border-2 border-blue-300 bg-blue-50 hover:bg-blue-100 hover:border-blue-400 transition-colors cursor-pointer text-left no-underline text-inherit"
-            >
-              <span className="text-xl">🚀</span>
-              <div>
-                <div className="font-medium text-fg text-sm">
-                  {t.addSubject.contribute}
-                </div>
-                <div className="text-xs text-fg-muted">
-                  {t.addSubject.contributeDesc}
-                </div>
+              <div className="text-xs text-fg-muted">
+                {t.addSubject.openIssueDesc}
               </div>
-            </a>
-
-            <div className="pt-2 border-t border-border">
-              <a
-                href="mailto:pablo.portas@udc.es"
-                onClick={() => track("add_subject_email")}
-                className="flex items-center gap-3 p-3 rounded-xl border-2 border-border bg-surface/50 hover:bg-surface hover:border-border transition-colors cursor-pointer text-left no-underline text-inherit"
-              >
-                <span className="text-xl">✉️</span>
-                <div>
-                  <div className="font-medium text-fg-secondary text-sm">
-                    {t.addSubject.email}
-                  </div>
-                  <div className="text-xs text-fg-muted">
-                    pablo.portas@udc.es
-                  </div>
-                </div>
-              </a>
             </div>
+          </a>
+
+          <a
+            href="https://github.com/TeenBiscuits/Pasame-Examenes/blob/main/CONTRIBUTING.md"
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => track("add_subject_contribute")}
+            className="flex items-center gap-3 p-3 rounded-xl border-2 border-blue-300 bg-blue-50 hover:bg-blue-100 hover:border-blue-400 transition-colors cursor-pointer text-left no-underline text-inherit"
+          >
+            <span className="text-xl">🚀</span>
+            <div>
+              <div className="font-medium text-fg text-sm">
+                {t.addSubject.contribute}
+              </div>
+              <div className="text-xs text-fg-muted">
+                {t.addSubject.contributeDesc}
+              </div>
+            </div>
+          </a>
+
+          <div className="pt-2 border-t border-border">
+            <a
+              href="mailto:pablo.portas@udc.es"
+              onClick={() => track("add_subject_email")}
+              className="flex items-center gap-3 p-3 rounded-xl border-2 border-border bg-surface/50 hover:bg-surface hover:border-border transition-colors cursor-pointer text-left no-underline text-inherit"
+            >
+              <span className="text-xl">✉️</span>
+              <div>
+                <div className="font-medium text-fg-secondary text-sm">
+                  {t.addSubject.email}
+                </div>
+                <div className="text-xs text-fg-muted">pablo.portas@udc.es</div>
+              </div>
+            </a>
           </div>
         </div>
-      </dialog>
-    );
+      </div>
+    </dialog>
+  );
 }
 
 export default AddSubjectModal;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -83,7 +83,9 @@ export default function Header() {
               setLang(nextLang);
             }}
             aria-label={
-              lang === "en" ? "🇪🇸 ES — Switch to Spanish" : "🇬🇧 EN — Cambiar a inglés"
+              lang === "en"
+                ? "🇪🇸 ES — Switch to Spanish"
+                : "🇬🇧 EN — Cambiar a inglés"
             }
           >
             {lang === "en" ? "🇪🇸 ES" : "🇬🇧 EN"}

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -97,7 +97,9 @@ function MCQuestion({
               {letter}
             </span>
             <span className="flex-1">
-              <InlineMarkdown>{opt.replace(/^[a-eA-E][.)]\s*/, "")}</InlineMarkdown>
+              <InlineMarkdown>
+                {opt.replace(/^[a-eA-E][.)]\s*/, "")}
+              </InlineMarkdown>
             </span>
           </button>
         );
@@ -344,7 +346,9 @@ export default function QuestionCard(props: QuestionCardProps) {
           </span>
         )}
         {props.examDate && (
-          <span className={`text-xs text-fg-muted ${!question.repeated ? "ml-auto" : ""}`}>
+          <span
+            className={`text-xs text-fg-muted ${!question.repeated ? "ml-auto" : ""}`}
+          >
             {props.examDate}
           </span>
         )}

--- a/src/pages/ExamSimulation.tsx
+++ b/src/pages/ExamSimulation.tsx
@@ -509,9 +509,22 @@ export default function ExamSimulation() {
           disabled={currentIndex === 0}
         >
           <span className="flex items-center gap-1.5">
-            <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
+            <svg
+              viewBox="0 0 24 24"
+              width="18"
+              height="18"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              aria-hidden="true"
+            >
               <rect x="2.5" y="2.5" width="19" height="19" rx="5" />
-              <path d="M14 8l-4 4 4 4" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+              <path
+                d="M14 8l-4 4 4 4"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
             </svg>
             {t.exam.previous}
           </span>
@@ -546,9 +559,22 @@ export default function ExamSimulation() {
         >
           <span className="flex items-center gap-1.5">
             {t.exam.next}
-            <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
+            <svg
+              viewBox="0 0 24 24"
+              width="18"
+              height="18"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              aria-hidden="true"
+            >
               <rect x="2.5" y="2.5" width="19" height="19" rx="5" />
-              <path d="M10 8l4 4-4 4" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+              <path
+                d="M10 8l4 4-4 4"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
             </svg>
           </span>
         </button>

--- a/src/pages/PracticeHome.tsx
+++ b/src/pages/PracticeHome.tsx
@@ -9,7 +9,11 @@ export default function PracticeHome() {
   const { subjectId } = useParams<{ subjectId: string }>();
   const t = useT();
   const subject = subjectId ? getSubject(subjectId) : undefined;
-  useDocumentTitle(subject ? `${t.practiceHome.title} \u2014 ${subject.name} \u2014 ${t.home.title}` : t.home.title);
+  useDocumentTitle(
+    subject
+      ? `${t.practiceHome.title} \u2014 ${subject.name} \u2014 ${t.home.title}`
+      : t.home.title,
+  );
 
   if (!subject) return null;
 

--- a/src/pages/PracticeTopic.tsx
+++ b/src/pages/PracticeTopic.tsx
@@ -394,9 +394,22 @@ export default function PracticeTopic() {
           disabled={currentIndex === 0}
         >
           <span className="flex items-center gap-1.5">
-            <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
+            <svg
+              viewBox="0 0 24 24"
+              width="18"
+              height="18"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              aria-hidden="true"
+            >
               <rect x="2.5" y="2.5" width="19" height="19" rx="5" />
-              <path d="M14 8l-4 4 4 4" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+              <path
+                d="M14 8l-4 4 4 4"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
             </svg>
             {t.practice.previous}
           </span>
@@ -466,9 +479,22 @@ export default function PracticeTopic() {
         >
           <span className="flex items-center gap-1.5">
             {t.practice.next}
-            <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
+            <svg
+              viewBox="0 0 24 24"
+              width="18"
+              height="18"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              aria-hidden="true"
+            >
               <rect x="2.5" y="2.5" width="19" height="19" rx="5" />
-              <path d="M10 8l4 4-4 4" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+              <path
+                d="M10 8l4 4-4 4"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
             </svg>
           </span>
         </button>

--- a/src/pages/SubjectHome.tsx
+++ b/src/pages/SubjectHome.tsx
@@ -17,7 +17,9 @@ export default function SubjectHome() {
   const t = useT();
   const examModalRef = useRef<AddExamModalHandle>(null);
   const subject = subjectId ? getSubject(subjectId) : undefined;
-  useDocumentTitle(subject ? `${subject.name} \u2014 ${t.home.title}` : t.home.title);
+  useDocumentTitle(
+    subject ? `${subject.name} \u2014 ${t.home.title}` : t.home.title,
+  );
 
   if (!subject) {
     return (

--- a/src/subjects/index.ts
+++ b/src/subjects/index.ts
@@ -21,7 +21,9 @@ const questionsModules = import.meta.glob<QuestionsModule>("./*/questions.ts", {
 export const subjects: SubjectMeta[] = [];
 for (const m of Object.values(metaModules)) {
   const s = m.meta;
-  if (!(import.meta.env.PROD && __VERCEL_PRODUCTION__ && s.id === "_template")) {
+  if (
+    !(import.meta.env.PROD && __VERCEL_PRODUCTION__ && s.id === "_template")
+  ) {
     subjects.push(s);
   }
 }

--- a/src/theme/context.tsx
+++ b/src/theme/context.tsx
@@ -72,8 +72,6 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   );
 
   return (
-    <ThemeContext.Provider value={value}>
-      {children}
-    </ThemeContext.Provider>
+    <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
   );
 }


### PR DESCRIPTION
## Changes

Adds a pre-build script that automatically generates `sitemap.xml` with all site URLs (currently 66), improving search engine indexability.

### What's included

- **`scripts/generate-sitemap.ts`** — Pre-build script that discovers all subjects, topics, and exams from the filesystem by dynamically importing each `meta.ts` file. Generates proper XML with appropriate `priority` and `changefreq` values per page type.
- **`package.json`** — Added `tsx` devDependency and updated build command: `tsc -b && tsx scripts/generate-sitemap.ts && vite build`
- **`public/robots.txt`** — Added `Sitemap` directive pointing to `https://pe.pablopl.dev/sitemap.xml`
- **`.gitignore`** — Added `public/sitemap.xml` (generated at build time, not tracked)
- **`eslint.config.js`** — Ignored scripts directory from type-aware linting

### How it works

1. Reads all subject directories (excluding `_template`)
2. Dynamically imports each `meta.ts` to get topics and exams
3. Generates URLs for: home, subject pages, practice home, practice topics, exam simulations
4. Writes `public/sitemap.xml` — Vite then copies it to `dist/` during build

### Adding new subjects/exams

No manual sitemap updates needed — the script auto-discovers everything.