### PR TITLE
feat: recently visited subjects strip on homepage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ dist-ssr
 *.sln
 *.sw?
 public/sitemap.xml
+
+# Env
+.env

--- a/src/components/SubjectCard.tsx
+++ b/src/components/SubjectCard.tsx
@@ -3,6 +3,7 @@ import type { SubjectMeta } from "../data/types";
 import { useT } from "../i18n/hooks";
 import { track } from "../lib/umami";
 import { triggerLight } from "../lib/haptics";
+import { recordSubjectClick } from "../lib/recent";
 
 interface SubjectCardProps {
   subject: SubjectMeta;
@@ -18,6 +19,7 @@ export default function SubjectCard({ subject }: SubjectCardProps) {
       onClick={() => {
         triggerLight();
         track("subject_card_click", { subjectId: subject.id });
+        recordSubjectClick(subject.id);
       }}
     >
       <div className="flex items-start justify-between mb-3">

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -5,6 +5,7 @@ export const en = {
       "Open-source platform for practicing university exams. Choose a subject below to start drilling questions from past exams.",
     addSubject: "Add Subject?",
     recentlyVisited: "Recently visited",
+    clearRecent: "Clear recent subjects",
   },
   subjectHome: {
     notFound: "Subject Not Found",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -4,6 +4,7 @@ export const en = {
     subtitle:
       "Open-source platform for practicing university exams. Choose a subject below to start drilling questions from past exams.",
     addSubject: "Add Subject?",
+    recentlyVisited: "Recently visited",
   },
   subjectHome: {
     notFound: "Subject Not Found",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -7,6 +7,7 @@ export const es: Translations = {
       "Plataforma de código abierto para practicar exámenes universitarios. Elige una asignatura para empezar a practicar con preguntas de exámenes anteriores.",
     addSubject: "¿Añadir asignatura?",
     recentlyVisited: "Visitadas recientemente",
+    clearRecent: "Limpiar asignaturas recientes",
   },
   subjectHome: {
     notFound: "Asignatura no encontrada",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -6,6 +6,7 @@ export const es: Translations = {
     subtitle:
       "Plataforma de código abierto para practicar exámenes universitarios. Elige una asignatura para empezar a practicar con preguntas de exámenes anteriores.",
     addSubject: "¿Añadir asignatura?",
+    recentlyVisited: "Visitadas recientemente",
   },
   subjectHome: {
     notFound: "Asignatura no encontrada",

--- a/src/i18n/gl.ts
+++ b/src/i18n/gl.ts
@@ -6,6 +6,7 @@ export const gl: Translations = {
     subtitle:
       "Plataforma de código aberto para practicar exames universitarios. Elixe unha materia para comezar a practicar con preguntas de exames anteriores.",
     addSubject: "Engadir materia?",
+    recentlyVisited: "Visitadas recentemente",
   },
   subjectHome: {
     notFound: "Materia non atopada",

--- a/src/i18n/gl.ts
+++ b/src/i18n/gl.ts
@@ -7,6 +7,7 @@ export const gl: Translations = {
       "Plataforma de código aberto para practicar exames universitarios. Elixe unha materia para comezar a practicar con preguntas de exames anteriores.",
     addSubject: "Engadir materia?",
     recentlyVisited: "Visitadas recentemente",
+    clearRecent: "Limpar materias recentes",
   },
   subjectHome: {
     notFound: "Materia non atopada",

--- a/src/lib/recent.ts
+++ b/src/lib/recent.ts
@@ -1,0 +1,22 @@
+const STORAGE_KEY = "recent-subjects";
+const MAX_RECENT = 3;
+
+export function getRecentSubjects(): string[] {
+  try {
+    const data = localStorage.getItem(STORAGE_KEY);
+    return data ? JSON.parse(data) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function recordSubjectClick(subjectId: string) {
+  try {
+    const recent = getRecentSubjects().filter((id) => id !== subjectId);
+    recent.unshift(subjectId);
+    if (recent.length > MAX_RECENT) recent.length = MAX_RECENT;
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(recent));
+  } catch {
+    /* localStorage unavailable */
+  }
+}

--- a/src/lib/recent.ts
+++ b/src/lib/recent.ts
@@ -20,3 +20,11 @@ export function recordSubjectClick(subjectId: string) {
     /* localStorage unavailable */
   }
 }
+
+export function clearRecentSubjects() {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    /* localStorage unavailable */
+  }
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from "react";
+import { useMemo, useRef, useState } from "react";
 import { subjects } from "../subjects";
 import SubjectCard from "../components/SubjectCard";
 import AddSubjectModal, {
@@ -8,7 +8,34 @@ import { useT } from "../i18n/hooks";
 import { useDocumentTitle } from "../lib/title";
 import { useSeoHead } from "../lib/seo";
 import { LangLink } from "../lib/lang-link";
-import { getRecentSubjects, recordSubjectClick } from "../lib/recent";
+import {
+  getRecentSubjects,
+  recordSubjectClick,
+  clearRecentSubjects,
+} from "../lib/recent";
+
+const MAX_SLOTS = 3;
+
+function TrashIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="w-4 h-4"
+    >
+      <path d="M3 6h18" />
+      <path d="M8 6V4a2 2 0 012-2h4a2 2 0 012 2v2" />
+      <path d="M10 11v6" />
+      <path d="M14 11v6" />
+      <path d="M5 6l1 14a2 2 0 002 2h8a2 2 0 002-2l1-14" />
+    </svg>
+  );
+}
 
 export default function Home() {
   const t = useT();
@@ -19,13 +46,25 @@ export default function Home() {
     pathWithoutLang: "/",
   });
   const modalRef = useRef<AddSubjectModalHandle>(null);
+  const [recentKey, setRecentKey] = useState(0);
 
   const recentSubjects = useMemo(() => {
     const recentIds = getRecentSubjects();
     return recentIds
       .map((id) => subjects.find((s) => s.id === id))
       .filter((s): s is NonNullable<typeof s> => s != null);
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [recentKey]);
+
+  function handleClearRecent() {
+    clearRecentSubjects();
+    setRecentKey((k) => k + 1);
+  }
+
+  const slots = Array.from({ length: MAX_SLOTS }, (_, i) => {
+    const subject = recentSubjects[i];
+    return subject ? { type: "subject" as const, subject } : { type: "placeholder" as const };
+  });
 
   return (
     <div className="max-w-6xl mx-auto px-4 py-8 text-center animate-fade-in animate-duration-fast">
@@ -35,23 +74,46 @@ export default function Home() {
       </p>
 
       {recentSubjects.length > 0 && (
-        <div className="mb-10">
-          <h2 className="text-sm font-semibold text-fg-muted uppercase tracking-wide mb-3">
-            {t.home.recentlyVisited}
-          </h2>
-          <div className="flex flex-wrap justify-center gap-3">
-            {recentSubjects.map((subject) => (
-              <LangLink
-                key={subject.id}
-                to={`/${subject.id}`}
-                onClick={() => recordSubjectClick(subject.id)}
-                className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-border bg-surface-alt text-fg hover:border-accent hover:bg-accent-light/30 hover:scale-[1.03] transition-colors transition-transform duration-200"
+        <div className="mb-10 text-left">
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-sm font-semibold text-fg-muted uppercase tracking-wide">
+              {t.home.recentlyVisited}
+            </h2>
+            <button
+              type="button"
+              onClick={handleClearRecent}
+              className="text-fg-muted hover:text-red-500 transition-colors p-1 rounded"
+              aria-label={t.home.clearRecent}
+              title={t.home.clearRecent}
+            >
+              <TrashIcon />
+            </button>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            {slots.map((slot, i) => (
+              <div
+                key={i}
+                className={i >= 2 ? "block sm:hidden lg:block" : undefined}
               >
-                <span className="text-lg" aria-hidden="true">
-                  {subject.icon}
-                </span>
-                <span className="text-sm font-medium">{subject.name}</span>
-              </LangLink>
+                {slot.type === "subject" ? (
+                  <LangLink
+                    to={`/${slot.subject.id}`}
+                    onClick={() => recordSubjectClick(slot.subject.id)}
+                    className="block w-full p-5 rounded-xl border-2 border-border hover:border-accent bg-surface-alt hover:bg-accent-light/30 hover:scale-[1.02] hover:shadow-md transition-colors transition-transform duration-200"
+                  >
+                    <div className="flex items-center gap-3">
+                      <span className="text-2xl" aria-hidden="true">
+                        {slot.subject.icon}
+                      </span>
+                      <span className="font-semibold text-fg text-base">
+                        {slot.subject.name}
+                      </span>
+                    </div>
+                  </LangLink>
+                ) : (
+                  <div className="block w-full p-5 rounded-xl border-2 border-dashed border-border" />
+                )}
+              </div>
             ))}
           </div>
         </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -37,6 +37,29 @@ function TrashIcon() {
   );
 }
 
+function PlaceholderCard() {
+  return (
+    <div
+      className="block w-full p-5 rounded-xl border-2 border-dashed border-border"
+      aria-hidden="true"
+    >
+      <div className="flex items-center gap-3 invisible">
+        <span className="text-2xl">&nbsp;</span>
+        <span className="font-semibold text-base">&nbsp;</span>
+      </div>
+    </div>
+  );
+}
+
+function slotClassName(i: number, isPlaceholder: boolean): string | undefined {
+  if (isPlaceholder) {
+    if (i >= 2) return "hidden lg:block";
+    return "hidden sm:block";
+  }
+  if (i >= 2) return "block sm:hidden lg:block";
+  return undefined;
+}
+
 export default function Home() {
   const t = useT();
   useDocumentTitle(t.home.title);
@@ -63,7 +86,9 @@ export default function Home() {
 
   const slots = Array.from({ length: MAX_SLOTS }, (_, i) => {
     const subject = recentSubjects[i];
-    return subject ? { type: "subject" as const, subject } : { type: "placeholder" as const };
+    return subject
+      ? ({ type: "subject" as const, subject })
+      : ({ type: "placeholder" as const });
   });
 
   return (
@@ -91,10 +116,7 @@ export default function Home() {
           </div>
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
             {slots.map((slot, i) => (
-              <div
-                key={i}
-                className={i >= 2 ? "block sm:hidden lg:block" : undefined}
-              >
+              <div key={i} className={slotClassName(i, slot.type === "placeholder")}>
                 {slot.type === "subject" ? (
                   <LangLink
                     to={`/${slot.subject.id}`}
@@ -111,28 +133,36 @@ export default function Home() {
                     </div>
                   </LangLink>
                 ) : (
-                  <div className="block w-full p-5 rounded-xl border-2 border-dashed border-border" />
+                  <PlaceholderCard />
                 )}
               </div>
             ))}
           </div>
+          <hr className="mt-10 border-border" />
         </div>
       )}
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 text-left">
         {subjects.map((subject) => (
-          <SubjectCard key={subject.id} subject={subject} />
-        ))}
-        <button
-          type="button"
-          onClick={() => modalRef.current?.open()}
-          className="block w-full p-5 rounded-xl border-2 border-dashed border-border text-fg-muted hover:text-accent hover:border-accent hover:bg-accent-light/30 hover:scale-[1.02] transition-colors transition-transform duration-200 cursor-pointer"
-        >
-          <div className="flex flex-col items-center justify-center h-full min-h-[120px] gap-2">
-            <span className="text-4xl font-light leading-none">+</span>
-            <span className="text-sm font-medium">{t.home.addSubject}</span>
+          <div
+            key={subject.id}
+            className="animate-fade-in-up timeline-view"
+          >
+            <SubjectCard subject={subject} />
           </div>
-        </button>
+        ))}
+        <div className="animate-fade-in-up timeline-view">
+          <button
+            type="button"
+            onClick={() => modalRef.current?.open()}
+            className="block w-full p-5 rounded-xl border-2 border-dashed border-border text-fg-muted hover:text-accent hover:border-accent hover:bg-accent-light/30 hover:scale-[1.02] transition-colors transition-transform duration-200 cursor-pointer"
+          >
+            <div className="flex flex-col items-center justify-center h-full min-h-[120px] gap-2">
+              <span className="text-4xl font-light leading-none">+</span>
+              <span className="text-sm font-medium">{t.home.addSubject}</span>
+            </div>
+          </button>
+        </div>
       </div>
 
       <AddSubjectModal ref={modalRef} onClose={() => {}} />

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { subjects } from "../subjects";
 import SubjectCard from "../components/SubjectCard";
 import AddSubjectModal, {
@@ -71,13 +71,10 @@ export default function Home() {
   const modalRef = useRef<AddSubjectModalHandle>(null);
   const [recentKey, setRecentKey] = useState(0);
 
-  const recentSubjects = useMemo(() => {
-    const recentIds = getRecentSubjects();
-    return recentIds
-      .map((id) => subjects.find((s) => s.id === id))
-      .filter((s): s is NonNullable<typeof s> => s != null);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [recentKey]);
+  const recentIds = getRecentSubjects();
+  const recentSubjects = recentIds
+    .map((id) => subjects.find((s) => s.id === id))
+    .filter((s): s is NonNullable<typeof s> => s != null);
 
   function handleClearRecent() {
     clearRecentSubjects();
@@ -99,7 +96,7 @@ export default function Home() {
       </p>
 
       {recentSubjects.length > 0 && (
-        <div className="mb-10 text-left">
+        <div className="mb-10 text-left" key={recentKey}>
           <div className="flex items-center justify-between mb-3">
             <h2 className="text-sm font-semibold text-fg-muted uppercase tracking-wide">
               {t.home.recentlyVisited}
@@ -116,7 +113,10 @@ export default function Home() {
           </div>
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
             {slots.map((slot, i) => (
-              <div key={i} className={slotClassName(i, slot.type === "placeholder")}>
+              <div
+                key={slot.type === "subject" ? slot.subject.id : `placeholder-${i}`}
+                className={slotClassName(i, slot.type === "placeholder")}
+              >
                 {slot.type === "subject" ? (
                   <LangLink
                     to={`/${slot.subject.id}`}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useMemo, useRef } from "react";
 import { subjects } from "../subjects";
 import SubjectCard from "../components/SubjectCard";
 import AddSubjectModal, {
@@ -7,6 +7,8 @@ import AddSubjectModal, {
 import { useT } from "../i18n/hooks";
 import { useDocumentTitle } from "../lib/title";
 import { useSeoHead } from "../lib/seo";
+import { LangLink } from "../lib/lang-link";
+import { getRecentSubjects, recordSubjectClick } from "../lib/recent";
 
 export default function Home() {
   const t = useT();
@@ -18,12 +20,42 @@ export default function Home() {
   });
   const modalRef = useRef<AddSubjectModalHandle>(null);
 
+  const recentSubjects = useMemo(() => {
+    const recentIds = getRecentSubjects();
+    return recentIds
+      .map((id) => subjects.find((s) => s.id === id))
+      .filter((s): s is NonNullable<typeof s> => s != null);
+  }, []);
+
   return (
     <div className="max-w-6xl mx-auto px-4 py-8 text-center animate-fade-in animate-duration-fast">
       <h1 className="text-3xl font-bold text-fg mb-3">{t.home.title}</h1>
       <p className="text-fg-secondary max-w-xl mx-auto mb-10">
         {t.home.subtitle}
       </p>
+
+      {recentSubjects.length > 0 && (
+        <div className="mb-10">
+          <h2 className="text-sm font-semibold text-fg-muted uppercase tracking-wide mb-3">
+            {t.home.recentlyVisited}
+          </h2>
+          <div className="flex flex-wrap justify-center gap-3">
+            {recentSubjects.map((subject) => (
+              <LangLink
+                key={subject.id}
+                to={`/${subject.id}`}
+                onClick={() => recordSubjectClick(subject.id)}
+                className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-border bg-surface-alt text-fg hover:border-accent hover:bg-accent-light/30 hover:scale-[1.03] transition-colors transition-transform duration-200"
+              >
+                <span className="text-lg" aria-hidden="true">
+                  {subject.icon}
+                </span>
+                <span className="text-sm font-medium">{subject.name}</span>
+              </LangLink>
+            ))}
+          </div>
+        </div>
+      )}
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 text-left">
         {subjects.map((subject) => (

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -146,12 +146,12 @@ export default function Home() {
         {subjects.map((subject) => (
           <div
             key={subject.id}
-            className="animate-fade-in-up timeline-view"
+            className="animate-fade-in-up timeline-view animate-range-entry"
           >
             <SubjectCard subject={subject} />
           </div>
         ))}
-        <div className="animate-fade-in-up timeline-view">
+        <div className="animate-fade-in-up timeline-view animate-range-entry">
           <button
             type="button"
             onClick={() => modalRef.current?.open()}


### PR DESCRIPTION
## What

Adds a strip of 3 recently clicked subject chips (emoji + title) on the homepage above the main subject grid.

## How

- **`src/lib/recent.ts`**: localStorage wrapper — `getRecentSubjects()` reads the array, `recordSubjectClick()` pushes to front, deduplicates, and keeps only 3 entries.
- **`SubjectCard.tsx`**: calls `recordSubjectClick()` on click.
- **`Home.tsx`**: reads recent subjects via `useMemo`, renders a horizontal flex strip with `LangLink` pills showing emoji + subject name. Only appears when there are recent subjects.
- **i18n**: `home.recentlyVisited` translation key added for en/es/gl.

## Screenshots

*(pending deploy preview)*