### PR TITLE
fix: track real page views instead of custom events in Umami

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import {
 import Header from "./components/Header";
 import { useLang, useT } from "./i18n/hooks";
 import type { Lang } from "./i18n/context";
-import { track, identify } from "./lib/umami";
+import { track, trackPageView, identify } from "./lib/umami";
 import { buildLangPath } from "./lib/lang-link";
 import { useTheme } from "./theme/hooks";
 
@@ -34,7 +34,7 @@ function PageViewTracker() {
 
   useEffect(() => {
     window.scrollTo({ top: 0, behavior: "smooth" });
-    track("page_view", { path: pathname });
+    trackPageView();
   }, [pathname]);
 
   return null;

--- a/src/lib/umami.ts
+++ b/src/lib/umami.ts
@@ -1,15 +1,24 @@
 declare global {
   interface Window {
     umami?: {
-      track: (
+      track(): void;
+      track(payload: Record<string, unknown>): void;
+      track(eventName: string): void;
+      track(
         eventName: string,
         eventData?: Record<string, string | number | boolean>,
-      ) => void;
+      ): void;
       identify: (
         idOrData: string | Record<string, string | number | boolean>,
         data?: Record<string, string | number | boolean>,
       ) => void;
     };
+  }
+}
+
+export function trackPageView() {
+  if (typeof window !== "undefined" && window.umami) {
+    window.umami.track();
   }
 }
 


### PR DESCRIPTION
## Problem

Con `data-auto-track="false"` en `index.html`, las page views deben enviarse manualmente llamando a `umami.track()` (sin argumentos). El código anterior llamaba a `umami.track("page_view", ...)`, lo que registraba **eventos custom** en lugar de page views reales, causando que las visitas no se trackearan correctamente.

## Cambios

- **`src/lib/umami.ts`**: Se añaden overloads de `track()` en la declaración de tipos de `Window.umami` para soportar todas las firmas del tracker de Umami (page view sin args, page view con payload, eventos custom). Se añade `trackPageView()`.
- **`src/App.tsx`**: `PageViewTracker` ahora usa `trackPageView()` en lugar de `track("page_view", ...)`.

## Referencias

- [Umami tracker functions](https://docs.umami.is/docs/tracker-functions#pageviews) — `umami.track()` sin argumentos = page view
- [Umami tracker configuration](https://docs.umami.is/docs/tracker-configuration#data-auto-track) — `data-auto-track="false"` desactiva el tracking automático