### PR TITLE
fix: use theme-aware colors for contribute button in modals

### DIFF
--- a/src/components/AddExamModal.tsx
+++ b/src/components/AddExamModal.tsx
@@ -108,7 +108,7 @@ function AddExamModal({
             target="_blank"
             rel="noopener noreferrer"
             onClick={() => track("add_exam_contribute", { subjectId })}
-            className="flex items-center gap-3 p-3 rounded-xl border-2 border-blue-300 bg-blue-50 hover:bg-blue-100 hover:border-blue-400 transition-colors cursor-pointer text-left no-underline text-inherit"
+            className="flex items-center gap-3 p-3 rounded-xl border-2 border-contribute-border bg-contribute-bg hover:bg-contribute-hover-bg hover:border-contribute-hover-border transition-colors cursor-pointer text-left no-underline text-inherit"
           >
             <span className="text-xl">🚀</span>
             <div>

--- a/src/components/AddSubjectModal.tsx
+++ b/src/components/AddSubjectModal.tsx
@@ -99,7 +99,7 @@ function AddSubjectModal({ onClose, ref }: AddSubjectModalProps) {
             target="_blank"
             rel="noopener noreferrer"
             onClick={() => track("add_subject_contribute")}
-            className="flex items-center gap-3 p-3 rounded-xl border-2 border-blue-300 bg-blue-50 hover:bg-blue-100 hover:border-blue-400 transition-colors cursor-pointer text-left no-underline text-inherit"
+            className="flex items-center gap-3 p-3 rounded-xl border-2 border-contribute-border bg-contribute-bg hover:bg-contribute-hover-bg hover:border-contribute-hover-border transition-colors cursor-pointer text-left no-underline text-inherit"
           >
             <span className="text-xl">🚀</span>
             <div>

--- a/src/index.css
+++ b/src/index.css
@@ -28,6 +28,11 @@ body {
   --color-accent-border: #bbf7d0;
   --color-code: #f3f4f6;
   --color-code-block: #111827;
+  /* Contribute button */
+  --color-contribute-bg: #eff6ff;
+  --color-contribute-border: #93c5fd;
+  --color-contribute-hover-bg: #dbeafe;
+  --color-contribute-hover-border: #60a5fa;
   /* Topic card colors */
   --color-t-blue-bg: #eff6ff;
   --color-t-blue-border: #bfdbfe;
@@ -73,6 +78,11 @@ html[data-theme="dark"] {
   --color-accent-border: #166534;
   --color-code: #374151;
   --color-code-block: #030712;
+  /* Contribute button */
+  --color-contribute-bg: #172554;
+  --color-contribute-border: #1e3a8a;
+  --color-contribute-hover-bg: #1e3a8a;
+  --color-contribute-hover-border: #2563eb;
   /* Topic cards – darker saturated shades */
   --color-t-blue-bg: #172554;
   --color-t-blue-border: #1e3a8a;
@@ -135,6 +145,11 @@ html[data-theme="catppuccin"] {
   --color-accent-border: #45475a;
   --color-code: #313244;
   --color-code-block: #11111b;
+  /* Contribute button */
+  --color-contribute-bg: #313244;
+  --color-contribute-border: #45475a;
+  --color-contribute-hover-bg: #45475a;
+  --color-contribute-hover-border: #89b4fa;
   /* Topic cards – catppuccin palette */
   --color-t-blue-bg: #313244;
   --color-t-blue-border: #45475a;
@@ -181,6 +196,11 @@ html[data-theme="catppuccin"] {
     --color-accent-border: #166534;
     --color-code: #374151;
     --color-code-block: #030712;
+    /* Contribute button */
+    --color-contribute-bg: #172554;
+    --color-contribute-border: #1e3a8a;
+    --color-contribute-hover-bg: #1e3a8a;
+    --color-contribute-hover-border: #2563eb;
     /* Topic cards */
     --color-t-blue-bg: #172554;
     --color-t-blue-border: #1e3a8a;


### PR DESCRIPTION
The Contribute button in the Add Subject and Add Exam modals used hardcoded Tailwind blue colors (`bg-blue-50`, `border-blue-300`, etc.) which didn't adapt to the dark and catppuccin themes. The `text-fg` text color is light on dark themes, so light text on a light blue background had terrible contrast.

This PR adds theme-aware CSS variables (`--color-contribute-bg`, `--color-contribute-border`, `--color-contribute-hover-bg`, `--color-contribute-hover-border`) with appropriate values for all theme variants (light, dark, catppuccin, system dark) and updates both modals to use them.