### PR TITLE
feat: improve Umami tracking — session identity, theme toggle, config

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,6 +79,14 @@
       data-domains="pe.pablopl.dev"
       data-exclude-search="true"
     ></script>
+    <script
+      defer
+      src="https://analytics.pablopl.dev/recorder.js"
+      data-website-id="63168f0e-a1cf-4ec6-a0c4-58fc7d57a0f4"
+      data-sample-rate="0.25"
+      data-mask-level="moderate"
+      data-max-duration="300000"
+    ></script>
     <link rel="preconnect" href="https://analytics.pablopl.dev" />
   </head>
   <body>

--- a/index.html
+++ b/index.html
@@ -75,6 +75,9 @@
       src="https://analytics.pablopl.dev/script.js"
       data-website-id="63168f0e-a1cf-4ec6-a0c4-58fc7d57a0f4"
       data-performance="true"
+      data-auto-track="false"
+      data-domains="pe.pablopl.dev"
+      data-exclude-search="true"
     ></script>
     <link rel="preconnect" href="https://analytics.pablopl.dev" />
   </head>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,8 +2,9 @@ import { lazy, Suspense } from "react";
 import { BrowserRouter, Routes, Route, useLocation } from "react-router-dom";
 import { useEffect } from "react";
 import Header from "./components/Header";
-import { useT } from "./i18n/hooks";
-import { track } from "./lib/umami";
+import { useLang, useT } from "./i18n/hooks";
+import { track, identify } from "./lib/umami";
+import { useTheme } from "./theme/hooks";
 
 const Home = lazy(() => import("./pages/Home"));
 const SubjectHome = lazy(() => import("./pages/SubjectHome"));
@@ -26,6 +27,17 @@ function PageViewTracker() {
     window.scrollTo({ top: 0, behavior: "smooth" });
     track("page_view", { path: pathname });
   }, [pathname]);
+
+  return null;
+}
+
+function SessionTracker() {
+  const { lang } = useLang();
+  const { theme } = useTheme();
+
+  useEffect(() => {
+    identify({ lang, theme });
+  }, [lang, theme]);
 
   return null;
 }
@@ -69,6 +81,7 @@ export default function App() {
     <BrowserRouter>
       <div className="min-h-screen min-h-svh flex flex-col bg-surface text-fg font-sans">
         <PageViewTracker />
+        <SessionTracker />
         <Header />
         <main className="flex-grow">
           <Suspense fallback={<PageLoader />}>

--- a/src/lib/umami.ts
+++ b/src/lib/umami.ts
@@ -5,6 +5,10 @@ declare global {
         eventName: string,
         eventData?: Record<string, string | number | boolean>,
       ) => void;
+      identify: (
+        idOrData: string | Record<string, string | number | boolean>,
+        data?: Record<string, string | number | boolean>,
+      ) => void;
     };
   }
 }
@@ -15,5 +19,13 @@ export function track(
 ) {
   if (typeof window !== "undefined" && window.umami) {
     window.umami.track(eventName, eventData);
+  }
+}
+
+export function identify(
+  data: Record<string, string | number | boolean>,
+) {
+  if (typeof window !== "undefined" && window.umami) {
+    window.umami.identify(data);
   }
 }

--- a/src/theme/ThemeToggle.tsx
+++ b/src/theme/ThemeToggle.tsx
@@ -1,6 +1,7 @@
 import { useTheme } from "./hooks";
-import { themeLabels } from "./types";
+import { themeLabels, themeOrder } from "./types";
 import type { Theme } from "./types";
+import { track } from "../lib/umami";
 
 function ThemeIcon({ theme }: { theme: Theme }) {
   switch (theme) {
@@ -100,11 +101,18 @@ function ThemeIcon({ theme }: { theme: Theme }) {
 export default function ThemeToggle() {
   const { theme, cycleTheme } = useTheme();
 
+  function handleToggle() {
+    const idx = themeOrder.indexOf(theme);
+    const next = themeOrder[(idx + 1) % themeOrder.length];
+    cycleTheme();
+    track("theme_toggle", { theme: next });
+  }
+
   return (
     <button
       type="button"
       className="px-2 py-1 rounded border border-border hover:bg-surface active:scale-95 transition cursor-pointer"
-      onClick={cycleTheme}
+      onClick={handleToggle}
       aria-label={`Theme: ${themeLabels[theme]}`}
       title={themeLabels[theme]}
     >


### PR DESCRIPTION
## Changes

- **Disable auto-tracking** (`data-auto-track="false"`) to avoid double-counting page views (auto-track + manual `track("page_view")` were both firing)
- **Restrict to production** with `data-domains="pe.pablopl.dev"`
- **Cleaner URLs** with `data-exclude-search="true"`
- **Expose `identify()`** wrapper in `src/lib/umami.ts` matching the existing `track()` pattern
- **Session identification**: call `umami.identify({ lang, theme })` via a new `SessionTracker` component so Umami sessions are tagged with user preferences
- **Track theme toggles**: add `track("theme_toggle", { theme })` in `ThemeToggle` (language toggles were already tracked)
- **Session replay**: add `recorder.js` script with 25% sample rate, moderate masking, 5min max duration