### PR TITLE
refactor: merge V/F questions into matching-type grouped by topic in equisi

### DIFF
--- a/src/subjects/equisi/meta.ts
+++ b/src/subjects/equisi/meta.ts
@@ -10,10 +10,16 @@ export const meta: SubjectMeta = {
     "Preguntas recopiladas de exámenes oficiais do Grao en Enxeñaría Informática.",
   topics: [
     {
-      key: "preguntas",
-      label: "Preguntas",
-      icon: "❓",
-      color: "blue",
+      key: "teoria",
+      label: "Teoría",
+      icon: "📖",
+      color: "indigo",
+    },
+    {
+      key: "practica",
+      label: "Práctica",
+      icon: "🛠️",
+      color: "green",
     },
   ],
   exams: [

--- a/src/subjects/equisi/questions.ts
+++ b/src/subjects/equisi/questions.ts
@@ -6,149 +6,61 @@ export const questions: Question[] = [
   // Exam Xaneiro 2024
   // ============================================================
 
-  // --- Tema 2: Planificación ---
+  // --- V/F Teoría ---
   {
-    id: "2024-01_q1_1",
+    id: "2024-01_vf_teoria",
     exam: "2024-01",
-    topic: "preguntas",
-    type: "mc",
-    points: 0.5,
+    topic: "teoria",
+    type: "matching",
+    points: 3,
     question:
-      "O Diagrama de Gantt ten unha estreita relación coas Redes de Precedencia, pois é unha representación simplificada destas.",
-    options: ["V. Verdadeiro", "F. Falso"],
-    correctAnswer: "a",
+      "Indique se as seguintes afirmacións son verdadeiras ou falsas:",
+    correctAnswer: {
+      "O Diagrama de Gantt ten unha estreita relación coas Redes de Precedencia, pois é unha representación simplificada destas.":
+        "V",
+      "Para aplicar CPM e calcular as datas early e late é imprescindible coñecer as asignacións dos recursos.":
+        "F",
+      "A FC B é equivalente a A CC+2d B se A dura 2 días.":
+        "V",
+      "Aínda que haxa unha forma de priorizar riscos, ás veces o Xefe de Proxecto pode e debe tratar como relevantes riscos que non o son atendendo á súa priorización.":
+        "V",
+      "Un Plan de Proxecto é o único produto de saída (entregable) das actividades de Xestión de Proxectos que habería que someter a Xestión da Configuración do Software.":
+        "F",
+      "Hai polo menos 3 razóns que xustifican, en Xestión da Configuración do Software, a necesidade de ter dispoñibles as versións intermedias dun ECS.":
+        "V",
+    },
     explanation:
-      "O Diagrama de Gantt é unha representación visual simplificada das relacións de precedencia definidas nas redes PERT/CPM.",
-  },
-  {
-    id: "2024-01_q1_2",
-    exam: "2024-01",
-    topic: "preguntas",
-    type: "mc",
-    points: 0.5,
-    question:
-      "Para aplicar CPM e calcular as datas early e late é imprescindible coñecer as asignacións dos recursos.",
-    options: ["V. Verdadeiro", "F. Falso"],
-    correctAnswer: "b",
-    explanation:
-      "O CPM (Critical Path Method) calcúlase sen necesidade de coñecer as asignacións de recursos. O CPM só ten en conta as dependencias e duracións das tarefas.",
-  },
-  {
-    id: "2024-01_q1_3",
-    exam: "2024-01",
-    topic: "preguntas",
-    type: "mc",
-    points: 0.5,
-    question:
-      "A FC B é equivalente a A CC+2d B se A dura 2 días.",
-    options: ["V. Verdadeiro", "F. Falso"],
-    correctAnswer: "a",
-    explanation:
-      "FC (Finish-to-Start) con 0 días de retraso significa que B comeza cando A remata. CC+2d (Start-to-Start) con 2 días de retraso significa que B comeza 2 días despois de que A comece. Se A dura 2 días, ambas expresións son equivalentes.",
+      "O Diagrama de Gantt representa visualmente as relacións de precedencia (PERT/CPM). CPM non necesita asignacións de recursos. FC e CC+2d son equivalentes cando A dura 2 días. O Xefe de Proxecto pode priorizar riscos fóra da fórmula. GCS aplica a múltiples entregables, non só ao Plan. As versións intermedias en GCS son necesarias para trazabilidade, recuperación e traballo paralelo.",
   },
 
-  // --- Tema 3: MS-Project ---
+  // --- V/F Práctica ---
   {
-    id: "2024-01_q1_4",
+    id: "2024-01_vf_practica",
     exam: "2024-01",
-    topic: "preguntas",
-    type: "mc",
-    points: 0.5,
+    topic: "practica",
+    type: "matching",
+    points: 2,
     question:
-      "MS-Project pode identificar sobrecargas que sexan 'ficticias', pero tamén permite confirmar se realmente son sobrecargas ou non.",
-    options: ["V. Verdadeiro", "F. Falso"],
-    correctAnswer: "a",
+      "Indique se as seguintes afirmacións sobre MS-Project son verdadeiras ou falsas:",
+    correctAnswer: {
+      "MS-Project pode identificar sobrecargas que sexan 'ficticias', pero tamén permite confirmar se realmente son sobrecargas ou non.":
+        "V",
+      "MS-Project non controla a correcta aplicación en seguimento das restricións lóxicas.":
+        "F",
+      "Ao establecer liña de base en MS-Project, os datos previstos 'copianse' nos datos actuais.":
+        "V",
+      "En MS-Project, o camiño crítico sempre será un camiño continuo desde o principio ao final do proxecto.":
+        "F",
+    },
     explanation:
-      "MS-Project dispón de ferramentas de análise que permiten distinguir entre sobrecargas reais e ficticias, facilitando a toma de decisións na nivelación de recursos.",
-  },
-  {
-    id: "2024-01_q1_5",
-    exam: "2024-01",
-    topic: "preguntas",
-    type: "mc",
-    points: 0.5,
-    question:
-      "MS-Project non controla a correcta aplicación en seguimento das restricións lóxicas.",
-    options: ["V. Verdadeiro", "F. Falso"],
-    correctAnswer: "b",
-    explanation:
-      "MS-Project si controla e respecta as restricións lóxicas (dependencias entre tarefas) durante o seguimento do proxecto.",
-  },
-  {
-    id: "2024-01_q1_6",
-    exam: "2024-01",
-    topic: "preguntas",
-    type: "mc",
-    points: 0.5,
-    question:
-      "Ao establecer liña de base en MS-Project, os datos previstos 'copianse' nos datos actuais.",
-    options: ["V. Verdadeiro", "F. Falso"],
-    correctAnswer: "a",
-    explanation:
-      "Ao gardar unha liña de base, MS-Project copia os valores planificados (previstos) aos campos de liña de base. Os datos actuais reflíctense nos campos de seguimento.",
-  },
-  {
-    id: "2024-01_q1_7",
-    exam: "2024-01",
-    topic: "preguntas",
-    type: "mc",
-    points: 0.5,
-    question:
-      "En MS-Project, o camiño crítico sempre será un camiño continuo desde o principio ao final do proxecto.",
-    options: ["V. Verdadeiro", "F. Falso"],
-    correctAnswer: "b",
-    explanation:
-      "O camiño crítico en MS-Project non ten por que ser continuo de principio a fin. Pode haber tramos do proxecto sen folgura que non estean conectados entre si.",
-  },
-
-  // --- Tema 4: Xestión de Riscos ---
-  {
-    id: "2024-01_q1_8",
-    exam: "2024-01",
-    topic: "preguntas",
-    type: "mc",
-    points: 0.5,
-    question:
-      "Aínda que haxa unha forma de priorizar riscos, ás veces o Xefe de Proxecto pode e debe tratar como relevantes riscos que non o son atendendo á súa priorización.",
-    options: ["V. Verdadeiro", "F. Falso"],
-    correctAnswer: "a",
-    explanation:
-      "O criterio do xefe de proxecto pode elevar a relevancia dun risco máis aló do que indica a súa priorización cuantitativa, baseándose na experiencia ou en factores non cuantificables.",
-  },
-
-  // --- Tema 5: Xestión da Configuración do Software ---
-  {
-    id: "2024-01_q1_9",
-    exam: "2024-01",
-    topic: "preguntas",
-    type: "mc",
-    points: 0.5,
-    question:
-      "Un Plan de Proxecto é o único produto de saída (entregable) das actividades de Xestión de Proxectos que habería que someter a Xestión da Configuración do Software.",
-    options: ["V. Verdadeiro", "F. Falso"],
-    correctAnswer: "b",
-    explanation:
-      "Non só o Plan de Proxecto, senón múltiples entregables da GP (plan de riscos, plan de calidade, EDT, calendario, etc.) deben someterse a GCS.",
-  },
-  {
-    id: "2024-01_q1_10",
-    exam: "2024-01",
-    topic: "preguntas",
-    type: "mc",
-    points: 0.5,
-    question:
-      "Hai polo menos 3 razóns que xustifican, en Xestión da Configuración do Software, a necesidade de ter dispoñibles as versións intermedias dun ECS.",
-    options: ["V. Verdadeiro", "F. Falso"],
-    correctAnswer: "a",
-    explanation:
-      "As versións intermedias dun Elemento de Configuración Software son necesarias para trazabilidade, recuperación ante erros, auditoría e para permitir o traballo paralelo.",
+      "MS-Project distingue sobrecargas reais e ficticias. Si controla restricións lóxicas. A liña base copia os previstos, non ao revés. O camiño crítico non ten por que ser continuo.",
   },
 
   // --- Tema 8: Calidade ---
   {
     id: "2024-01_q2",
     exam: "2024-01",
-    topic: "preguntas",
+    topic: "teoria",
     type: "text",
     points: 1,
     question:
@@ -163,7 +75,7 @@ export const questions: Question[] = [
   {
     id: "2024-01_q3",
     exam: "2024-01",
-    topic: "preguntas",
+    topic: "teoria",
     type: "text",
     points: 1,
     question:
@@ -178,7 +90,7 @@ export const questions: Question[] = [
   {
     id: "2024-01_q4",
     exam: "2024-01",
-    topic: "preguntas",
+    topic: "teoria",
     type: "text",
     points: 1,
     question:
@@ -193,7 +105,7 @@ export const questions: Question[] = [
   {
     id: "2024-01_q5",
     exam: "2024-01",
-    topic: "preguntas",
+    topic: "practica",
     type: "text",
     points: 1,
     question:
@@ -206,7 +118,7 @@ export const questions: Question[] = [
   {
     id: "2024-01_q6",
     exam: "2024-01",
-    topic: "preguntas",
+    topic: "practica",
     type: "text",
     points: 1,
     question:
@@ -225,7 +137,7 @@ export const questions: Question[] = [
   {
     id: "2026-01_q1",
     exam: "2026-01",
-    topic: "preguntas",
+    topic: "teoria",
     type: "text",
     points: 3,
     question:
@@ -239,7 +151,7 @@ export const questions: Question[] = [
   {
     id: "2026-01_q2",
     exam: "2026-01",
-    topic: "preguntas",
+    topic: "teoria",
     type: "calculation",
     points: 2,
     question: `Escribe a forma estándar do seguinte problema:
@@ -266,153 +178,61 @@ A primeira ecuación multiplícase por −1 para ter o lado dereito positivo: x�
       "Na forma estándar, todas as restricións deben ser igualdades con lado dereito ≥ 0. As restricións ≥ requiren variables de exceso e artificiais. As ≤ requiren variables de folgura. As de igualdade requiren artificiais se o lado dereito é positivo.",
   },
 
-  // --- Tema 1: Introdución ---
+  // --- V/F Teoría ---
   {
-    id: "2026-01_q3_1",
+    id: "2026-01_vf_teoria",
     exam: "2026-01",
-    topic: "preguntas",
-    type: "mc",
-    points: 0.5,
+    topic: "teoria",
+    type: "matching",
+    points: 3,
     question:
-      "É altamente recomendable establecer unha clasificación de proxectos de cara a Xestión de Proxectos e de Riscos e empregala tamén para segmentar os históricos para Estimación.",
-    options: ["V. Verdadeiro", "F. Falso"],
-    correctAnswer: "a",
+      "Indique se as seguintes afirmacións son verdadeiras ou falsas:",
+    correctAnswer: {
+      "É altamente recomendable establecer unha clasificación de proxectos de cara a Xestión de Proxectos e de Riscos e empregala tamén para segmentar os históricos para Estimación.":
+        "V",
+      "En notación ADM as relacións de precedencia entre as actividades son do tipo acabar-para-empezar.":
+        "V",
+      "Para calcular as datas early e late en CPM non se necesitan coñecer as asignacións dos recursos.":
+        "V",
+      "A FC B é equivalente a A CC+2d B se a duración estimada de A é 2 días.":
+        "V",
+      "Se para un risco se calculou a súa ER e é baixa, o Xefe de Proxecto non pode tratar ese risco como relevante (ER alta).":
+        "F",
+      "A GCS é unha disciplina dentro da Enxeñaría do Software cuxa única misión é a de controlar a evolución dun sistema software durante o seu ciclo de desenvolvemento.":
+        "F",
+    },
     explanation:
-      "A clasificación de proxectos permite aplicar estratexias de xestión adaptadas a cada tipo e usar datos históricos segmentados para mellorar a precisión das estimacións.",
+      "A clasificación de proxectos é útil para xestión e estimación. ADM só usa relacións FC. CPM non necesita asignacións de recursos. FC e CC+2d son equivalentes con A duración 2 días. O Xefe de Proxecto pode elevar a prioridade dun risco con ER baixa. GCS ten funcións máis alá do control de evolución (identificación, auditoría, rexistro).",
   },
 
-  // --- Tema 2: Planificación ---
+  // --- V/F Práctica ---
   {
-    id: "2026-01_q3_2",
+    id: "2026-01_vf_practica",
     exam: "2026-01",
-    topic: "preguntas",
-    type: "mc",
-    points: 0.5,
+    topic: "practica",
+    type: "matching",
+    points: 2,
     question:
-      "En notación ADM as relacións de precedencia entre as actividades son do tipo acabar-para-empezar.",
-    options: ["V. Verdadeiro", "F. Falso"],
-    correctAnswer: "a",
+      "Indique se as seguintes afirmacións sobre MS-Project son verdadeiras ou falsas:",
+    correctAnswer: {
+      "Se MS-Project identifica unha sobrecarga, non é seguro que ese recurso realice máis esforzo do posible.":
+        "V",
+      "MS-Project sempre pintará o Camiño Crítico como un camiño continuo desde o principio ao final do proxecto.":
+        "F",
+      "Unha boa estratexia é usar as modalidades de seguimento que ofrece MS-Project en función da folgura da tarefa sobre a que se fai seguimento.":
+        "V",
+      "Ao establecer liña base en MS-Project, os datos reais 'copianse' nos datos previstos.":
+        "F",
+    },
     explanation:
-      "ADM (Arrow Diagramming Method) só permite relacións de precedencia do tipo Finish-to-Start (acabar-para-empezar). As outras relacións (SS, FF, SF) son exclusivas de PDM (Precedence Diagramming Method).",
-  },
-  {
-    id: "2026-01_q3_3",
-    exam: "2026-01",
-    topic: "preguntas",
-    type: "mc",
-    points: 0.5,
-    question:
-      "Para calcular as datas early e late en CPM non se necesitan coñecer as asignacións dos recursos.",
-    options: ["V. Verdadeiro", "F. Falso"],
-    correctAnswer: "a",
-    explanation:
-      "O CPM (Critical Path Method) baséase unicamente nas dependencias e duracións das tarefas. As asignacións de recursos non son necesarias para o cálculo das datas early e late.",
-  },
-  {
-    id: "2026-01_q3_4",
-    exam: "2026-01",
-    topic: "preguntas",
-    type: "mc",
-    points: 0.5,
-    question:
-      "A FC B é equivalente a A CC+2d B se a duración estimada de A é 2 días.",
-    options: ["V. Verdadeiro", "F. Falso"],
-    correctAnswer: "a",
-    explanation:
-      "FC (Finish-to-Start) sen retraso: B empeza cando A termina. CC+2d (Start-to-Start + 2 días): B empeza 2 días despois de A. Se A dura 2 días, ambas significan que B empeza no día 3.",
-  },
-
-  // --- Tema 3: MS-Project ---
-  {
-    id: "2026-01_q3_5",
-    exam: "2026-01",
-    topic: "preguntas",
-    type: "mc",
-    points: 0.5,
-    question:
-      "Se MS-Project identifica unha sobrecarga, non é seguro que ese recurso realice máis esforzo do posible.",
-    options: ["V. Verdadeiro", "F. Falso"],
-    correctAnswer: "a",
-    explanation:
-      "MS-Project pode sinalar sobrecargas que sexan 'ficticias', por exemplo cando un recurso está asignado a tarefas que non se solapan realmente ou cando a dedicación real é inferior á planificada.",
-  },
-  {
-    id: "2026-01_q3_6",
-    exam: "2026-01",
-    topic: "preguntas",
-    type: "mc",
-    points: 0.5,
-    question:
-      "MS-Project sempre pintará o Camiño Crítico como un camiño continuo desde o principio ao final do proxecto.",
-    options: ["V. Verdadeiro", "F. Falso"],
-    correctAnswer: "b",
-    explanation:
-      "O camiño crítico non sempre é unha liña continua de principio a fin. Poden existir múltiples camiños críticos non conectados ou tramos críticos illados noutras partes do proxecto.",
-  },
-
-  // --- Tema 4: Riscos ---
-  {
-    id: "2026-01_q3_7",
-    exam: "2026-01",
-    topic: "preguntas",
-    type: "mc",
-    points: 0.5,
-    question:
-      "Se para un risco se calculou a súa ER e é baixa, o Xefe de Proxecto non pode tratar ese risco como relevante (ER alta).",
-    options: ["V. Verdadeiro", "F. Falso"],
-    correctAnswer: "b",
-    explanation:
-      "O xefe de proxecto ten a potestade de elevar a prioridade dun risco baseándose no seu criterio profesional, experiencia ou factores cualitativos non capturados pola fórmula ER = P · I.",
-  },
-
-  // --- Tema 5: Xestión da Configuración do Software ---
-  {
-    id: "2026-01_q3_8",
-    exam: "2026-01",
-    topic: "preguntas",
-    type: "mc",
-    points: 0.5,
-    question:
-      "A GCS é unha disciplina dentro da Enxeñaría do Software cuxa única misión é a de controlar a evolución dun sistema software durante o seu ciclo de desenvolvemento.",
-    options: ["V. Verdadeiro", "F. Falso"],
-    correctAnswer: "b",
-    explanation:
-      "A GCS (Xestión da Configuración do Software) non só controla a evolución. As súas funcións inclúen tamén a identificación dos elementos de configuración, a auditoría da configuración e o rexistro do estado da configuración.",
-  },
-
-  // --- Tema 6: Seguimento e Control ---
-  {
-    id: "2026-01_q3_9",
-    exam: "2026-01",
-    topic: "preguntas",
-    type: "mc",
-    points: 0.5,
-    question:
-      "Unha boa estratexia é usar as modalidades de seguimento que ofrece MS-Project en función da folgura da tarefa sobre a que se fai seguimento.",
-    options: ["V. Verdadeiro", "F. Falso"],
-    correctAnswer: "a",
-    explanation:
-      "As modalidades de seguimento de MS-Project deben elixirse segundo a criticidade da tarefa. Para tarefas do camiño crítico (folgura 0) convén un seguimento máis detallado que para tarefas con folgura ampla.",
-  },
-  {
-    id: "2026-01_q3_10",
-    exam: "2026-01",
-    topic: "preguntas",
-    type: "mc",
-    points: 0.5,
-    question:
-      "Ao establecer liña base en MS-Project, os datos reais 'copianse' nos datos previstos.",
-    options: ["V. Verdadeiro", "F. Falso"],
-    correctAnswer: "b",
-    explanation:
-      "É ao revés: ao establecer a liña base, os datos previstos (planificados) cópianse aos campos de liña base. Os datos reais rexístranse posteriormente durante o seguimento.",
+      "MS-Project pode marcar sobrecargas ficticias. O camiño crítico non sempre é continuo. O seguimento debe adaptarse á folgura da tarefa. A liña base copia os previstos, non os reais.",
   },
 
   // --- Tema 1: Introdución ---
   {
     id: "2026-01_q4",
     exam: "2026-01",
-    topic: "preguntas",
+    topic: "teoria",
     type: "text",
     points: 1,
     question:
@@ -427,7 +247,7 @@ A primeira ecuación multiplícase por −1 para ter o lado dereito positivo: x�
   {
     id: "2026-01_q5",
     exam: "2026-01",
-    topic: "preguntas",
+    topic: "teoria",
     type: "text",
     points: 1,
     question:
@@ -442,7 +262,7 @@ A primeira ecuación multiplícase por −1 para ter o lado dereito positivo: x�
   {
     id: "2026-01_q6",
     exam: "2026-01",
-    topic: "preguntas",
+    topic: "teoria",
     type: "text",
     points: 1,
     question:
@@ -457,7 +277,7 @@ A primeira ecuación multiplícase por −1 para ter o lado dereito positivo: x�
   {
     id: "2026-01_q7",
     exam: "2026-01",
-    topic: "preguntas",
+    topic: "practica",
     type: "text",
     points: 1,
     question:
@@ -472,7 +292,7 @@ A primeira ecuación multiplícase por −1 para ter o lado dereito positivo: x�
   {
     id: "2026-01_q8",
     exam: "2026-01",
-    topic: "preguntas",
+    topic: "practica",
     type: "text",
     points: 1,
     question:
@@ -487,7 +307,7 @@ A primeira ecuación multiplícase por −1 para ter o lado dereito positivo: x�
   {
     id: "2026-01_q9a",
     exam: "2026-01",
-    topic: "preguntas",
+    topic: "practica",
     type: "text",
     points: 2.5,
     question:
@@ -500,7 +320,7 @@ A primeira ecuación multiplícase por −1 para ter o lado dereito positivo: x�
   {
     id: "2026-01_q9b",
     exam: "2026-01",
-    topic: "preguntas",
+    topic: "practica",
     type: "text",
     points: 2.5,
     question:
@@ -513,7 +333,7 @@ A primeira ecuación multiplícase por −1 para ter o lado dereito positivo: x�
   {
     id: "2026-01_q9c",
     exam: "2026-01",
-    topic: "preguntas",
+    topic: "practica",
     type: "text",
     points: 2.5,
     question:
@@ -526,7 +346,7 @@ A primeira ecuación multiplícase por −1 para ter o lado dereito positivo: x�
   {
     id: "2026-01_q9d",
     exam: "2026-01",
-    topic: "preguntas",
+    topic: "practica",
     type: "text",
     points: 2.5,
     question:


### PR DESCRIPTION
Agrupa as 20 preguntas verdadeiro/falso de equisi en 4 preguntas de tipo `matching`, separadas por tema (teoría/práctica) e por exame (2024-01 / 2026-01).

- Cada pregunta `matching` mostra as afirmacións con botóns V/F lado a lado
- Actualizados os topics en `meta.ts` (teoría + práctica)
- `pnpm build` e `pnpm lint` OK