### PR TITLE
fix: match Safari iOS toolbar color to header/footer theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,8 +17,11 @@
     />
     <meta name="apple-mobile-web-app-title" content="Pásame Éxamenes" />
     <link rel="manifest" href="/site.webmanifest?v=20260620" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="theme-color" content="#f9fafb" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
+    <meta id="theme-color" name="theme-color" content="#f9fafb" />
     <meta name="color-scheme" content="light dark" />
     <meta
       name="description"
@@ -32,6 +35,21 @@
       (function () {
         var t = localStorage.getItem("theme") || "system";
         document.documentElement.setAttribute("data-theme", t);
+
+        var colors = {
+          light: "#ffffff",
+          dark: "#1f2937",
+          pink: "#ffffff",
+          catppuccin: "#313244",
+        };
+        var color = colors[t];
+        if (t === "system") {
+          color = window.matchMedia("(prefers-color-scheme: dark)").matches
+            ? colors.dark
+            : colors.light;
+        }
+        var meta = document.getElementById("theme-color");
+        if (meta) meta.setAttribute("content", color);
       })();
     </script>
     <title>Pásame Exámenes</title>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,7 +33,7 @@ function PageViewTracker() {
 function Footer() {
   const t = useT();
   return (
-    <footer className="bg-surface-alt border-t border-border py-6 text-sm text-fg-muted">
+    <footer className="bg-surface-alt border-t border-border pt-6 pb-[calc(1.5rem+env(safe-area-inset-bottom))] text-sm text-fg-muted">
       <div className="max-w-6xl mx-auto px-4 flex flex-col sm:flex-row items-center justify-between gap-4">
         <p className="font-medium">{t.footer.byline}</p>
         <a

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,14 @@
 @import "tailwindcss";
 @import "tailwind-animations";
 
+/* ── iOS safe-area / overscroll helpers ── */
+html,
+body {
+  /* Match the header/footer surface so the Safari toolbar/safe-area background
+     has the same color as the surrounding chrome. */
+  background-color: var(--color-surface-alt);
+}
+
 /* ── Theme tokens (light defaults) ── */
 @theme {
   --color-surface: #f9fafb;

--- a/src/theme/context.tsx
+++ b/src/theme/context.tsx
@@ -32,6 +32,22 @@ function getInitialTheme(): Theme {
   return "system";
 }
 
+const themeColors: Record<Exclude<Theme, "system">, string> = {
+  light: "#ffffff",
+  dark: "#1f2937",
+  pink: "#ffffff",
+  catppuccin: "#313244",
+};
+
+function resolveThemeColor(theme: Theme): string {
+  if (theme === "system") {
+    return window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? themeColors.dark
+      : themeColors.light;
+  }
+  return themeColors[theme];
+}
+
 function applyTheme(theme: Theme): Theme {
   if (typeof document === "undefined") return theme;
   try {
@@ -40,6 +56,8 @@ function applyTheme(theme: Theme): Theme {
     /* localStorage unavailable */
   }
   document.documentElement.setAttribute("data-theme", theme);
+  const meta = document.getElementById("theme-color");
+  if (meta) meta.setAttribute("content", resolveThemeColor(theme));
   return theme;
 }
 
@@ -48,6 +66,14 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     applyTheme(theme);
+  }, [theme]);
+
+  useEffect(() => {
+    if (theme !== "system") return;
+    const media = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = () => applyTheme("system");
+    media.addEventListener("change", handler);
+    return () => media.removeEventListener("change", handler);
   }, [theme]);
 
   const setTheme = useCallback((next: Theme) => {


### PR DESCRIPTION
Corrige el bloque negro que aparecía debajo de la barra de herramientas de Safari en iOS al usar temas oscuros o no estándar.

Cambios:
- Añade `viewport-fit=cover` al viewport.
- Hace dinámico el `<meta name="theme-color">` según el tema activo, usando el mismo color que el header/footer (`--color-surface-alt`).
- Actualiza el color también cuando el tema es `system` y cambia `prefers-color-scheme`.
- Aplica `env(safe-area-inset-bottom)` al footer para evitar que el contenido quede tapado por la barra de herramientas/indicador de inicio.
- Establece el fondo de `html`/`body` a `--color-surface-alt` para mantener consistencia visual.
