### PR TITLE
fix: scroll to top when navigating to subject, topic, or exam

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,16 @@ function PageLoader() {
   );
 }
 
+function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}
+
 function SessionTracker() {
   const { lang } = useLang();
   const { theme } = useTheme();
@@ -128,6 +138,7 @@ export default function App() {
     <BrowserRouter>
       <div className="min-h-screen min-h-svh flex flex-col bg-surface text-fg font-sans">
         <SessionTracker />
+        <ScrollToTop />
         <Header />
         <main className="flex-grow">
           <Suspense fallback={<PageLoader />}>


### PR DESCRIPTION
Adds a `ScrollToTop` component that watches `useLocation().pathname` and scrolls the page to the top whenever the pathname changes (i.e., when navigating to a subject, topic, or exam page).

Previously, the browser retained its scroll position between navigations, causing a jarring experience where the user would land mid-page after clicking a link.