### PR TITLE
fix: resolve React Review and React Doctor lint warnings

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -12,3 +12,5 @@ b59c6e3c158accf8b885e9d0e444f12eeaabadd1
 e9e4a38e6e6a9dce76e89b399c5072435777f915
 # format: format code
 ac74b990a78d38897b9b0c66284d32ffef1c9891
+# format: format code
+e0dce8de26ccc26444a0df32f336d94d2a6ad497

--- a/package.json
+++ b/package.json
@@ -30,10 +30,11 @@
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.6.0",
     "prettier": "3.8.3",
+    "react-grab": "^0.1.47",
     "tailwindcss": "^4.3.0",
+    "tsx": "^4.22.4",
     "typescript": "~6.0.2",
     "typescript-eslint": "^8.59.2",
-    "tsx": "^4.22.4",
     "vite": "^8.0.12",
     "vite-imagetools": "^10.0.1"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         version: 10.0.1(eslint@10.5.0(jiti@2.7.0))
       '@tailwindcss/vite':
         specifier: ^4.3.0
-        version: 4.3.1(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
+        version: 4.3.1(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@types/node':
         specifier: ^24
         version: 24.13.2
@@ -41,7 +41,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.2(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
+        version: 6.0.2(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       eslint:
         specifier: ^10.3.0
         version: 10.5.0(jiti@2.7.0)
@@ -57,6 +57,9 @@ importers:
       prettier:
         specifier: 3.8.3
         version: 3.8.3
+      react-grab:
+        specifier: ^0.1.47
+        version: 0.1.47(react@19.2.7)
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.1
@@ -71,10 +74,10 @@ importers:
         version: 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
       vite:
         specifier: ^8.0.12
-        version: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)
+        version: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
       vite-imagetools:
         specifier: ^10.0.1
-        version: 10.0.1(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
+        version: 10.0.1(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
 packages:
 
@@ -372,6 +375,9 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@iarna/toml@2.2.5':
+    resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
+
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
@@ -558,6 +564,10 @@ packages:
 
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
+
+  '@react-grab/cli@0.1.47':
+    resolution: {integrity: sha512-Cc7d8mSwvoV8gpeTQbE8dMPdeXIyO6w+yIhzgi3jY06i03WLNhb/6jIxNBNF1cVRI7ujnFQXZA66BbnBNTpBSw==}
+    hasBin: true
 
   '@rolldown/binding-android-arm64@1.0.3':
     resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
@@ -865,8 +875,16 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-install@0.0.6:
+    resolution: {integrity: sha512-7NRMZ/ZDz2vHevQTgJsocBFpakB1/Wx5ip19YSJuj4VOXpraWztTerViNtdSyARKZT9e2yVwUUB5JXXCE7mNrA==}
+    hasBin: true
+
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -876,6 +894,11 @@ packages:
     resolution: {integrity: sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  bippy@0.5.41:
+    resolution: {integrity: sha512-jCP2pXXLhXqPrAN+iSEFZmLI4uUM4fjSqajh0K+TmM062VehfDT3ZJNkrTGyN701Z5XMejs9qAudSqkMGhSMKg==}
+    peerDependencies:
+      react: '>=17.0.1'
 
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
@@ -888,6 +911,22 @@ packages:
 
   caniuse-lite@1.0.30001799:
     resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  cli-cursor@5.0.0:
+    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
+    engines: {node: '>=18'}
+
+  cli-spinners@3.4.0:
+    resolution: {integrity: sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==}
+    engines: {node: '>=18.20'}
+
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -1037,6 +1076,10 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
@@ -1078,6 +1121,14 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-interactive@2.0.0:
+    resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
+    engines: {node: '>=12'}
+
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
@@ -1107,8 +1158,15 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  kleur@3.0.3:
+    resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
+    engines: {node: '>=6'}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -1192,11 +1250,19 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  log-symbols@7.0.1:
+    resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
+    engines: {node: '>=18'}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -1217,9 +1283,17 @@ packages:
     resolution: {integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==}
     engines: {node: '>=18'}
 
+  onetime@7.0.0:
+    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
+    engines: {node: '>=18'}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
+
+  ora@9.4.0:
+    resolution: {integrity: sha512-84cglkRILFxdtA8hAvLNdMrtBpPNBTrQ9/ulg0FA7xLMnD6mifv+enAIeRmvtv+WgdCE+LPGOfQmtJRrVaIVhQ==}
+    engines: {node: '>=20'}
 
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
@@ -1228,6 +1302,9 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  package-manager-detector@1.6.0:
+    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -1257,6 +1334,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  prompts@2.4.2:
+    resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
+    engines: {node: '>= 6'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -1265,6 +1346,15 @@ packages:
     resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
     peerDependencies:
       react: ^19.2.7
+
+  react-grab@0.1.47:
+    resolution: {integrity: sha512-1GNy24KMJ4CY1IxorYO9mydItGi0L1HkQB19uYU3t0BMsJB0K+D/QYiaBz+rugRynyY8LzmXIuOcon1TykLlCg==}
+    hasBin: true
+    peerDependencies:
+      react: '>=17.0.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
 
   react-router-dom@7.17.0:
     resolution: {integrity: sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==}
@@ -1286,6 +1376,10 @@ packages:
   react@19.2.7:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
+
+  restore-cursor@5.1.0:
+    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
 
   rolldown@1.0.3:
     resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
@@ -1319,9 +1413,28 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  stdin-discarder@0.3.2:
+    resolution: {integrity: sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==}
+    engines: {node: '>=18'}
+
+  string-width@8.2.1:
+    resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
+    engines: {node: '>=20'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   tailwind-animations@1.0.1:
     resolution: {integrity: sha512-5ouCdgfGS4kcyuzRSb/1O3o9f5Akssi7ue46PHfKjvPLMWjtnzmqM8i6ElES3tKVTyhjSaTPfLti7aB7WSxhZg==}
@@ -1334,6 +1447,10 @@ packages:
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
@@ -1459,9 +1576,18 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yoctocolors@2.1.2:
+    resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
+    engines: {node: '>=18'}
 
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
@@ -1723,6 +1849,8 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@iarna/toml@2.2.5': {}
+
   '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.35.1':
@@ -1857,6 +1985,17 @@ snapshots:
 
   '@oxc-project/types@0.133.0': {}
 
+  '@react-grab/cli@0.1.47':
+    dependencies:
+      agent-install: 0.0.6
+      commander: 14.0.3
+      ignore: 7.0.5
+      ora: 9.4.0
+      package-manager-detector: 1.6.0
+      picocolors: 1.1.1
+      prompts: 2.4.2
+      tinyexec: 1.2.4
+
   '@rolldown/binding-android-arm64@1.0.3':
     optional: true
 
@@ -1975,12 +2114,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.1
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.1
 
-  '@tailwindcss/vite@4.3.1(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))':
+  '@tailwindcss/vite@4.3.1(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.3.1
       '@tailwindcss/oxide': 4.3.1
       tailwindcss: 4.3.1
-      vite: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)
+      vite: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@tybys/wasm-util@0.10.2':
     dependencies:
@@ -2096,16 +2235,25 @@ snapshots:
       '@typescript-eslint/types': 8.61.1
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))':
+  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)
+      vite: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
       acorn: 8.17.0
 
   acorn@8.17.0: {}
+
+  agent-install@0.0.6:
+    dependencies:
+      '@iarna/toml': 2.2.5
+      commander: 14.0.3
+      jsonc-parser: 3.3.1
+      picocolors: 1.1.1
+      prompts: 2.4.2
+      yaml: 2.9.0
 
   ajv@6.15.0:
     dependencies:
@@ -2114,9 +2262,15 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ansi-regex@6.2.2: {}
+
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.37: {}
+
+  bippy@0.5.41(react@19.2.7):
+    dependencies:
+      react: 19.2.7
 
   brace-expansion@5.0.6:
     dependencies:
@@ -2131,6 +2285,16 @@ snapshots:
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   caniuse-lite@1.0.30001799: {}
+
+  chalk@5.6.2: {}
+
+  cli-cursor@5.0.0:
+    dependencies:
+      restore-cursor: 5.1.0
+
+  cli-spinners@3.4.0: {}
+
+  commander@14.0.3: {}
 
   convert-source-map@2.0.0: {}
 
@@ -2306,6 +2470,8 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
+  get-east-asian-width@1.6.0: {}
+
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
@@ -2334,6 +2500,10 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-interactive@2.0.0: {}
+
+  is-unicode-supported@2.1.0: {}
+
   isexe@2.0.0: {}
 
   jiti@2.7.0: {}
@@ -2350,9 +2520,13 @@ snapshots:
 
   json5@2.2.3: {}
 
+  jsonc-parser@3.3.1: {}
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  kleur@3.0.3: {}
 
   levn@0.4.1:
     dependencies:
@@ -2412,6 +2586,11 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  log-symbols@7.0.1:
+    dependencies:
+      is-unicode-supported: 2.1.0
+      yoctocolors: 2.1.2
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -2419,6 +2598,8 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  mimic-function@5.0.1: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -2432,6 +2613,10 @@ snapshots:
 
   node-releases@2.0.47: {}
 
+  onetime@7.0.0:
+    dependencies:
+      mimic-function: 5.0.1
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -2441,6 +2626,17 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  ora@9.4.0:
+    dependencies:
+      chalk: 5.6.2
+      cli-cursor: 5.0.0
+      cli-spinners: 3.4.0
+      is-interactive: 2.0.0
+      is-unicode-supported: 2.1.0
+      log-symbols: 7.0.1
+      stdin-discarder: 0.3.2
+      string-width: 8.2.1
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
@@ -2448,6 +2644,8 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  package-manager-detector@1.6.0: {}
 
   path-exists@4.0.0: {}
 
@@ -2467,12 +2665,24 @@ snapshots:
 
   prettier@3.8.3: {}
 
+  prompts@2.4.2:
+    dependencies:
+      kleur: 3.0.3
+      sisteransi: 1.0.5
+
   punycode@2.3.1: {}
 
   react-dom@19.2.7(react@19.2.7):
     dependencies:
       react: 19.2.7
       scheduler: 0.27.0
+
+  react-grab@0.1.47(react@19.2.7):
+    dependencies:
+      '@react-grab/cli': 0.1.47
+      bippy: 0.5.41(react@19.2.7)
+    optionalDependencies:
+      react: 19.2.7
 
   react-router-dom@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
@@ -2489,6 +2699,11 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
 
   react@19.2.7: {}
+
+  restore-cursor@5.1.0:
+    dependencies:
+      onetime: 7.0.0
+      signal-exit: 4.1.0
 
   rolldown@1.0.3:
     dependencies:
@@ -2557,7 +2772,22 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  signal-exit@4.1.0: {}
+
+  sisteransi@1.0.5: {}
+
   source-map-js@1.2.1: {}
+
+  stdin-discarder@0.3.2: {}
+
+  string-width@8.2.1:
+    dependencies:
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   tailwind-animations@1.0.1(tailwindcss@4.3.1):
     dependencies:
@@ -2566,6 +2796,8 @@ snapshots:
   tailwindcss@4.3.1: {}
 
   tapable@2.3.3: {}
+
+  tinyexec@1.2.4: {}
 
   tinyglobby@0.2.17:
     dependencies:
@@ -2614,16 +2846,16 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite-imagetools@10.0.1(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)):
+  vite-imagetools@10.0.1(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@rollup/pluginutils': 5.4.0
       imagetools-core: 10.0.0
       sharp: 0.35.1
-      vite: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)
+      vite: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - rollup
 
-  vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4):
+  vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -2636,6 +2868,7 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
       tsx: 4.22.4
+      yaml: 2.9.0
 
   web-haptics@0.0.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     optionalDependencies:
@@ -2650,7 +2883,11 @@ snapshots:
 
   yallist@3.1.1: {}
 
+  yaml@2.9.0: {}
+
   yocto-queue@0.1.0: {}
+
+  yoctocolors@2.1.2: {}
 
   zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ import Header from "./components/Header";
 import { useLang, useT } from "./i18n/hooks";
 import type { Lang } from "./i18n/context";
 import { track, identify } from "./lib/umami";
-import { buildLangPath } from "./lib/lang-link";
+import { buildLangPath } from "./lib/lang-link-utils";
 import { useTheme } from "./theme/hooks";
 
 const Home = lazy(() => import("./pages/Home"));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,7 @@ function PageLoader() {
       className="flex items-center justify-center py-16"
       style={{ minHeight: "60svh" }}
     >
-      <div className="h-8 w-8 animate-spin rounded-full border-2 border-accent border-t-transparent" />
+      <div className="size-8 animate-spin rounded-full border-2 border-accent border-t-transparent" />
     </div>
   );
 }
@@ -122,7 +122,7 @@ function Footer() {
             strokeWidth="2"
             strokeLinecap="round"
             strokeLinejoin="round"
-            className="w-5 h-5"
+            className="size-5"
             aria-hidden="true"
           >
             <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4" />

--- a/src/components/AddExamModal.tsx
+++ b/src/components/AddExamModal.tsx
@@ -71,7 +71,7 @@ function AddExamModal({
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
-              className="h-5 w-5"
+              className="size-5"
               viewBox="0 0 20 20"
               fill="currentColor"
             >

--- a/src/components/AddSubjectModal.tsx
+++ b/src/components/AddSubjectModal.tsx
@@ -62,7 +62,7 @@ function AddSubjectModal({ onClose, ref }: AddSubjectModalProps) {
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
-              className="h-5 w-5"
+              className="size-5"
               viewBox="0 0 20 20"
               fill="currentColor"
             >

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,7 +5,8 @@ import type { Lang } from "../i18n/context";
 import { track } from "../lib/umami";
 import { triggerLight } from "../lib/haptics";
 import ThemeToggle from "../theme/ThemeToggle";
-import { LangLink as Link, replaceLangInPath } from "../lib/lang-link";
+import { LangLink as Link } from "../lib/lang-link";
+import { replaceLangInPath } from "../lib/lang-link-utils";
 
 const langCycle: Lang[] = ["en", "es", "gl"];
 

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -110,9 +110,9 @@ function MCQuestion({
       const key = e.key.toLowerCase();
       let selectedLetter: string | undefined;
 
-      if (['a', 'b', 'c', 'd', 'e'].includes(key)) {
+      if (["a", "b", "c", "d", "e"].includes(key)) {
         selectedLetter = key;
-      } else if (['1', '2', '3', '4', '5'].includes(key)) {
+      } else if (["1", "2", "3", "4", "5"].includes(key)) {
         selectedLetter = String.fromCharCode(96 + parseInt(key)); // '1' -> 'a'
       }
 
@@ -562,7 +562,10 @@ export default function QuestionCard(props: QuestionCardProps) {
             </thead>
             <tbody className="divide-y divide-border bg-surface-alt">
               {question.table.rows.map((row, ri) => (
-                <tr key={`${question.id}-row-${ri}`} className="hover:bg-surface/50 transition-colors">
+                <tr
+                  key={`${question.id}-row-${ri}`}
+                  className="hover:bg-surface/50 transition-colors"
+                >
                   {row.map((cell, ci) => (
                     <td
                       key={`${question.id}-cell-${ri}-${ci}`}

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -246,6 +246,7 @@ function TextQuestion({
       </label>
       <textarea
         id={`answer-${question.id}`}
+        aria-label="Your answer"
         className="w-full p-3 border-2 border-border rounded-lg focus:border-accent focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none resize-y min-h-[120px] text-sm"
         placeholder="Type your answer…"
         autoComplete="off"
@@ -276,7 +277,7 @@ function TextQuestion({
 
           {isOpen && (
             <div className="p-4 bg-surface rounded-lg border border-border space-y-3">
-              <h4 className="text-xs font-bold uppercase tracking-wider text-fg-muted">
+              <h4 className="text-xs font-semibold uppercase tracking-wider text-fg-muted">
                 {t.questionCard.modelSolution}
               </h4>
               <Markdown className="text-xs whitespace-pre-wrap font-sans text-fg-secondary">
@@ -561,10 +562,10 @@ export default function QuestionCard(props: QuestionCardProps) {
             </thead>
             <tbody className="divide-y divide-border bg-surface-alt">
               {question.table.rows.map((row, ri) => (
-                <tr key={ri} className="hover:bg-surface/50 transition-colors">
+                <tr key={`${question.id}-row-${ri}`} className="hover:bg-surface/50 transition-colors">
                   {row.map((cell, ci) => (
                     <td
-                      key={ci}
+                      key={`${question.id}-cell-${ri}-${ci}`}
                       className="px-4 py-2 text-fg-secondary whitespace-nowrap"
                     >
                       <InlineMarkdown>{cell}</InlineMarkdown>

--- a/src/components/SubjectCard.tsx
+++ b/src/components/SubjectCard.tsx
@@ -47,7 +47,8 @@ export default function SubjectCard({ subject }: SubjectCardProps) {
       <p className="text-sm text-fg-muted mb-4">{subject.university}</p>
       <div className="text-xs text-fg-muted flex items-center gap-2">
         <span>
-          {questionCount !== null ? questionCount : "..."} {t.subjectCard.questions}
+          {questionCount !== null ? questionCount : "..."}{" "}
+          {t.subjectCard.questions}
         </span>
         <span>&middot;</span>
         <span>

--- a/src/hooks/useExamSession.ts
+++ b/src/hooks/useExamSession.ts
@@ -1,0 +1,226 @@
+import { useReducer, useCallback, useRef, useEffect } from "react";
+import type { Question } from "../data/types";
+import { saveAttempt } from "../data/store";
+import { track } from "../lib/umami";
+import { triggerMedium } from "../lib/haptics";
+
+const getNow = () => Date.now();
+
+interface ExamState {
+  currentIndex: number;
+  answers: Record<string, string>;
+  selfGrades: Record<string, "correct" | "incorrect">;
+  submitted: boolean;
+  timeLeft: number;
+  started: boolean;
+}
+
+type ExamAction =
+  | { type: "SET_CURRENT_INDEX"; index: number }
+  | { type: "ANSWER"; questionId: string; answer: string }
+  | { type: "SELF_GRADE"; questionId: string; grade: "correct" | "incorrect" }
+  | { type: "SUBMIT"; elapsed: number }
+  | { type: "START" }
+  | { type: "TICK" }
+  | { type: "SET_TIME"; timeLeft: number };
+
+function reducer(state: ExamState, action: ExamAction): ExamState {
+  switch (action.type) {
+    case "SET_CURRENT_INDEX":
+      return { ...state, currentIndex: action.index };
+    case "ANSWER":
+      return {
+        ...state,
+        answers: { ...state.answers, [action.questionId]: action.answer },
+      };
+    case "SELF_GRADE":
+      return {
+        ...state,
+        selfGrades: { ...state.selfGrades, [action.questionId]: action.grade },
+      };
+    case "SUBMIT":
+      return { ...state, submitted: true };
+    case "START":
+      return { ...state, started: true };
+    case "TICK":
+      return { ...state, timeLeft: state.timeLeft - 1 };
+    case "SET_TIME":
+      return { ...state, timeLeft: action.timeLeft };
+  }
+}
+
+function gradeQuestion(
+  question: Question,
+  answer: string,
+  selfGrade?: "correct" | "incorrect",
+): number {
+  if (!answer || answer.trim() === "") return 0;
+  if (question.type === "mc") {
+    return answer === question.correctAnswer ? question.points : 0;
+  }
+  if (question.type === "matching") {
+    try {
+      const user = JSON.parse(answer) as Record<string, string>;
+      const correct = question.correctAnswer as Record<string, string>;
+      const items = Object.keys(correct);
+      let correctCount = 0;
+      for (const item of items) {
+        if (user[item] === correct[item]) correctCount++;
+      }
+      return Math.round((correctCount / items.length) * question.points);
+    } catch {
+      return 0;
+    }
+  }
+  if (question.type === "text") {
+    return selfGrade === "correct" ? question.points : 0;
+  }
+  return 0;
+}
+
+export function useExamSession(
+  questions: Question[],
+  subjectId: string,
+  year: string,
+  initialTimeLeft: number,
+  t: { exam: { submitConfirm: string } },
+) {
+  const [state, dispatch] = useReducer(reducer, {
+    currentIndex: 0,
+    answers: {},
+    selfGrades: {},
+    submitted: false,
+    timeLeft: initialTimeLeft,
+    started: false,
+  });
+
+  const startTimeRef = useRef(0);
+  const attemptIdRef = useRef("");
+  const timeUpTrackedRef = useRef(false);
+
+  const setCurrentIndex = useCallback(
+    (index: number) => dispatch({ type: "SET_CURRENT_INDEX", index }),
+    [],
+  );
+
+  const handleAnswer = useCallback((questionId: string, answer: string) => {
+    dispatch({ type: "ANSWER", questionId, answer });
+  }, []);
+
+  const handleStart = useCallback(() => {
+    triggerMedium();
+    track("exam_start", {
+      subjectId,
+      year,
+      questionsCount: questions.length,
+      totalPoints: questions.reduce((s, q) => s + q.points, 0),
+    });
+    dispatch({ type: "START" });
+    startTimeRef.current = getNow();
+  }, [subjectId, year, questions]);
+
+  const handleSubmit = useCallback(() => {
+    if (!window.confirm(t.exam.submitConfirm)) return;
+
+    triggerMedium();
+    const elapsed = Math.floor((getNow() - startTimeRef.current) / 1000);
+    const id = getNow().toString();
+    attemptIdRef.current = id;
+    let score = 0;
+    for (const q of questions) {
+      score += gradeQuestion(
+        q,
+        state.answers[q.id] || "",
+        state.selfGrades[q.id],
+      );
+    }
+    const answeredCount = Object.values(state.answers).filter(
+      (a) => a && a.trim() !== "",
+    ).length;
+    track("exam_submit", {
+      subjectId,
+      year,
+      score,
+      maxScore: questions.reduce((s, q) => s + q.points, 0),
+      timeSpent: elapsed,
+      questionsCount: questions.length,
+      answered: answeredCount,
+    });
+    saveAttempt(subjectId, {
+      id,
+      exam: year,
+      mode: "exam",
+      date: new Date().toISOString(),
+      score,
+      maxScore: questions.reduce((s, q) => s + q.points, 0),
+      answers: state.answers,
+      timeSpent: elapsed,
+    });
+    dispatch({ type: "SUBMIT", elapsed });
+  }, [subjectId, year, questions, state.answers, state.selfGrades, t]);
+
+  const handleSelfGrade = useCallback(
+    (questionId: string, grade: "correct" | "incorrect") => {
+      track("exam_self_grade", { subjectId, year, questionId, grade });
+      dispatch({ type: "SELF_GRADE", questionId, grade });
+      const elapsed = Math.floor((getNow() - startTimeRef.current) / 1000);
+      let score = 0;
+      const nextGrades = { ...state.selfGrades, [questionId]: grade };
+      for (const q of questions) {
+        score += gradeQuestion(q, state.answers[q.id] || "", nextGrades[q.id]);
+      }
+      saveAttempt(subjectId, {
+        id: attemptIdRef.current || getNow().toString(),
+        exam: year,
+        mode: "exam",
+        date: new Date().toISOString(),
+        score,
+        maxScore: questions.reduce((s, q) => s + q.points, 0),
+        answers: state.answers,
+        timeSpent: elapsed,
+      });
+    },
+    [subjectId, year, questions, state.answers, state.selfGrades],
+  );
+
+  // Timer
+  useEffect(() => {
+    if (!state.started || state.submitted) return;
+    const timer = setInterval(() => dispatch({ type: "TICK" }), 1000);
+    return () => clearInterval(timer);
+  }, [state.started, state.submitted]);
+
+  // Time up tracking
+  useEffect(() => {
+    if (
+      state.timeLeft === 0 &&
+      state.started &&
+      !state.submitted &&
+      !timeUpTrackedRef.current
+    ) {
+      timeUpTrackedRef.current = true;
+      track("exam_time_up", {
+        subjectId,
+        year,
+        questionsCount: questions.length,
+      });
+    }
+  }, [
+    state.timeLeft,
+    state.started,
+    state.submitted,
+    subjectId,
+    year,
+    questions.length,
+  ]);
+
+  return {
+    ...state,
+    setCurrentIndex,
+    handleAnswer,
+    handleStart,
+    handleSubmit,
+    handleSelfGrade,
+    dispatch,
+  };
+}

--- a/src/hooks/usePracticeSession.ts
+++ b/src/hooks/usePracticeSession.ts
@@ -1,0 +1,177 @@
+import { useReducer, useCallback, useRef } from "react";
+import type { Question } from "../data/types";
+import { saveAttempt } from "../data/store";
+import { track } from "../lib/umami";
+import { triggerMedium } from "../lib/haptics";
+
+const getNow = () => Date.now();
+
+interface PracticeState {
+  currentIndex: number;
+  answers: Record<string, string>;
+  selfGrades: Record<string, "correct" | "incorrect">;
+  submitted: boolean;
+  checkedQuestions: Record<string, boolean>;
+}
+
+type PracticeAction =
+  | { type: "SET_CURRENT_INDEX"; index: number }
+  | { type: "ANSWER"; questionId: string; answer: string }
+  | { type: "SELF_GRADE"; questionId: string; grade: "correct" | "incorrect" }
+  | { type: "SUBMIT" }
+  | { type: "CHECK_QUESTION"; questionId: string };
+
+function reducer(state: PracticeState, action: PracticeAction): PracticeState {
+  switch (action.type) {
+    case "SET_CURRENT_INDEX":
+      return { ...state, currentIndex: action.index };
+    case "ANSWER":
+      return {
+        ...state,
+        answers: { ...state.answers, [action.questionId]: action.answer },
+      };
+    case "SELF_GRADE":
+      return {
+        ...state,
+        selfGrades: { ...state.selfGrades, [action.questionId]: action.grade },
+      };
+    case "SUBMIT":
+      return { ...state, submitted: true };
+    case "CHECK_QUESTION":
+      return {
+        ...state,
+        checkedQuestions: {
+          ...state.checkedQuestions,
+          [action.questionId]: true,
+        },
+      };
+  }
+}
+
+function gradeQuestion(
+  question: Question,
+  answer: string,
+  selfGrade?: "correct" | "incorrect",
+): number {
+  if (!answer || answer.trim() === "") return 0;
+  if (question.type === "mc") {
+    return answer === question.correctAnswer ? question.points : 0;
+  }
+  if (question.type === "matching") {
+    try {
+      const user = JSON.parse(answer) as Record<string, string>;
+      const correct = question.correctAnswer as Record<string, string>;
+      const items = Object.keys(correct);
+      let correctCount = 0;
+      for (const item of items) {
+        if (user[item] === correct[item]) correctCount++;
+      }
+      return Math.round((correctCount / items.length) * question.points);
+    } catch {
+      return 0;
+    }
+  }
+  if (question.type === "text") {
+    return selfGrade === "correct" ? question.points : 0;
+  }
+  return 0;
+}
+
+export function usePracticeSession(
+  questions: Question[],
+  subjectId: string,
+  topic: string,
+) {
+  const [state, dispatch] = useReducer(reducer, {
+    currentIndex: 0,
+    answers: {},
+    selfGrades: {},
+    submitted: false,
+    checkedQuestions: {},
+  });
+
+  const attemptIdRef = useRef("");
+
+  const setCurrentIndex = useCallback(
+    (index: number) => dispatch({ type: "SET_CURRENT_INDEX", index }),
+    [],
+  );
+
+  const handleAnswer = useCallback((questionId: string, answer: string) => {
+    dispatch({ type: "ANSWER", questionId, answer });
+  }, []);
+
+  const handleSubmit = useCallback(() => {
+    triggerMedium();
+    const id = getNow().toString();
+    attemptIdRef.current = id;
+    let score = 0;
+    for (const q of questions) {
+      score += gradeQuestion(
+        q,
+        state.answers[q.id] || "",
+        state.selfGrades[q.id],
+      );
+    }
+    const answeredCount = Object.values(state.answers).filter(
+      (a) => a && a.trim() !== "",
+    ).length;
+    track("practice_submit", {
+      subjectId,
+      topic,
+      score,
+      maxScore: questions.reduce((s, q) => s + q.points, 0),
+      questionsCount: questions.length,
+      answered: answeredCount,
+    });
+    saveAttempt(subjectId, {
+      id,
+      exam: "practice",
+      mode: "practice",
+      topic,
+      date: new Date().toISOString(),
+      score,
+      maxScore: questions.reduce((s, q) => s + q.points, 0),
+      answers: state.answers,
+    });
+    dispatch({ type: "SUBMIT" });
+  }, [subjectId, topic, questions, state.answers, state.selfGrades]);
+
+  const handleSelfGrade = useCallback(
+    (questionId: string, grade: "correct" | "incorrect") => {
+      track("practice_self_grade", { subjectId, topic, questionId, grade });
+      dispatch({ type: "SELF_GRADE", questionId, grade });
+      let score = 0;
+      const nextGrades = { ...state.selfGrades, [questionId]: grade };
+      for (const q of questions) {
+        score += gradeQuestion(q, state.answers[q.id] || "", nextGrades[q.id]);
+      }
+      saveAttempt(subjectId, {
+        id: attemptIdRef.current || getNow().toString(),
+        exam: "practice",
+        mode: "practice",
+        topic,
+        date: new Date().toISOString(),
+        score,
+        maxScore: questions.reduce((s, q) => s + q.points, 0),
+        answers: state.answers,
+      });
+    },
+    [subjectId, topic, questions, state.answers, state.selfGrades],
+  );
+
+  const handleCheckQuestion = useCallback((questionId: string) => {
+    track("practice_check_question", { questionId });
+    dispatch({ type: "CHECK_QUESTION", questionId });
+  }, []);
+
+  return {
+    ...state,
+    setCurrentIndex,
+    handleAnswer,
+    handleSubmit,
+    handleSelfGrade,
+    handleCheckQuestion,
+    dispatch,
+  };
+}

--- a/src/i18n/context-value.ts
+++ b/src/i18n/context-value.ts
@@ -1,0 +1,16 @@
+import { createContext } from "react";
+import { en, type Translations } from "./en";
+
+export type Lang = "en" | "es" | "gl";
+
+export interface I18nContextType {
+  t: Translations;
+  lang: Lang;
+  setLang: (lang: Lang) => void;
+}
+
+export const I18nContext = createContext<I18nContextType>({
+  t: en,
+  lang: "en",
+  setLang: () => {},
+});

--- a/src/i18n/context.tsx
+++ b/src/i18n/context.tsx
@@ -1,30 +1,12 @@
-/* eslint-disable react-refresh/only-export-components */
-import {
-  createContext,
-  useState,
-  useCallback,
-  useMemo,
-  type ReactNode,
-} from "react";
+import { useState, useCallback, useMemo, type ReactNode } from "react";
 import { en, type Translations } from "./en";
 import { es } from "./es";
 import { gl } from "./gl";
+import { I18nContext, type Lang } from "./context-value";
 
-export type Lang = "en" | "es" | "gl";
+export type { Lang } from "./context-value";
 
 const translations: Record<Lang, Translations> = { en, es, gl };
-
-export interface I18nContextType {
-  t: Translations;
-  lang: Lang;
-  setLang: (lang: Lang) => void;
-}
-
-export const I18nContext = createContext<I18nContextType>({
-  t: en,
-  lang: "en",
-  setLang: () => {},
-});
 
 function getLangFromPathname(): Lang | null {
   const match = window.location.pathname.match(/^\/(en|es|gl)(\/|$)/);

--- a/src/i18n/hooks.ts
+++ b/src/i18n/hooks.ts
@@ -1,5 +1,5 @@
 import { use } from "react";
-import { I18nContext } from "./context";
+import { I18nContext } from "./context-value";
 
 export function useT() {
   return use(I18nContext).t;

--- a/src/lib/lang-link-utils.ts
+++ b/src/lib/lang-link-utils.ts
@@ -1,0 +1,16 @@
+import type { Lang } from "../i18n/context";
+
+export function buildLangPath(lang: Lang, path: string): string {
+  if (path === "/") return `/${lang}`;
+  return `/${lang}${path}`;
+}
+
+export function replaceLangInPath(pathname: string, newLang: Lang): string {
+  const langPattern = /^\/(en|es|gl)(\/|$)/;
+  const match = pathname.match(langPattern);
+  if (match) {
+    const rest = pathname.slice(match[0].length - (match[2] === "/" ? 1 : 0));
+    return buildLangPath(newLang, rest || "/");
+  }
+  return buildLangPath(newLang, pathname === "/" ? "/" : pathname);
+}

--- a/src/lib/lang-link.tsx
+++ b/src/lib/lang-link.tsx
@@ -1,34 +1,5 @@
-/* eslint-disable react-refresh/only-export-components */
-import { useCallback } from "react";
 import { Link, type LinkProps } from "react-router-dom";
 import { useLang } from "../i18n/hooks";
-import type { Lang } from "../i18n/context";
-
-export function useLangTo() {
-  const { lang } = useLang();
-  return useCallback(
-    (path: string) => {
-      if (path === "/") return `/${lang}`;
-      return `/${lang}${path}`;
-    },
-    [lang],
-  );
-}
-
-export function buildLangPath(lang: Lang, path: string): string {
-  if (path === "/") return `/${lang}`;
-  return `/${lang}${path}`;
-}
-
-export function replaceLangInPath(pathname: string, newLang: Lang): string {
-  const langPattern = /^\/(en|es|gl)(\/|$)/;
-  const match = pathname.match(langPattern);
-  if (match) {
-    const rest = pathname.slice(match[0].length - (match[2] === "/" ? 1 : 0));
-    return buildLangPath(newLang, rest || "/");
-  }
-  return buildLangPath(newLang, pathname === "/" ? "/" : pathname);
-}
 
 export function LangLink(props: LinkProps) {
   const { lang } = useLang();

--- a/src/lib/markdown.tsx
+++ b/src/lib/markdown.tsx
@@ -107,14 +107,12 @@ function renderTable(mdTable: string, key: string): ReactNode {
   if (lines.length < 2) return null;
   const headerCells = lines[0]
     .split("|")
-    .map((c) => c.trim())
-    .filter(Boolean);
+    .flatMap((c) => (c.trim() || undefined ? [c.trim()] : []));
   const bodyLines = lines.slice(2);
   const rows = bodyLines.map((line) =>
     line
       .split("|")
-      .map((c) => c.trim())
-      .filter(Boolean),
+      .flatMap((c) => (c.trim() || undefined ? [c.trim()] : [])),
   );
   return (
     <div
@@ -124,9 +122,9 @@ function renderTable(mdTable: string, key: string): ReactNode {
       <table className="min-w-full divide-y divide-border text-sm">
         <thead className="bg-surface">
           <tr>
-            {headerCells.map((h, i) => (
+            {headerCells.map((h) => (
               <th
-                key={i}
+                key={`${key}-h-${h}`}
                 scope="col"
                 className="px-3 py-2 text-left font-semibold text-fg whitespace-nowrap"
               >
@@ -137,10 +135,10 @@ function renderTable(mdTable: string, key: string): ReactNode {
         </thead>
         <tbody className="divide-y divide-border bg-surface-alt">
           {rows.map((row, ri) => (
-            <tr key={ri}>
+            <tr key={`${key}-r-${ri}`}>
               {row.map((cell, ci) => (
                 <td
-                  key={ci}
+                  key={`${key}-c-${ri}-${ci}`}
                   className="px-3 py-2 text-fg-secondary whitespace-nowrap"
                 >
                   <InlineMarkdown>{cell}</InlineMarkdown>

--- a/src/lib/markdown.tsx
+++ b/src/lib/markdown.tsx
@@ -110,9 +110,7 @@ function renderTable(mdTable: string, key: string): ReactNode {
     .flatMap((c) => (c.trim() || undefined ? [c.trim()] : []));
   const bodyLines = lines.slice(2);
   const rows = bodyLines.map((line) =>
-    line
-      .split("|")
-      .flatMap((c) => (c.trim() || undefined ? [c.trim()] : [])),
+    line.split("|").flatMap((c) => (c.trim() || undefined ? [c.trim()] : [])),
   );
   return (
     <div

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -86,11 +86,23 @@ export function useSeoHead({
       { id: "og:description", content: description, attr: "property" as const },
       { id: "og:locale", content: meta.locale, attr: "property" as const },
       { id: "og:url", content: canonicalUrl, attr: "property" as const },
-      { id: "og:site_name", content: t.seo.siteName, attr: "property" as const },
+      {
+        id: "og:site_name",
+        content: t.seo.siteName,
+        attr: "property" as const,
+      },
       { id: "og:type", content: "website", attr: "property" as const },
       { id: "twitter:title", content: title, attr: "name" as const },
-      { id: "twitter:description", content: description, attr: "name" as const },
-      { id: "twitter:card", content: "summary_large_image", attr: "name" as const },
+      {
+        id: "twitter:description",
+        content: description,
+        attr: "name" as const,
+      },
+      {
+        id: "twitter:card",
+        content: "summary_large_image",
+        attr: "name" as const,
+      },
     ];
 
     const linkOps = [

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -80,27 +80,34 @@ export function useSeoHead({
     const canonicalPath = buildCanonicalPath(lang, pathWithoutLang);
     const canonicalUrl = `${BASE_URL}${canonicalPath}`;
 
-    setMeta("meta-description", description, "name");
-    setMeta("og:title", title, "property");
-    setMeta("og:description", description, "property");
-    setMeta("og:locale", meta.locale, "property");
-    setMeta("og:url", canonicalUrl, "property");
-    setMeta("og:site_name", t.seo.siteName, "property");
-    setMeta("og:type", "website", "property");
-    setMeta("twitter:title", title, "name");
-    setMeta("twitter:description", description, "name");
-    setMeta("twitter:card", "summary_large_image", "name");
+    const metaOps = [
+      { id: "meta-description", content: description, attr: "name" as const },
+      { id: "og:title", content: title, attr: "property" as const },
+      { id: "og:description", content: description, attr: "property" as const },
+      { id: "og:locale", content: meta.locale, attr: "property" as const },
+      { id: "og:url", content: canonicalUrl, attr: "property" as const },
+      { id: "og:site_name", content: t.seo.siteName, attr: "property" as const },
+      { id: "og:type", content: "website", attr: "property" as const },
+      { id: "twitter:title", content: title, attr: "name" as const },
+      { id: "twitter:description", content: description, attr: "name" as const },
+      { id: "twitter:card", content: "summary_large_image", attr: "name" as const },
+    ];
 
-    setLink("link-canonical", "canonical", canonicalUrl);
+    const linkOps = [
+      { id: "link-canonical", rel: "canonical", href: canonicalUrl },
+      ...meta.alternateLocales.map((altLang) => ({
+        id: `link-hreflang-${altLang}`,
+        rel: "alternate" as const,
+        href: `${BASE_URL}${buildCanonicalPath(altLang, pathWithoutLang)}`,
+        extra: { hreflang: langMeta[altLang].hreflang },
+      })),
+    ];
 
-    for (const altLang of meta.alternateLocales) {
-      const altPath = buildCanonicalPath(altLang, pathWithoutLang);
-      setLink(
-        `link-hreflang-${altLang}`,
-        "alternate",
-        `${BASE_URL}${altPath}`,
-        { hreflang: langMeta[altLang].hreflang },
-      );
+    for (const op of metaOps) {
+      setMeta(op.id, op.content, op.attr);
+    }
+    for (const op of linkOps) {
+      setLink(op.id, op.rel, op.href, "extra" in op ? op.extra : undefined);
     }
   }, [title, description, pathWithoutLang, lang, meta, t.seo.siteName]);
 }

--- a/src/lib/umami.ts
+++ b/src/lib/umami.ts
@@ -16,12 +16,6 @@ declare global {
   }
 }
 
-export function trackPageView() {
-  if (typeof window !== "undefined" && window.umami) {
-    window.umami.track();
-  }
-}
-
 export function track(
   eventName: string,
   eventData?: Record<string, string | number | boolean>,

--- a/src/lib/useLangTo.ts
+++ b/src/lib/useLangTo.ts
@@ -1,0 +1,8 @@
+import { useCallback } from "react";
+import { useLang } from "../i18n/hooks";
+import { buildLangPath } from "./lang-link-utils";
+
+export function useLangTo() {
+  const { lang } = useLang();
+  return useCallback((path: string) => buildLangPath(lang, path), [lang]);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,7 @@
+if (import.meta.env.DEV) {
+  import("react-grab");
+}
+
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";

--- a/src/pages/ExamSimulation.tsx
+++ b/src/pages/ExamSimulation.tsx
@@ -1,21 +1,20 @@
 import { useState, useCallback, useEffect, useRef, useMemo } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { LangLink as Link, useLangTo } from "../lib/lang-link";
+import { LangLink as Link } from "../lib/lang-link";
+import { useLangTo } from "../lib/useLangTo";
 import {
   getSubject,
   getQuestionsByExam,
   getTopicMegaTopicLabel,
 } from "../subjects";
 import type { Question, Exam } from "../data/types";
-import { saveAttempt } from "../data/store";
 import QuestionCard from "../components/QuestionCard";
 import { useT } from "../i18n/hooks";
 import { track } from "../lib/umami";
-import { triggerLight, triggerMedium } from "../lib/haptics";
+import { triggerLight } from "../lib/haptics";
 import { useDocumentTitle } from "../lib/title";
 import { useSeoHead } from "../lib/seo";
-
-const getNow = () => Date.now();
+import { useExamSession } from "../hooks/useExamSession";
 
 function formatTime(seconds: number) {
   const h = Math.floor(seconds / 3600);
@@ -24,375 +23,122 @@ function formatTime(seconds: number) {
   return `${h.toString().padStart(2, "0")}:${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`;
 }
 
-function gradeQuestion(
-  question: Question,
-  answer: string,
-  selfGrade?: "correct" | "incorrect",
-): number {
-  if (!answer || answer.trim() === "") return 0;
-  if (question.type === "mc") {
-    return answer === question.correctAnswer ? question.points : 0;
-  }
-  if (question.type === "matching") {
-    try {
-      const user = JSON.parse(answer) as Record<string, string>;
-      const correct = question.correctAnswer as Record<string, string>;
-      const items = Object.keys(correct);
-      let correctCount = 0;
-      for (const item of items) {
-        if (user[item] === correct[item]) correctCount++;
-      }
-      return Math.round((correctCount / items.length) * question.points);
-    } catch {
-      return 0;
-    }
-  }
-  if (question.type === "text") {
-    return selfGrade === "correct" ? question.points : 0;
-  }
-  return 0;
+interface ExamStartScreenProps {
+  subject: NonNullable<ReturnType<typeof getSubject>>;
+  examInfo: Exam;
+  questions: Question[];
+  totalPoints: number;
+  onStart: () => void;
 }
 
-export default function ExamSimulation() {
-  const { subjectId, year } = useParams<{ subjectId: string; year: string }>();
-  const navigate = useNavigate();
+function ExamStartScreen({
+  subject,
+  examInfo,
+  questions,
+  totalPoints,
+  onStart,
+}: ExamStartScreenProps) {
   const t = useT();
-  const langTo = useLangTo();
-
-  const subject = subjectId ? getSubject(subjectId) : undefined;
-  const [questions, setQuestions] = useState<Question[]>([]);
-  const [megatopicLabels, setMegatopicLabels] = useState<
-    Record<string, string>
-  >({});
-  const examInfo = useMemo(
-    () => subject?.exams.find((e: Exam) => e.year === year),
-    [subject, year],
-  );
-  useEffect(() => {
-    if (subject && year) {
-      getQuestionsByExam(subject.id, year).then(setQuestions);
-    }
-  }, [subject, year]);
-
-  useEffect(() => {
-    if (!subject || questions.length === 0) return;
-    const topics = [...new Set(questions.map((q) => q.topic))];
-    Promise.all(
-      topics.map(async (t) => {
-        const label = await getTopicMegaTopicLabel(subject.id, t);
-        return [t, label] as const;
-      }),
-    ).then((entries) => {
-      const labels: Record<string, string> = {};
-      for (const [t, l] of entries) {
-        if (l != null) labels[t] = l;
-      }
-      setMegatopicLabels(labels);
-    });
-  }, [subject, questions]);
-  useDocumentTitle(
-    examInfo && subject
-      ? `${examInfo.title} \u2014 ${subject.name} \u2014 ${t.home.title}`
-      : subject
-        ? `${subject.name} \u2014 ${t.home.title}`
-        : t.home.title,
-  );
-
-  useSeoHead({
-    title:
-      examInfo && subject
-        ? `${examInfo.title} \u2014 ${subject.name}`
-        : t.home.title,
-    description:
-      examInfo && subject
-        ? `${examInfo.title} \u2014 ${subject.name} (${subject.courseCode})`
-        : t.seo.defaultDescription,
-    pathWithoutLang: subject && year ? `/${subject.id}/exam/${year}` : "/",
-  });
-
-  const [currentIndex, setCurrentIndex] = useState(0);
-  const [answers, setAnswers] = useState<Record<string, string>>({});
-  const [selfGrades, setSelfGrades] = useState<
-    Record<string, "correct" | "incorrect">
-  >({});
-  const [submitted, setSubmitted] = useState(false);
-  const [timeLeft, setTimeLeft] = useState(
-    (examInfo?.durationMinutes || 120) * 60,
-  );
-  const [started, setStarted] = useState(false);
-  const startTimeRef = useRef<number>(0);
-  const attemptIdRef = useRef<string>("");
-  const timeUpTrackedRef = useRef(false);
-  const [direction, setDirection] = useState<"next" | "prev" | undefined>();
-  const navRef = useRef<HTMLDivElement>(null);
-  const [showLeftFade, setShowLeftFade] = useState(false);
-  const [showRightFade, setShowRightFade] = useState(false);
-  const currentIndexRef = useRef(currentIndex);
-  const startedRef = useRef(started);
-
-  const scrollToNav = useCallback((index: number) => {
-    const container = navRef.current;
-    if (!container) return;
-    const btn = container.children[index] as HTMLElement | undefined;
-    if (!btn) return;
-    requestAnimationFrame(() => {
-      const cr = container.getBoundingClientRect();
-      const br = btn.getBoundingClientRect();
-      const step = 108;
-      if (br.right > cr.right - 84)
-        container.scrollBy({ left: step, behavior: "smooth" });
-      else if (br.left < cr.left + 84)
-        container.scrollBy({ left: -step, behavior: "smooth" });
-    });
-  }, []);
-
-  useEffect(() => {
-    currentIndexRef.current = currentIndex;
-    startedRef.current = started;
-  });
-
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (!startedRef.current) return;
-      const tag = document.activeElement?.tagName.toLowerCase();
-      if (tag === "input" || tag === "textarea" || tag === "select") return;
-      const idx = currentIndexRef.current;
-      if (e.key === "ArrowLeft" && idx > 0) {
-        e.preventDefault();
-        const nextIndex = idx - 1;
-        triggerLight();
-        setDirection("prev");
-        track("exam_navigate", {
-          direction: "prev",
-          fromIndex: idx,
-          toIndex: nextIndex,
-        });
-        setCurrentIndex(nextIndex);
-        scrollToNav(nextIndex);
-      } else if (e.key === "ArrowRight" && idx < questions.length - 1) {
-        e.preventDefault();
-        const nextIndex = idx + 1;
-        triggerLight();
-        setDirection("next");
-        track("exam_navigate", {
-          direction: "next",
-          fromIndex: idx,
-          toIndex: nextIndex,
-        });
-        setCurrentIndex(nextIndex);
-        scrollToNav(nextIndex);
-      }
-    };
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [questions.length, scrollToNav]);
-
-  useEffect(() => {
-    if (!subject || !examInfo) {
-      navigate(langTo("/"), { replace: true });
-    }
-  }, [subject, examInfo, navigate, langTo]);
-
-  useEffect(() => {
-    const el = navRef.current;
-    if (!el) return;
-    const check = () => {
-      setShowLeftFade(el.scrollLeft > 4);
-      setShowRightFade(el.scrollLeft + el.clientWidth < el.scrollWidth - 4);
-    };
-    check();
-    el.addEventListener("scroll", check, { passive: true });
-    const ro = new ResizeObserver(check);
-    ro.observe(el);
-    return () => {
-      el.removeEventListener("scroll", check);
-      ro.disconnect();
-    };
-  }, [questions, started]);
-
-  const totalPoints = questions.reduce((s, q) => s + q.points, 0);
-
-  useEffect(() => {
-    if (!started || submitted) return;
-    const timer = setInterval(() => {
-      setTimeLeft((t) => {
-        if (t <= 1) {
-          clearInterval(timer);
-          return 0;
-        }
-        return t - 1;
-      });
-    }, 1000);
-    return () => clearInterval(timer);
-  }, [started, submitted]);
-
-  useEffect(() => {
-    if (timeLeft === 0 && started && !submitted && !timeUpTrackedRef.current) {
-      timeUpTrackedRef.current = true;
-      track("exam_time_up", {
-        subjectId: subject?.id || "",
-        year: year || "",
-        questionsCount: questions.length,
-      });
-    }
-  }, [timeLeft, started, submitted, subject?.id, year, questions.length]);
-
-  const handleAnswer = useCallback((questionId: string, answer: string) => {
-    setAnswers((prev) => ({ ...prev, [questionId]: answer }));
-  }, []);
-
-  const handleSubmit = () => {
-    if (!subject || !year) return;
-
-    if (!window.confirm(t.exam.submitConfirm)) return;
-
-    triggerMedium();
-    const elapsed = Math.floor((getNow() - startTimeRef.current) / 1000);
-    const id = getNow().toString();
-    attemptIdRef.current = id;
-    let score = 0;
-    for (const q of questions) {
-      score += gradeQuestion(q, answers[q.id] || "", selfGrades[q.id]);
-    }
-    const answeredCount = Object.values(answers).filter(
-      (a) => a && a.trim() !== "",
-    ).length;
-    track("exam_submit", {
-      subjectId: subject.id,
-      year: year || "",
-      score,
-      maxScore: totalPoints,
-      timeSpent: elapsed,
-      questionsCount: questions.length,
-      answered: answeredCount,
-    });
-    saveAttempt(subject.id, {
-      id,
-      exam: year,
-      mode: "exam",
-      date: new Date().toISOString(),
-      score,
-      maxScore: totalPoints,
-      answers,
-      timeSpent: elapsed,
-    });
-    setSubmitted(true);
-  };
-
-  const handleSelfGrade = (
-    questionId: string,
-    grade: "correct" | "incorrect",
-  ) => {
-    if (!subject || !year) return;
-    track("exam_self_grade", {
-      subjectId: subject.id,
-      year: year || "",
-      questionId,
-      grade,
-    });
-    setSelfGrades((prev) => {
-      const next = { ...prev, [questionId]: grade };
-      const elapsed = Math.floor((getNow() - startTimeRef.current) / 1000);
-      let score = 0;
-      for (const q of questions) {
-        score += gradeQuestion(q, answers[q.id] || "", next[q.id]);
-      }
-      saveAttempt(subject.id, {
-        id: attemptIdRef.current || getNow().toString(),
-        exam: year,
-        mode: "exam",
-        date: new Date().toISOString(),
-        score,
-        maxScore: totalPoints,
-        answers,
-        timeSpent: elapsed,
-      });
-      return next;
-    });
-  };
-
-  const handleStart = () => {
-    triggerMedium();
-    track("exam_start", {
-      subjectId: subject?.id || "",
-      year: year || "",
-      questionsCount: questions.length,
-      totalPoints,
-    });
-    setStarted(true);
-    startTimeRef.current = getNow();
-  };
-
-  if (questions.length === 0 || !subject || !examInfo) {
-    return (
-      <div className="max-w-3xl mx-auto px-4 py-16 text-center">
-        <p className="text-fg-muted">{t.exam.noQuestions}</p>
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-16 animate-fade-in animate-duration-fast">
+      <div className="mb-6">
         <Link
-          to={subject ? `/${subject.id}` : "/"}
-          className="text-accent hover:underline mt-4 inline-block"
-          onClick={() => triggerLight()}
+          to={`/${subject.id}`}
+          className="text-sm text-accent hover:underline focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none rounded-md px-1"
         >
-          {t.exam.backToHome}
+          {t.exam.backToSubject}
         </Link>
       </div>
-    );
-  }
-
-  if (!started) {
-    return (
-      <div className="max-w-2xl mx-auto px-4 py-16 animate-fade-in animate-duration-fast">
-        <div className="mb-6">
-          <Link
-            to={`/${subject.id}`}
-            className="text-sm text-accent hover:underline focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none rounded-md px-1"
-          >
-            {t.exam.backToSubject}
-          </Link>
-        </div>
-        <div className="text-center">
-          <h1 className="text-3xl font-semibold text-fg mb-2">
-            {examInfo.title}
-          </h1>
-          <p className="text-fg-muted mb-8">
-            {subject.name} ({subject.courseCode})
-          </p>
-        </div>
-        <div className="bg-surface-alt rounded-xl border border-border p-8 shadow-sm space-y-4">
-          <div className="grid grid-cols-2 gap-4 text-sm">
-            <div>
-              <span className="text-fg-muted">{t.exam.questions}</span>
-              <p className="font-semibold">{questions.length}</p>
-            </div>
-            <div>
-              <span className="text-fg-muted">{t.exam.totalPoints}</span>
-              <p className="font-semibold">{totalPoints}p</p>
-            </div>
-            <div>
-              <span className="text-fg-muted">{t.exam.pass}</span>
-              <p className="font-semibold">{examInfo.passPoints}p</p>
-            </div>
-            <div>
-              <span className="text-fg-muted">{t.exam.timeLimit}</span>
-              <p className="font-semibold">
-                {examInfo.durationMinutes} {t.exam.minutes}
-              </p>
-            </div>
-          </div>
-          <div className="bg-amber-50 border border-amber-200 rounded-lg p-4 text-sm text-amber-800">
-            {t.exam.simulationNote}
-          </div>
-          <button
-            type="button"
-            className="w-full py-3 bg-accent text-white rounded-lg hover:bg-accent-hover active:scale-[0.98] focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none transition font-medium animate-pulse"
-            onClick={handleStart}
-          >
-            {t.exam.startExam}
-          </button>
-        </div>
+      <div className="text-center">
+        <h1 className="text-3xl font-semibold text-fg mb-2">
+          {examInfo.title}
+        </h1>
+        <p className="text-fg-muted mb-8">
+          {subject.name} ({subject.courseCode})
+        </p>
       </div>
-    );
-  }
+      <div className="bg-surface-alt rounded-xl border border-border p-8 shadow-sm space-y-4">
+        <div className="grid grid-cols-2 gap-4 text-sm">
+          <div>
+            <span className="text-fg-muted">{t.exam.questions}</span>
+            <p className="font-semibold">{questions.length}</p>
+          </div>
+          <div>
+            <span className="text-fg-muted">{t.exam.totalPoints}</span>
+            <p className="font-semibold">{totalPoints}p</p>
+          </div>
+          <div>
+            <span className="text-fg-muted">{t.exam.pass}</span>
+            <p className="font-semibold">{examInfo.passPoints}p</p>
+          </div>
+          <div>
+            <span className="text-fg-muted">{t.exam.timeLimit}</span>
+            <p className="font-semibold">
+              {examInfo.durationMinutes} {t.exam.minutes}
+            </p>
+          </div>
+        </div>
+        <div className="bg-amber-50 border border-amber-200 rounded-lg p-4 text-sm text-amber-800">
+          {t.exam.simulationNote}
+        </div>
+        <button
+          type="button"
+          className="w-full py-3 bg-accent text-white rounded-lg hover:bg-accent-hover active:scale-[0.98] focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none transition font-medium animate-pulse"
+          onClick={onStart}
+        >
+          {t.exam.startExam}
+        </button>
+      </div>
+    </div>
+  );
+}
 
+interface ExamPlayerProps {
+  subject: NonNullable<ReturnType<typeof getSubject>>;
+  examInfo: Exam;
+  questions: Question[];
+  megatopicLabels: Record<string, string>;
+  currentIndex: number;
+  setCurrentIndex: (i: number) => void;
+  answers: Record<string, string>;
+  selfGrades: Record<string, "correct" | "incorrect">;
+  submitted: boolean;
+  timeLeft: number;
+  totalPoints: number;
+  direction: "next" | "prev" | undefined;
+  setDirection: (d: "next" | "prev" | undefined) => void;
+  showLeftFade: boolean;
+  showRightFade: boolean;
+  navRef: React.RefObject<HTMLDivElement | null>;
+  scrollToNav: (index: number) => void;
+  onAnswer: (questionId: string, answer: string) => void;
+  onSelfGrade: (questionId: string, grade: "correct" | "incorrect") => void;
+  onSubmit: () => void;
+}
+
+function ExamPlayer({
+  subject,
+  examInfo,
+  questions,
+  megatopicLabels,
+  currentIndex,
+  setCurrentIndex,
+  answers,
+  selfGrades,
+  submitted,
+  timeLeft,
+  totalPoints,
+  direction,
+  setDirection,
+  showLeftFade,
+  showRightFade,
+  navRef,
+  scrollToNav,
+  onAnswer,
+  onSelfGrade,
+  onSubmit,
+}: ExamPlayerProps) {
+  const t = useT();
   const currentQuestion = questions[currentIndex];
   const currentTopic = subject.topics.find(
     (tp) => tp.key === currentQuestion.topic,
@@ -401,7 +147,25 @@ export default function ExamSimulation() {
   const getScore = () => {
     let score = 0;
     for (const q of questions) {
-      score += gradeQuestion(q, answers[q.id] || "", selfGrades[q.id]);
+      if (!answers[q.id] || answers[q.id].trim() === "") continue;
+      if (q.type === "mc") {
+        if (answers[q.id] === q.correctAnswer) score += q.points;
+      } else if (q.type === "matching") {
+        try {
+          const user = JSON.parse(answers[q.id]) as Record<string, string>;
+          const correct = q.correctAnswer as Record<string, string>;
+          const items = Object.keys(correct);
+          let correctCount = 0;
+          for (const item of items) {
+            if (user[item] === correct[item]) correctCount++;
+          }
+          score += Math.round((correctCount / items.length) * q.points);
+        } catch {
+          /* skip */
+        }
+      } else if (q.type === "text") {
+        if (selfGrades[q.id] === "correct") score += q.points;
+      }
     }
     return score;
   };
@@ -518,11 +282,11 @@ export default function ExamSimulation() {
         megatopicLabel={megatopicLabels[currentQuestion.topic]}
         examDate={examInfo?.date || examInfo?.title}
         subjectId={subject.id}
-        onAnswer={handleAnswer}
+        onAnswer={onAnswer}
         savedAnswer={answers[currentQuestion.id]}
         showResult={submitted}
         selfGrade={selfGrades[currentQuestion.id]}
-        onSelfGrade={handleSelfGrade}
+        onSelfGrade={onSelfGrade}
         direction={direction}
       />
 
@@ -570,7 +334,7 @@ export default function ExamSimulation() {
             <button
               type="button"
               className="px-4 py-2 text-sm rounded-lg bg-red-600 text-white hover:bg-red-700 active:scale-95 focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:outline-none transition font-medium"
-              onClick={handleSubmit}
+              onClick={onSubmit}
             >
               {t.exam.submitExam}
             </button>
@@ -616,5 +380,237 @@ export default function ExamSimulation() {
         </button>
       </div>
     </div>
+  );
+}
+
+export default function ExamSimulation() {
+  const { subjectId, year } = useParams<{ subjectId: string; year: string }>();
+  const navigate = useNavigate();
+  const t = useT();
+  const langTo = useLangTo();
+
+  const subject = subjectId ? getSubject(subjectId) : undefined;
+  const [questions, setQuestions] = useState<Question[]>([]);
+  const [megatopicLabels, setMegatopicLabels] = useState<
+    Record<string, string>
+  >({});
+  const examInfo = useMemo(
+    () => subject?.exams.find((e: Exam) => e.year === year),
+    [subject, year],
+  );
+  useEffect(() => {
+    if (subject && year) {
+      getQuestionsByExam(subject.id, year).then(setQuestions);
+    }
+  }, [subject, year]);
+
+  useEffect(() => {
+    if (!subject || questions.length === 0) return;
+    const topics = [...new Set(questions.map((q) => q.topic))];
+    Promise.all(
+      topics.map(async (t) => {
+        const label = await getTopicMegaTopicLabel(subject.id, t);
+        return [t, label] as const;
+      }),
+    ).then((entries) => {
+      const labels: Record<string, string> = {};
+      for (const [t, l] of entries) {
+        if (l != null) labels[t] = l;
+      }
+      setMegatopicLabels(labels);
+    });
+  }, [subject, questions]);
+  useDocumentTitle(
+    examInfo && subject
+      ? `${examInfo.title} \u2014 ${subject.name} \u2014 ${t.home.title}`
+      : subject
+        ? `${subject.name} \u2014 ${t.home.title}`
+        : t.home.title,
+  );
+
+  useSeoHead({
+    title:
+      examInfo && subject
+        ? `${examInfo.title} \u2014 ${subject.name}`
+        : t.home.title,
+    description:
+      examInfo && subject
+        ? `${examInfo.title} \u2014 ${subject.name} (${subject.courseCode})`
+        : t.seo.defaultDescription,
+    pathWithoutLang: subject && year ? `/${subject.id}/exam/${year}` : "/",
+  });
+
+  const {
+    currentIndex,
+    setCurrentIndex,
+    answers,
+    selfGrades,
+    submitted,
+    timeLeft,
+    started,
+    handleAnswer,
+    handleStart,
+    handleSubmit,
+    handleSelfGrade,
+  } = useExamSession(
+    questions,
+    subject?.id || "",
+    year || "",
+    (examInfo?.durationMinutes || 120) * 60,
+    t,
+  );
+
+  const [navState, setNavState] = useState({
+    direction: undefined as "next" | "prev" | undefined,
+    showLeftFade: false,
+    showRightFade: false,
+  });
+  const { direction, showLeftFade, showRightFade } = navState;
+  const setDirection = useCallback(
+    (d: typeof navState.direction) =>
+      setNavState((prev) => ({ ...prev, direction: d })),
+    // setNavState is stable from useState
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+  const navRef = useRef<HTMLDivElement>(null);
+  const currentIndexRef = useRef(currentIndex);
+  const startedRef = useRef(started);
+
+  const scrollToNav = useCallback((index: number) => {
+    const container = navRef.current;
+    if (!container) return;
+    const btn = container.children[index] as HTMLElement | undefined;
+    if (!btn) return;
+    requestAnimationFrame(() => {
+      const cr = container.getBoundingClientRect();
+      const br = btn.getBoundingClientRect();
+      const step = 108;
+      if (br.right > cr.right - 84)
+        container.scrollBy({ left: step, behavior: "smooth" });
+      else if (br.left < cr.left + 84)
+        container.scrollBy({ left: -step, behavior: "smooth" });
+    });
+  }, []);
+
+  useEffect(() => {
+    currentIndexRef.current = currentIndex;
+    startedRef.current = started;
+  });
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (!startedRef.current) return;
+      const tag = document.activeElement?.tagName.toLowerCase();
+      if (tag === "input" || tag === "textarea" || tag === "select") return;
+      const idx = currentIndexRef.current;
+      if (e.key === "ArrowLeft" && idx > 0) {
+        e.preventDefault();
+        const nextIndex = idx - 1;
+        triggerLight();
+        setNavState((prev) => ({ ...prev, direction: "prev" }));
+        track("exam_navigate", {
+          direction: "prev",
+          fromIndex: idx,
+          toIndex: nextIndex,
+        });
+        setCurrentIndex(nextIndex);
+        scrollToNav(nextIndex);
+      } else if (e.key === "ArrowRight" && idx < questions.length - 1) {
+        e.preventDefault();
+        const nextIndex = idx + 1;
+        triggerLight();
+        setNavState((prev) => ({ ...prev, direction: "next" }));
+        track("exam_navigate", {
+          direction: "next",
+          fromIndex: idx,
+          toIndex: nextIndex,
+        });
+        setCurrentIndex(nextIndex);
+        scrollToNav(nextIndex);
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [questions.length, scrollToNav, setCurrentIndex, setNavState]);
+
+  useEffect(() => {
+    if (!subject || !examInfo) {
+      navigate(langTo("/"), { replace: true });
+    }
+  }, [subject, examInfo, navigate, langTo]);
+
+  useEffect(() => {
+    const el = navRef.current;
+    if (!el) return;
+    const check = () => {
+      setNavState((prev) => ({
+        ...prev,
+        showLeftFade: el.scrollLeft > 4,
+        showRightFade: el.scrollLeft + el.clientWidth < el.scrollWidth - 4,
+      }));
+    };
+    check();
+    el.addEventListener("scroll", check, { passive: true });
+    const ro = new ResizeObserver(check);
+    ro.observe(el);
+    return () => {
+      el.removeEventListener("scroll", check);
+      ro.disconnect();
+    };
+  }, [questions, started, setNavState]);
+
+  const totalPoints = questions.reduce((s, q) => s + q.points, 0);
+
+  if (questions.length === 0 || !subject || !examInfo) {
+    return (
+      <div className="max-w-3xl mx-auto px-4 py-16 text-center">
+        <p className="text-fg-muted">{t.exam.noQuestions}</p>
+        <Link
+          to={subject ? `/${subject.id}` : "/"}
+          className="text-accent hover:underline mt-4 inline-block"
+          onClick={() => triggerLight()}
+        >
+          {t.exam.backToHome}
+        </Link>
+      </div>
+    );
+  }
+
+  if (!started) {
+    return (
+      <ExamStartScreen
+        subject={subject}
+        examInfo={examInfo}
+        questions={questions}
+        totalPoints={totalPoints}
+        onStart={handleStart}
+      />
+    );
+  }
+
+  return (
+    <ExamPlayer
+      subject={subject}
+      examInfo={examInfo}
+      questions={questions}
+      megatopicLabels={megatopicLabels}
+      currentIndex={currentIndex}
+      setCurrentIndex={setCurrentIndex}
+      answers={answers}
+      selfGrades={selfGrades}
+      submitted={submitted}
+      timeLeft={timeLeft}
+      totalPoints={totalPoints}
+      direction={direction}
+      setDirection={setDirection}
+      showLeftFade={showLeftFade}
+      showRightFade={showRightFade}
+      navRef={navRef}
+      scrollToNav={scrollToNav}
+      onAnswer={handleAnswer}
+      onSelfGrade={handleSelfGrade}
+      onSubmit={handleSubmit}
+    />
   );
 }

--- a/src/pages/ExamSimulation.tsx
+++ b/src/pages/ExamSimulation.tsx
@@ -350,7 +350,9 @@ export default function ExamSimulation() {
           </Link>
         </div>
         <div className="text-center">
-          <h1 className="text-3xl font-semibold text-fg mb-2">{examInfo.title}</h1>
+          <h1 className="text-3xl font-semibold text-fg mb-2">
+            {examInfo.title}
+          </h1>
           <p className="text-fg-muted mb-8">
             {subject.name} ({subject.courseCode})
           </p>

--- a/src/pages/ExamSimulation.tsx
+++ b/src/pages/ExamSimulation.tsx
@@ -350,7 +350,7 @@ export default function ExamSimulation() {
           </Link>
         </div>
         <div className="text-center">
-          <h1 className="text-3xl font-bold text-fg mb-2">{examInfo.title}</h1>
+          <h1 className="text-3xl font-semibold text-fg mb-2">{examInfo.title}</h1>
           <p className="text-fg-muted mb-8">
             {subject.name} ({subject.courseCode})
           </p>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -26,7 +26,7 @@ function TrashIcon() {
       strokeWidth={1.5}
       strokeLinecap="round"
       strokeLinejoin="round"
-      className="w-4 h-4"
+      className="size-4"
     >
       <path d="M3 6h18" />
       <path d="M8 6V4a2 2 0 012-2h4a2 2 0 012 2v2" />
@@ -90,7 +90,7 @@ export default function Home() {
 
   return (
     <div className="max-w-6xl mx-auto px-4 py-8 text-center animate-fade-in animate-duration-fast">
-      <h1 className="text-3xl font-bold text-fg mb-3">{t.home.title}</h1>
+      <h1 className="text-3xl font-semibold text-fg mb-3">{t.home.title}</h1>
       <p className="text-fg-secondary max-w-xl mx-auto mb-10">
         {t.home.subtitle}
       </p>

--- a/src/pages/PracticeTopic.tsx
+++ b/src/pages/PracticeTopic.tsx
@@ -1,291 +1,107 @@
 import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { LangLink as Link, useLangTo } from "../lib/lang-link";
+import { LangLink as Link } from "../lib/lang-link";
+import { useLangTo } from "../lib/useLangTo";
 import {
   getSubject,
   getQuestionsByTopic,
   getTopicMegaTopicLabel,
 } from "../subjects";
 import type { Question } from "../data/types";
-import { saveAttempt } from "../data/store";
 import QuestionCard from "../components/QuestionCard";
 import { useT } from "../i18n/hooks";
 import { track } from "../lib/umami";
-import { triggerLight, triggerMedium } from "../lib/haptics";
+import { triggerLight } from "../lib/haptics";
 import { useDocumentTitle } from "../lib/title";
 import { useSeoHead } from "../lib/seo";
+import { usePracticeSession } from "../hooks/usePracticeSession";
 
-const getNow = () => Date.now();
-
-function gradeQuestion(
-  question: Question,
-  answer: string,
-  selfGrade?: "correct" | "incorrect",
-): number {
-  if (!answer || answer.trim() === "") return 0;
-  if (question.type === "mc") {
-    return answer === question.correctAnswer ? question.points : 0;
-  }
-  if (question.type === "matching") {
-    try {
-      const user = JSON.parse(answer) as Record<string, string>;
-      const correct = question.correctAnswer as Record<string, string>;
-      const items = Object.keys(correct);
-      let correctCount = 0;
-      for (const item of items) {
-        if (user[item] === correct[item]) correctCount++;
-      }
-      return Math.round((correctCount / items.length) * question.points);
-    } catch {
-      return 0;
-    }
-  }
-  if (question.type === "text") {
-    return selfGrade === "correct" ? question.points : 0;
-  }
-  return 0;
+interface PracticePlayerProps {
+  subject: NonNullable<ReturnType<typeof getSubject>>;
+  topic: string;
+  questions: Question[];
+  megatopicLabel: string | undefined;
+  topicInfo: { icon: string; label: string } | undefined;
+  currentIndex: number;
+  setCurrentIndex: (i: number) => void;
+  answers: Record<string, string>;
+  selfGrades: Record<string, "correct" | "incorrect">;
+  submitted: boolean;
+  checkedQuestions: Record<string, boolean>;
+  totalPoints: number;
+  textQuestionCount: number;
+  direction: "next" | "prev" | undefined;
+  setDirection: (d: "next" | "prev" | undefined) => void;
+  showLeftFade: boolean;
+  showRightFade: boolean;
+  navRef: React.RefObject<HTMLDivElement | null>;
+  scrollToNav: (index: number) => void;
+  onAnswer: (questionId: string, answer: string) => void;
+  onSelfGrade: (questionId: string, grade: "correct" | "incorrect") => void;
+  onSubmit: () => void;
+  onCheckQuestion: (questionId: string) => void;
+  onClearAnswer: (questionId: string) => void;
 }
 
-export default function PracticeTopic() {
-  const { subjectId, topic } = useParams<{
-    subjectId: string;
-    topic: string;
-  }>();
-  const navigate = useNavigate();
+function PracticePlayer({
+  subject,
+  topic,
+  questions,
+  megatopicLabel,
+  topicInfo,
+  currentIndex,
+  setCurrentIndex,
+  answers,
+  selfGrades,
+  submitted,
+  checkedQuestions,
+  totalPoints,
+  textQuestionCount,
+  direction,
+  setDirection,
+  showLeftFade,
+  showRightFade,
+  navRef,
+  scrollToNav,
+  onAnswer,
+  onSelfGrade,
+  onSubmit,
+  onCheckQuestion,
+  onClearAnswer,
+}: PracticePlayerProps) {
   const t = useT();
-  const langTo = useLangTo();
-
-  const subject = subjectId ? getSubject(subjectId) : undefined;
-  const [questions, setQuestions] = useState<Question[]>([]);
-  const [megatopicLabel, setMegatopicLabel] = useState<string | undefined>();
-  const topicInfo = useMemo(
-    () => subject?.topics.find((tp) => tp.key === topic),
-    [subject, topic],
-  );
-  useEffect(() => {
-    if (subject && topic) {
-      getQuestionsByTopic(subject.id, topic).then(setQuestions);
-      getTopicMegaTopicLabel(subject.id, topic).then(setMegatopicLabel);
-    }
-  }, [subject, topic]);
-  const textQuestionCount = useMemo(
-    () => questions.filter((q) => q.type === "text").length,
-    [questions],
-  );
-  useDocumentTitle(
-    subject && topicInfo
-      ? `${topicInfo.label} \u2014 ${subject.name} \u2014 ${t.home.title}`
-      : subject
-        ? `${t.home.title} \u2014 ${subject.name}`
-        : t.home.title,
-  );
-
-  useSeoHead({
-    title:
-      subject && topicInfo
-        ? `${topicInfo.label} \u2014 ${subject.name}`
-        : t.home.title,
-    description:
-      subject && topicInfo
-        ? `${questions.length} ${t.subjectCard.questions} \u2014 ${topicInfo.label} \u2014 ${subject.name} (${subject.courseCode})`
-        : t.seo.defaultDescription,
-    pathWithoutLang:
-      subject && topic ? `/${subject.id}/practice/${topic}` : "/",
-  });
-
-  const [currentIndex, setCurrentIndex] = useState(0);
-  const [answers, setAnswers] = useState<Record<string, string>>({});
-  const [selfGrades, setSelfGrades] = useState<
-    Record<string, "correct" | "incorrect">
-  >({});
-  const [submitted, setSubmitted] = useState(false);
-  const [checkedQuestions, setCheckedQuestions] = useState<
-    Record<string, boolean>
-  >({});
-  const attemptIdRef = useRef<string>("");
-  const [direction, setDirection] = useState<"next" | "prev" | undefined>();
-  const navRef = useRef<HTMLDivElement>(null);
-  const [showLeftFade, setShowLeftFade] = useState(false);
-  const [showRightFade, setShowRightFade] = useState(false);
-  const currentIndexRef = useRef(currentIndex);
-
-  const scrollToNav = useCallback((index: number) => {
-    const container = navRef.current;
-    if (!container) return;
-    const btn = container.children[index] as HTMLElement | undefined;
-    if (!btn) return;
-    requestAnimationFrame(() => {
-      const cr = container.getBoundingClientRect();
-      const br = btn.getBoundingClientRect();
-      const step = 108;
-      if (br.right > cr.right - 84)
-        container.scrollBy({ left: step, behavior: "smooth" });
-      else if (br.left < cr.left + 84)
-        container.scrollBy({ left: -step, behavior: "smooth" });
-    });
-  }, []);
-
-  useEffect(() => {
-    currentIndexRef.current = currentIndex;
-  });
-
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      const tag = document.activeElement?.tagName.toLowerCase();
-      if (tag === "input" || tag === "textarea" || tag === "select") return;
-      const idx = currentIndexRef.current;
-      if (e.key === "ArrowLeft" && idx > 0) {
-        e.preventDefault();
-        const nextIndex = idx - 1;
-        triggerLight();
-        setDirection("prev");
-        track("practice_navigate", {
-          direction: "prev",
-          fromIndex: idx,
-          toIndex: nextIndex,
-        });
-        setCurrentIndex(nextIndex);
-        scrollToNav(nextIndex);
-      } else if (e.key === "ArrowRight" && idx < questions.length - 1) {
-        e.preventDefault();
-        const nextIndex = idx + 1;
-        triggerLight();
-        setDirection("next");
-        track("practice_navigate", {
-          direction: "next",
-          fromIndex: idx,
-          toIndex: nextIndex,
-        });
-        setCurrentIndex(nextIndex);
-        scrollToNav(nextIndex);
-      }
-    };
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [questions.length, scrollToNav]);
-
-  useEffect(() => {
-    if (!subject || !topicInfo) {
-      navigate(langTo("/"), { replace: true });
-    }
-  }, [subject, topicInfo, navigate, langTo]);
-
-  useEffect(() => {
-    const el = navRef.current;
-    if (!el) return;
-    const check = () => {
-      setShowLeftFade(el.scrollLeft > 4);
-      setShowRightFade(el.scrollLeft + el.clientWidth < el.scrollWidth - 4);
-    };
-    check();
-    el.addEventListener("scroll", check, { passive: true });
-    const ro = new ResizeObserver(check);
-    ro.observe(el);
-    return () => {
-      el.removeEventListener("scroll", check);
-      ro.disconnect();
-    };
-  }, [questions]);
-
-  const handleAnswer = useCallback((questionId: string, answer: string) => {
-    setAnswers((prev) => ({ ...prev, [questionId]: answer }));
-  }, []);
-
-  const handleSubmit = () => {
-    if (!subject) return;
-    triggerMedium();
-    const id = getNow().toString();
-    attemptIdRef.current = id;
-    let score = 0;
-    for (const q of questions) {
-      score += gradeQuestion(q, answers[q.id] || "", selfGrades[q.id]);
-    }
-    const answeredCount = Object.values(answers).filter(
-      (a) => a && a.trim() !== "",
-    ).length;
-    track("practice_submit", {
-      subjectId: subject.id,
-      topic: topic || "",
-      score,
-      maxScore: questions.reduce((s, q) => s + q.points, 0),
-      questionsCount: questions.length,
-      answered: answeredCount,
-    });
-    saveAttempt(subject.id, {
-      id,
-      exam: "practice",
-      mode: "practice",
-      topic: topic,
-      date: new Date().toISOString(),
-      score,
-      maxScore: questions.reduce((s, q) => s + q.points, 0),
-      answers,
-    });
-    setSubmitted(true);
-  };
-
-  const handleSelfGrade = (
-    questionId: string,
-    grade: "correct" | "incorrect",
-  ) => {
-    if (!subject) return;
-    track("practice_self_grade", {
-      subjectId: subject.id,
-      topic: topic || "",
-      questionId,
-      grade,
-    });
-    setSelfGrades((prev) => {
-      const next = { ...prev, [questionId]: grade };
-      let score = 0;
-      for (const q of questions) {
-        score += gradeQuestion(q, answers[q.id] || "", next[q.id]);
-      }
-      saveAttempt(subject.id, {
-        id: attemptIdRef.current || getNow().toString(),
-        exam: "practice",
-        mode: "practice",
-        topic: topic,
-        date: new Date().toISOString(),
-        score,
-        maxScore: questions.reduce((s, q) => s + q.points, 0),
-        answers,
-      });
-      return next;
-    });
-  };
-
   const currentQuestion = questions[currentIndex];
 
   const examDate = useMemo(() => {
     if (currentQuestion?.exam === "both") return undefined;
     const exam = currentQuestion
-      ? subject?.exams.find((e) => e.year === currentQuestion.exam)
+      ? subject.exams.find((e) => e.year === currentQuestion.exam)
       : undefined;
     return exam?.date || exam?.title;
   }, [subject, currentQuestion]);
 
-  if (questions.length === 0 || !subject) {
-    return (
-      <div className="max-w-3xl mx-auto px-4 py-16 text-center">
-        <p className="text-fg-muted">{t.practice.noQuestions}</p>
-        <Link
-          to={subject ? `/${subject.id}` : "/"}
-          className="text-accent hover:underline mt-4 inline-block"
-          onClick={() => triggerLight()}
-        >
-          {t.practice.backToHome}
-        </Link>
-      </div>
-    );
-  }
-
-  const totalPoints = questions.reduce((s, q) => s + q.points, 0);
-
   const getScore = () => {
     let score = 0;
     for (const q of questions) {
-      score += gradeQuestion(q, answers[q.id] || "", selfGrades[q.id]);
+      if (!answers[q.id] || answers[q.id].trim() === "") continue;
+      if (q.type === "mc") {
+        if (answers[q.id] === q.correctAnswer) score += q.points;
+      } else if (q.type === "matching") {
+        try {
+          const user = JSON.parse(answers[q.id]) as Record<string, string>;
+          const correct = q.correctAnswer as Record<string, string>;
+          const items = Object.keys(correct);
+          let correctCount = 0;
+          for (const item of items) {
+            if (user[item] === correct[item]) correctCount++;
+          }
+          score += Math.round((correctCount / items.length) * q.points);
+        } catch {
+          /* skip */
+        }
+      } else if (q.type === "text") {
+        if (selfGrades[q.id] === "correct") score += q.points;
+      }
     }
     return score;
   };
@@ -383,11 +199,11 @@ export default function PracticeTopic() {
         megatopicLabel={megatopicLabel}
         examDate={examDate}
         subjectId={subject.id}
-        onAnswer={handleAnswer}
+        onAnswer={onAnswer}
         savedAnswer={answers[currentQuestion.id]}
         showResult={submitted || !!checkedQuestions[currentQuestion.id]}
         selfGrade={selfGrades[currentQuestion.id]}
-        onSelfGrade={handleSelfGrade}
+        onSelfGrade={onSelfGrade}
         direction={direction}
       />
 
@@ -443,7 +259,7 @@ export default function PracticeTopic() {
                     track("practice_clear_answer", {
                       questionId: currentQuestion.id,
                     });
-                    handleAnswer(currentQuestion.id, "");
+                    onClearAnswer(currentQuestion.id);
                   }}
                 >
                   {t.practice.clear}
@@ -451,16 +267,7 @@ export default function PracticeTopic() {
                 <button
                   type="button"
                   className="px-4 py-2 text-sm rounded-lg bg-blue-600 text-white hover:bg-blue-700 active:scale-95 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none transition"
-                  onClick={() => {
-                    triggerMedium();
-                    track("practice_check_question", {
-                      questionId: currentQuestion.id,
-                    });
-                    setCheckedQuestions((prev) => ({
-                      ...prev,
-                      [currentQuestion.id]: true,
-                    }));
-                  }}
+                  onClick={() => onCheckQuestion(currentQuestion.id)}
                 >
                   {t.practice.check}
                 </button>
@@ -470,7 +277,7 @@ export default function PracticeTopic() {
             <button
               type="button"
               className="px-4 py-2 text-sm rounded-lg bg-accent text-white hover:bg-accent-hover active:scale-95 focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none transition"
-              onClick={handleSubmit}
+              onClick={onSubmit}
             >
               {t.practice.submit}
             </button>
@@ -516,5 +323,216 @@ export default function PracticeTopic() {
         </button>
       </div>
     </div>
+  );
+}
+
+export default function PracticeTopic() {
+  const { subjectId, topic } = useParams<{
+    subjectId: string;
+    topic: string;
+  }>();
+  const navigate = useNavigate();
+  const t = useT();
+  const langTo = useLangTo();
+
+  const subject = subjectId ? getSubject(subjectId) : undefined;
+  const [questions, setQuestions] = useState<Question[]>([]);
+  const [megatopicLabel, setMegatopicLabel] = useState<string | undefined>();
+  const topicInfo = useMemo(
+    () => subject?.topics.find((tp) => tp.key === topic),
+    [subject, topic],
+  );
+  useEffect(() => {
+    if (subject && topic) {
+      getQuestionsByTopic(subject.id, topic).then(setQuestions);
+      getTopicMegaTopicLabel(subject.id, topic).then(setMegatopicLabel);
+    }
+  }, [subject, topic]);
+  const textQuestionCount = useMemo(
+    () => questions.filter((q) => q.type === "text").length,
+    [questions],
+  );
+  useDocumentTitle(
+    subject && topicInfo
+      ? `${topicInfo.label} \u2014 ${subject.name} \u2014 ${t.home.title}`
+      : subject
+        ? `${t.home.title} \u2014 ${subject.name}`
+        : t.home.title,
+  );
+
+  useSeoHead({
+    title:
+      subject && topicInfo
+        ? `${topicInfo.label} \u2014 ${subject.name}`
+        : t.home.title,
+    description:
+      subject && topicInfo
+        ? `${questions.length} ${t.subjectCard.questions} \u2014 ${topicInfo.label} \u2014 ${subject.name} (${subject.courseCode})`
+        : t.seo.defaultDescription,
+    pathWithoutLang:
+      subject && topic ? `/${subject.id}/practice/${topic}` : "/",
+  });
+
+  const {
+    currentIndex,
+    setCurrentIndex,
+    answers,
+    selfGrades,
+    submitted,
+    checkedQuestions,
+    handleAnswer,
+    handleSubmit,
+    handleSelfGrade,
+    handleCheckQuestion,
+  } = usePracticeSession(questions, subject?.id || "", topic || "");
+
+  const [navState, setNavState] = useState({
+    direction: undefined as "next" | "prev" | undefined,
+    showLeftFade: false,
+    showRightFade: false,
+  });
+  const { direction, showLeftFade, showRightFade } = navState;
+  const setDirection = useCallback(
+    (d: typeof navState.direction) =>
+      setNavState((prev) => ({ ...prev, direction: d })),
+    // setNavState is stable from useState
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+  const navRef = useRef<HTMLDivElement>(null);
+  const currentIndexRef = useRef(currentIndex);
+
+  const scrollToNav = useCallback((index: number) => {
+    const container = navRef.current;
+    if (!container) return;
+    const btn = container.children[index] as HTMLElement | undefined;
+    if (!btn) return;
+    requestAnimationFrame(() => {
+      const cr = container.getBoundingClientRect();
+      const br = btn.getBoundingClientRect();
+      const step = 108;
+      if (br.right > cr.right - 84)
+        container.scrollBy({ left: step, behavior: "smooth" });
+      else if (br.left < cr.left + 84)
+        container.scrollBy({ left: -step, behavior: "smooth" });
+    });
+  }, []);
+
+  useEffect(() => {
+    currentIndexRef.current = currentIndex;
+  });
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const tag = document.activeElement?.tagName.toLowerCase();
+      if (tag === "input" || tag === "textarea" || tag === "select") return;
+      const idx = currentIndexRef.current;
+      if (e.key === "ArrowLeft" && idx > 0) {
+        e.preventDefault();
+        const nextIndex = idx - 1;
+        triggerLight();
+        setNavState((prev) => ({ ...prev, direction: "prev" }));
+        track("practice_navigate", {
+          direction: "prev",
+          fromIndex: idx,
+          toIndex: nextIndex,
+        });
+        setCurrentIndex(nextIndex);
+        scrollToNav(nextIndex);
+      } else if (e.key === "ArrowRight" && idx < questions.length - 1) {
+        e.preventDefault();
+        const nextIndex = idx + 1;
+        triggerLight();
+        setNavState((prev) => ({ ...prev, direction: "next" }));
+        track("practice_navigate", {
+          direction: "next",
+          fromIndex: idx,
+          toIndex: nextIndex,
+        });
+        setCurrentIndex(nextIndex);
+        scrollToNav(nextIndex);
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [questions.length, scrollToNav, setCurrentIndex, setNavState]);
+
+  useEffect(() => {
+    if (!subject || !topicInfo) {
+      navigate(langTo("/"), { replace: true });
+    }
+  }, [subject, topicInfo, navigate, langTo]);
+
+  useEffect(() => {
+    const el = navRef.current;
+    if (!el) return;
+    const check = () => {
+      setNavState((prev) => ({
+        ...prev,
+        showLeftFade: el.scrollLeft > 4,
+        showRightFade: el.scrollLeft + el.clientWidth < el.scrollWidth - 4,
+      }));
+    };
+    check();
+    el.addEventListener("scroll", check, { passive: true });
+    const ro = new ResizeObserver(check);
+    ro.observe(el);
+    return () => {
+      el.removeEventListener("scroll", check);
+      ro.disconnect();
+    };
+  }, [questions, setNavState]);
+
+  const totalPoints = questions.reduce((s, q) => s + q.points, 0);
+
+  const handleClearAnswer = useCallback(
+    (questionId: string) => {
+      handleAnswer(questionId, "");
+    },
+    [handleAnswer],
+  );
+
+  if (questions.length === 0 || !subject) {
+    return (
+      <div className="max-w-3xl mx-auto px-4 py-16 text-center">
+        <p className="text-fg-muted">{t.practice.noQuestions}</p>
+        <Link
+          to={subject ? `/${subject.id}` : "/"}
+          className="text-accent hover:underline mt-4 inline-block"
+          onClick={() => triggerLight()}
+        >
+          {t.practice.backToHome}
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <PracticePlayer
+      subject={subject}
+      topic={topic || ""}
+      questions={questions}
+      megatopicLabel={megatopicLabel}
+      topicInfo={topicInfo}
+      currentIndex={currentIndex}
+      setCurrentIndex={setCurrentIndex}
+      answers={answers}
+      selfGrades={selfGrades}
+      submitted={submitted}
+      checkedQuestions={checkedQuestions}
+      totalPoints={totalPoints}
+      textQuestionCount={textQuestionCount}
+      direction={direction}
+      setDirection={setDirection}
+      showLeftFade={showLeftFade}
+      showRightFade={showRightFade}
+      navRef={navRef}
+      scrollToNav={scrollToNav}
+      onAnswer={handleAnswer}
+      onSelfGrade={handleSelfGrade}
+      onSubmit={handleSubmit}
+      onCheckQuestion={handleCheckQuestion}
+      onClearAnswer={handleClearAnswer}
+    />
   );
 }

--- a/src/pages/PracticeTopic.tsx
+++ b/src/pages/PracticeTopic.tsx
@@ -299,7 +299,7 @@ export default function PracticeTopic() {
         >
           {t.practice.backToTopics}
         </Link>
-        <h1 className="text-2xl font-bold text-fg mt-2">
+        <h1 className="text-2xl font-semibold text-fg mt-2">
           {topicInfo?.icon} {topicInfo?.label || topic}
         </h1>
         <p className="text-sm text-fg-muted mt-1">

--- a/src/pages/SubjectHome.tsx
+++ b/src/pages/SubjectHome.tsx
@@ -54,7 +54,7 @@ export default function SubjectHome() {
   if (!subject) {
     return (
       <div className="max-w-6xl mx-auto px-4 py-16 text-center">
-        <h1 className="text-2xl font-bold text-fg mb-4">
+        <h1 className="text-2xl font-semibold text-fg mb-4">
           {t.subjectHome.notFound}
         </h1>
         <Link
@@ -107,7 +107,7 @@ export default function SubjectHome() {
         <p className="text-xs font-mono uppercase tracking-widest text-fg-muted mb-3">
           {subject.courseCode} &middot; {subject.university}
         </p>
-        <h1 className="text-3xl font-bold text-fg mb-3">{subject.name}</h1>
+        <h1 className="text-3xl font-semibold text-fg mb-3">{subject.name}</h1>
         <p className="text-fg-secondary max-w-xl mx-auto">{description}</p>
       </div>
 

--- a/src/subjects/iesede/questions.ts
+++ b/src/subjects/iesede/questions.ts
@@ -7,8 +7,14 @@ export const questions: Question[] = [
     topic: "general",
     type: "mc",
     points: 1,
-    question: "Suponga una aplicaci\u00f3n instalada siguiendo una arquitectura en 4 capas (capa 1: m\u00e1quina con el navegador; capa 2: m\u00e1quina con un servidor en el que est\u00e1 instalada una aplicaci\u00f3n web, internamente estructurada en una capa Interfaz Web de Usuario y una capa Acceso a Servicios, implementadas ambas con tecnolog\u00edas .NET; capa 3: m\u00e1quina con un servidor de aplicaciones en el que est\u00e1 instalado un servicio web, internamente estructurado en una capa Servicios y una capa Modelo, implementadas ambas con tecnolog\u00edas Java; capa 4: m\u00e1quina con la base de datos). Indicar cu\u00e1l de las siguientes afirmaciones es correcta:",
-    options: ["a) No es posible que el software instalado en las capas 2 y 3 est\u00e9 implementado con diferentes tecnolog\u00edas, por tanto, la arquitectura descrita no es v\u00e1lida.", "b) Para optimizar la arquitectura, se podr\u00eda instalar y ejecutar la capa Interfaz Web de Usuario en el servidor de aplicaciones de la capa 3, donde se ejecuta la capa Modelo, haciendo innecesarias las capas Servicios y Acceso a Servicios.", "c) Si se cambia la base de datos instalada en la capa 4, habr\u00eda que realizar las modificaciones pertinentes en el c\u00f3digo y reinstalar el software de las capas 2 y 3.", "d) Ninguna de las anteriores."],
+    question:
+      "Suponga una aplicaci\u00f3n instalada siguiendo una arquitectura en 4 capas (capa 1: m\u00e1quina con el navegador; capa 2: m\u00e1quina con un servidor en el que est\u00e1 instalada una aplicaci\u00f3n web, internamente estructurada en una capa Interfaz Web de Usuario y una capa Acceso a Servicios, implementadas ambas con tecnolog\u00edas .NET; capa 3: m\u00e1quina con un servidor de aplicaciones en el que est\u00e1 instalado un servicio web, internamente estructurado en una capa Servicios y una capa Modelo, implementadas ambas con tecnolog\u00edas Java; capa 4: m\u00e1quina con la base de datos). Indicar cu\u00e1l de las siguientes afirmaciones es correcta:",
+    options: [
+      "a) No es posible que el software instalado en las capas 2 y 3 est\u00e9 implementado con diferentes tecnolog\u00edas, por tanto, la arquitectura descrita no es v\u00e1lida.",
+      "b) Para optimizar la arquitectura, se podr\u00eda instalar y ejecutar la capa Interfaz Web de Usuario en el servidor de aplicaciones de la capa 3, donde se ejecuta la capa Modelo, haciendo innecesarias las capas Servicios y Acceso a Servicios.",
+      "c) Si se cambia la base de datos instalada en la capa 4, habr\u00eda que realizar las modificaciones pertinentes en el c\u00f3digo y reinstalar el software de las capas 2 y 3.",
+      "d) Ninguna de las anteriores.",
+    ],
     correctAnswer: "d", // Placeholder
   },
   {
@@ -17,8 +23,14 @@ export const questions: Question[] = [
     topic: "general",
     type: "mc",
     points: 1,
-    question: "Indique qu\u00e9 APIs o frameworks se han empleado en la asignatura para el desarrollo de la capa Servicios:",
-    options: ["a) Servlets y Apache Thrift.", "b) JDBC y HTTPClient.", "c) JDBC y Servlets.", "d) Apache Thrift y HTTPClient."],
+    question:
+      "Indique qu\u00e9 APIs o frameworks se han empleado en la asignatura para el desarrollo de la capa Servicios:",
+    options: [
+      "a) Servlets y Apache Thrift.",
+      "b) JDBC y HTTPClient.",
+      "c) JDBC y Servlets.",
+      "d) Apache Thrift y HTTPClient.",
+    ],
     correctAnswer: "a", // Placeholder
   },
   {
@@ -27,8 +39,14 @@ export const questions: Question[] = [
     topic: "general",
     type: "mc",
     points: 1,
-    question: "Indique qu\u00e9 afirmaci\u00f3n relativa a la capa Modelo de los ejemplos de la asignatura y de su pr\u00e1ctica es correcta:",
-    options: ["a) Para su compilaci\u00f3n requiere un driver JDBC espec\u00edfico a MySQL.", "b) Para su ejecuci\u00f3n requiere un driver JDBC espec\u00edfico a MySQL.", "c) Todas las anteriores.", "d) Ninguna de las anteriores."],
+    question:
+      "Indique qu\u00e9 afirmaci\u00f3n relativa a la capa Modelo de los ejemplos de la asignatura y de su pr\u00e1ctica es correcta:",
+    options: [
+      "a) Para su compilaci\u00f3n requiere un driver JDBC espec\u00edfico a MySQL.",
+      "b) Para su ejecuci\u00f3n requiere un driver JDBC espec\u00edfico a MySQL.",
+      "c) Todas las anteriores.",
+      "d) Ninguna de las anteriores.",
+    ],
     correctAnswer: "b", // Placeholder
   },
   {
@@ -37,8 +55,14 @@ export const questions: Question[] = [
     topic: "general",
     type: "mc",
     points: 1,
-    question: "Considere las dos siguientes estrategias de implementaci\u00f3n con respecto a los m\u00e9todos de los servicios de la capa Modelo. La capa Modelo est\u00e1 instalada dentro de un servidor de aplicaciones y es invocada por una capa Servicios REST. En la estrategia 2, la variable `dataSource` hace referencia a una instancia de una clase proporcionada por el servidor de aplicaciones que implementa la interfaz `DataSource` y utiliza la estrategia pool de conexiones. Indique la respuesta correcta.\n\n**Estrategia 1**\n```java\npublic void <<m\u00e9todo>> () {\n    try (Connection connection = DriverManager.getConnection(url, user, password)) {\n        << Implementar l\u00f3gica de negocio usando \"connection\". >>\n    } catch (SQLException e) {\n        throw new RuntimeException(e);\n    }\n}\n```\n\n**Estrategia 2**\n```java\npublic void <<m\u00e9todo>> () {\n    try (Connection connection = dataSource.getConnection()) {\n        << Implementar l\u00f3gica de negocio usando \"connection\". >>\n    } catch (SQLException e) {\n        throw new RuntimeException(e);\n    }\n}\n```",
-    options: ["a) La estrategia 1 conduce a un tiempo menor de ejecuci\u00f3n.", "b) La estrategia 2 conduce a un tiempo menor de ejecuci\u00f3n.", "c) El m\u00e9todo `getConnection` del `dataSource` (estrategia 2) lanzar\u00e1 siempre una excepci\u00f3n si no queda ninguna conexi\u00f3n libre en el pool.", "d) La b) y la c) son correctas."],
+    question:
+      'Considere las dos siguientes estrategias de implementaci\u00f3n con respecto a los m\u00e9todos de los servicios de la capa Modelo. La capa Modelo est\u00e1 instalada dentro de un servidor de aplicaciones y es invocada por una capa Servicios REST. En la estrategia 2, la variable `dataSource` hace referencia a una instancia de una clase proporcionada por el servidor de aplicaciones que implementa la interfaz `DataSource` y utiliza la estrategia pool de conexiones. Indique la respuesta correcta.\n\n**Estrategia 1**\n```java\npublic void <<m\u00e9todo>> () {\n    try (Connection connection = DriverManager.getConnection(url, user, password)) {\n        << Implementar l\u00f3gica de negocio usando "connection". >>\n    } catch (SQLException e) {\n        throw new RuntimeException(e);\n    }\n}\n```\n\n**Estrategia 2**\n```java\npublic void <<m\u00e9todo>> () {\n    try (Connection connection = dataSource.getConnection()) {\n        << Implementar l\u00f3gica de negocio usando "connection". >>\n    } catch (SQLException e) {\n        throw new RuntimeException(e);\n    }\n}\n```',
+    options: [
+      "a) La estrategia 1 conduce a un tiempo menor de ejecuci\u00f3n.",
+      "b) La estrategia 2 conduce a un tiempo menor de ejecuci\u00f3n.",
+      "c) El m\u00e9todo `getConnection` del `dataSource` (estrategia 2) lanzar\u00e1 siempre una excepci\u00f3n si no queda ninguna conexi\u00f3n libre en el pool.",
+      "d) La b) y la c) son correctas.",
+    ],
     correctAnswer: "b", // Placeholder
   },
   {
@@ -47,8 +71,14 @@ export const questions: Question[] = [
     topic: "general",
     type: "mc",
     points: 1,
-    question: "Analice el siguiente fragmento de c\u00f3digo e indique la afirmaci\u00f3n correcta:\n```java\ntry {\n    connection = dataSource.getConnection();\n    connection.setAutoCommit(false); // (1)\n    \n    Product product = productDao.find(connection, productId);\n    product.setStock(product.getStock() + increment);\n    productDao.update(connection, product);\n    \n    connection.commit();\n} catch (Exception e) {\n    connection.rollback(); // (2)\n}\n```",
-    options: ["a) La l\u00ednea (1) evita problemas de concurrencia con otras transacciones.", "b) La l\u00ednea (2) garantiza que todas las sentencias SQL se ejecutar\u00e1n dentro de la misma transacci\u00f3n.", "c) Todas las anteriores.", "d) Ninguna de las anteriores."],
+    question:
+      "Analice el siguiente fragmento de c\u00f3digo e indique la afirmaci\u00f3n correcta:\n```java\ntry {\n    connection = dataSource.getConnection();\n    connection.setAutoCommit(false); // (1)\n    \n    Product product = productDao.find(connection, productId);\n    product.setStock(product.getStock() + increment);\n    productDao.update(connection, product);\n    \n    connection.commit();\n} catch (Exception e) {\n    connection.rollback(); // (2)\n}\n```",
+    options: [
+      "a) La l\u00ednea (1) evita problemas de concurrencia con otras transacciones.",
+      "b) La l\u00ednea (2) garantiza que todas las sentencias SQL se ejecutar\u00e1n dentro de la misma transacci\u00f3n.",
+      "c) Todas las anteriores.",
+      "d) Ninguna de las anteriores.",
+    ],
     correctAnswer: "d", // Placeholder
   },
   {
@@ -57,8 +87,14 @@ export const questions: Question[] = [
     topic: "general",
     type: "mc",
     points: 1,
-    question: "Indique la afirmaci\u00f3n correcta de acuerdo al enfoque de desarrollo estudiado en la asignatura:",
-    options: ["a) Las operaciones de los DAOs de su pr\u00e1ctica reciben la conexi\u00f3n para poder agrupar de manera sencilla varias operaciones de un mismo o distintos DAOs en una \u00fanica transacci\u00f3n.", "b) El uso de DAOs simplifica la implementaci\u00f3n de los m\u00e9todos de los servicios de la capa Modelo.", "c) Todas las anteriores.", "d) Ninguna de las anteriores."],
+    question:
+      "Indique la afirmaci\u00f3n correcta de acuerdo al enfoque de desarrollo estudiado en la asignatura:",
+    options: [
+      "a) Las operaciones de los DAOs de su pr\u00e1ctica reciben la conexi\u00f3n para poder agrupar de manera sencilla varias operaciones de un mismo o distintos DAOs en una \u00fanica transacci\u00f3n.",
+      "b) El uso de DAOs simplifica la implementaci\u00f3n de los m\u00e9todos de los servicios de la capa Modelo.",
+      "c) Todas las anteriores.",
+      "d) Ninguna de las anteriores.",
+    ],
     correctAnswer: "c", // Placeholder
   },
   {
@@ -67,8 +103,14 @@ export const questions: Question[] = [
     topic: "general",
     type: "mc",
     points: 1,
-    question: "Se est\u00e1 dise\u00f1ando una aplicaci\u00f3n bancaria que incluye, entre otros, un caso de uso para realizar una transferencia entre dos cuentas (no se permite la transferencia si la cuenta origen no tiene suficiente saldo). La interfaz gr\u00e1fica incluye un formulario en el que el usuario tiene que introducir el identificador de la cuenta origen (Long), el identificador de la cuenta destino (Long) y la cantidad de dinero a transferir (BigDecimal). Analice el DAO de la entidad Account (cuenta) que figura a continuaci\u00f3n e indique la respuesta correcta en base al enfoque de desarrollo estudiado en la asignatura:\n\n```java\npublic interface SqlAccountDao {\n    public Account find(Connection connection, Long accountId)\n        throws InstanceNotFoundException;\n    public void update(Connection connection, Account account)\n        throws InstanceNotFoundException;\n    public void transfer(Long sourceAccountId, Long targetAccountId,\n        BigDecimal amount);\n}\n```",
-    options: ["a) La operaci\u00f3n `transfer` del DAO debe implementarse en t\u00e9rminos de `find` (para recuperar la cuenta origen y la cuenta destino) y `update` (para minorar el balance de la cuenta origen y aumentar el balance de la cuenta destino).", "b) En la operaci\u00f3n `transfer` del DAO falta el par\u00e1metro `Connection`, as\u00ed como especificar excepciones para el caso en el que la cuenta origen no tenga suficiente saldo o que alguna cuenta no exista.", "c) Todas las anteriores.", "d) Ninguna de las anteriores."],
+    question:
+      "Se est\u00e1 dise\u00f1ando una aplicaci\u00f3n bancaria que incluye, entre otros, un caso de uso para realizar una transferencia entre dos cuentas (no se permite la transferencia si la cuenta origen no tiene suficiente saldo). La interfaz gr\u00e1fica incluye un formulario en el que el usuario tiene que introducir el identificador de la cuenta origen (Long), el identificador de la cuenta destino (Long) y la cantidad de dinero a transferir (BigDecimal). Analice el DAO de la entidad Account (cuenta) que figura a continuaci\u00f3n e indique la respuesta correcta en base al enfoque de desarrollo estudiado en la asignatura:\n\n```java\npublic interface SqlAccountDao {\n    public Account find(Connection connection, Long accountId)\n        throws InstanceNotFoundException;\n    public void update(Connection connection, Account account)\n        throws InstanceNotFoundException;\n    public void transfer(Long sourceAccountId, Long targetAccountId,\n        BigDecimal amount);\n}\n```",
+    options: [
+      "a) La operaci\u00f3n `transfer` del DAO debe implementarse en t\u00e9rminos de `find` (para recuperar la cuenta origen y la cuenta destino) y `update` (para minorar el balance de la cuenta origen y aumentar el balance de la cuenta destino).",
+      "b) En la operaci\u00f3n `transfer` del DAO falta el par\u00e1metro `Connection`, as\u00ed como especificar excepciones para el caso en el que la cuenta origen no tenga suficiente saldo o que alguna cuenta no exista.",
+      "c) Todas las anteriores.",
+      "d) Ninguna de las anteriores.",
+    ],
     correctAnswer: "b", // Placeholder
   },
   {
@@ -77,8 +119,14 @@ export const questions: Question[] = [
     topic: "general",
     type: "mc",
     points: 1,
-    question: "\u00bfQu\u00e9 puede decir con respecto a este c\u00f3digo?\n```java\npublic ... buyMovie(Long movieId, ...) throws ... {\n    ...\n    try (Connection connection = ...) {\n        ...\n        Movie movie = movieDao.find(connection, movieId);\n        Sale sale = saleDao.create(connection, new Sale(...));\n        ...\n    } catch (...) {\n        ...\n    }\n}\n```",
-    options: ["a) Corresponde a la capa L\u00f3gica de Negocio.", "b) Corresponde a la capa Acceso a Datos.", "c) Corresponde a la capa Servicios Thrift.", "d) Corresponde a la capa Acceso a Servicios."],
+    question:
+      "\u00bfQu\u00e9 puede decir con respecto a este c\u00f3digo?\n```java\npublic ... buyMovie(Long movieId, ...) throws ... {\n    ...\n    try (Connection connection = ...) {\n        ...\n        Movie movie = movieDao.find(connection, movieId);\n        Sale sale = saleDao.create(connection, new Sale(...));\n        ...\n    } catch (...) {\n        ...\n    }\n}\n```",
+    options: [
+      "a) Corresponde a la capa L\u00f3gica de Negocio.",
+      "b) Corresponde a la capa Acceso a Datos.",
+      "c) Corresponde a la capa Servicios Thrift.",
+      "d) Corresponde a la capa Acceso a Servicios.",
+    ],
     correctAnswer: "a", // Placeholder
   },
   {
@@ -87,8 +135,14 @@ export const questions: Question[] = [
     topic: "general",
     type: "mc",
     points: 1,
-    question: "En base al enfoque aconsejado en la asignatura para la realizaci\u00f3n de pruebas de integraci\u00f3n, indique la afirmaci\u00f3n correcta:",
-    options: ["a) Durante la ejecuci\u00f3n de las pruebas se utiliza el `DataSource` proporcionado por Jetty, al que se accede por JNDI.", "b) Durante la ejecuci\u00f3n de las pruebas se utiliza el `DataSource` proporcionado por Tomcat, al que se accede por JNDI.", "c) Durante la ejecuci\u00f3n de las pruebas es posible utilizar el `DataSource` proporcionado por Jetty o por Tomcat, a los que se accede por JNDI, dependiendo del valor de una propiedad del fichero de configuraci\u00f3n `ConfigurationParameters.properties` presente en `src/test/resources`.", "d) Ninguna de las anteriores."],
+    question:
+      "En base al enfoque aconsejado en la asignatura para la realizaci\u00f3n de pruebas de integraci\u00f3n, indique la afirmaci\u00f3n correcta:",
+    options: [
+      "a) Durante la ejecuci\u00f3n de las pruebas se utiliza el `DataSource` proporcionado por Jetty, al que se accede por JNDI.",
+      "b) Durante la ejecuci\u00f3n de las pruebas se utiliza el `DataSource` proporcionado por Tomcat, al que se accede por JNDI.",
+      "c) Durante la ejecuci\u00f3n de las pruebas es posible utilizar el `DataSource` proporcionado por Jetty o por Tomcat, a los que se accede por JNDI, dependiendo del valor de una propiedad del fichero de configuraci\u00f3n `ConfigurationParameters.properties` presente en `src/test/resources`.",
+      "d) Ninguna de las anteriores.",
+    ],
     correctAnswer: "d", // Placeholder
   },
   {
@@ -97,8 +151,14 @@ export const questions: Question[] = [
     topic: "general",
     type: "mc",
     points: 1,
-    question: "Dado el siguiente fragmento de c\u00f3digo correspondiente a un m\u00e9todo de una clase de pruebas de integraci\u00f3n de la capa Modelo, implementada con JUnit 5, indique qu\u00e9 afirmaci\u00f3n es correcta:\n```java\n@Test\npublic void testRemoveElement() throws InputValidationException, InstanceNotFoundException {\n    // Fragmento de c\u00f3digo 1\n    ...\n    assertThrows(ElementNotRemovableException.class, () -> {\n        // Fragmento de c\u00f3digo 2\n        ...\n    });\n    // Fragmento de c\u00f3digo 3\n    ...\n}\n```",
-    options: ["a) Se corresponde con un test que se ejecutar\u00e1 correctamente si durante la ejecuci\u00f3n del fragmento de c\u00f3digo 2 se lanza la excepci\u00f3n `ElementNotRemovableException` y NO es capturada por el c\u00f3digo de ese fragmento.", "b) Se corresponde con un test que se ejecutar\u00e1 correctamente si durante su ejecuci\u00f3n se lanza cualquiera de las excepciones declaradas en su cl\u00e1usula `throws` y NO es capturada por el c\u00f3digo del m\u00e9todo.", "c) Todas las anteriores.", "d) Ninguna de las anteriores."],
+    question:
+      "Dado el siguiente fragmento de c\u00f3digo correspondiente a un m\u00e9todo de una clase de pruebas de integraci\u00f3n de la capa Modelo, implementada con JUnit 5, indique qu\u00e9 afirmaci\u00f3n es correcta:\n```java\n@Test\npublic void testRemoveElement() throws InputValidationException, InstanceNotFoundException {\n    // Fragmento de c\u00f3digo 1\n    ...\n    assertThrows(ElementNotRemovableException.class, () -> {\n        // Fragmento de c\u00f3digo 2\n        ...\n    });\n    // Fragmento de c\u00f3digo 3\n    ...\n}\n```",
+    options: [
+      "a) Se corresponde con un test que se ejecutar\u00e1 correctamente si durante la ejecuci\u00f3n del fragmento de c\u00f3digo 2 se lanza la excepci\u00f3n `ElementNotRemovableException` y NO es capturada por el c\u00f3digo de ese fragmento.",
+      "b) Se corresponde con un test que se ejecutar\u00e1 correctamente si durante su ejecuci\u00f3n se lanza cualquiera de las excepciones declaradas en su cl\u00e1usula `throws` y NO es capturada por el c\u00f3digo del m\u00e9todo.",
+      "c) Todas las anteriores.",
+      "d) Ninguna de las anteriores.",
+    ],
     correctAnswer: "a", // Placeholder
   },
   {
@@ -107,8 +167,14 @@ export const questions: Question[] = [
     topic: "general",
     type: "mc",
     points: 1,
-    question: "Asumiendo las convenciones de nombrado utilizadas en la asignatura, \u00bfqu\u00e9 puede decir con respecto al m\u00e9todo `toClientMovieDto`?\n```java\nprivate static ClientMovieDto toClientMovieDto(JsonNode movieNode)\n    throws ParsingException {\n    if (movieNode.getNodeType() != JsonNodeType.OBJECT) {\n        throw new ParsingException(\"Unrecognized JSON (object expected)\");\n    } else {\n        ObjectNode movieObject = (ObjectNode) movieNode;\n        JsonNode movieIdNode = movieObject.get(\"movieId\");\n        Long movieId = (movieIdNode != null) ? movieIdNode.longValue() : null;\n        ...\n        return new ClientMovieDto(movieId, ...);\n    }\n}\n```",
-    options: ["a) Convierte un DTO (Data Transfer Object) utilizado en la capa Servicios, a un objeto de la capa Modelo.", "b) Convierte un \u00e1rbol Jackson (recibe su nodo ra\u00edz) a un DTO utilizado en la capa Acceso a Servicios.", "c) Convierte un DTO (Data Transfer Object) utilizado en la capa Acceso a Servicios, a un \u00e1rbol Jackson (devuelve el nodo ra\u00edz del \u00e1rbol).", "d) Convierte un \u00e1rbol Jackson (recibe su nodo ra\u00edz) a un DTO utilizado en la capa Modelo."],
+    question:
+      'Asumiendo las convenciones de nombrado utilizadas en la asignatura, \u00bfqu\u00e9 puede decir con respecto al m\u00e9todo `toClientMovieDto`?\n```java\nprivate static ClientMovieDto toClientMovieDto(JsonNode movieNode)\n    throws ParsingException {\n    if (movieNode.getNodeType() != JsonNodeType.OBJECT) {\n        throw new ParsingException("Unrecognized JSON (object expected)");\n    } else {\n        ObjectNode movieObject = (ObjectNode) movieNode;\n        JsonNode movieIdNode = movieObject.get("movieId");\n        Long movieId = (movieIdNode != null) ? movieIdNode.longValue() : null;\n        ...\n        return new ClientMovieDto(movieId, ...);\n    }\n}\n```',
+    options: [
+      "a) Convierte un DTO (Data Transfer Object) utilizado en la capa Servicios, a un objeto de la capa Modelo.",
+      "b) Convierte un \u00e1rbol Jackson (recibe su nodo ra\u00edz) a un DTO utilizado en la capa Acceso a Servicios.",
+      "c) Convierte un DTO (Data Transfer Object) utilizado en la capa Acceso a Servicios, a un \u00e1rbol Jackson (devuelve el nodo ra\u00edz del \u00e1rbol).",
+      "d) Convierte un \u00e1rbol Jackson (recibe su nodo ra\u00edz) a un DTO utilizado en la capa Modelo.",
+    ],
     correctAnswer: "b", // Placeholder
   },
   {
@@ -117,8 +183,14 @@ export const questions: Question[] = [
     topic: "general",
     type: "mc",
     points: 1,
-    question: "Suponga que est\u00e1 dise\u00f1ando un Servicio Web seg\u00fan el enfoque REST estudiado en la asignatura y ya existe una funcionalidad que permite dar de alta un libro en un repositorio. Suponga que ahora desea modelar una funcionalidad que permite reemplazar la representaci\u00f3n de un libro en el repositorio. \u00bfQu\u00e9 opci\u00f3n escoger\u00eda?",
-    options: ["a) El servicio permitir\u00e1 reemplazar la representaci\u00f3n de un libro invocando el URL del recurso individual libro (e.g. `http://www.servicename.com/books/123`) con el m\u00e9todo POST e incluyendo los nuevos datos del libro en un documento JSON incluido en el cuerpo de la petici\u00f3n.", "b) El servicio permitir\u00e1 reemplazar la representaci\u00f3n de un libro invocando el URL del recurso colecci\u00f3n libros (e.g. `http://www.servicename.com/books/`) con el m\u00e9todo POST e incluyendo el identificador y los nuevos datos del libro en un documento JSON incluido en el cuerpo de la petici\u00f3n.", "c) El servicio permitir\u00e1 reemplazar la representaci\u00f3n de un libro invocando el URL del recurso individual libro (e.g. `http://www.servicename.com/books/123`) con el m\u00e9todo PUT e incluyendo los nuevos datos del libro en un documento JSON incluido en el cuerpo de la petici\u00f3n.", "d) El servicio permitir\u00e1 reemplazar la representaci\u00f3n de un libro invocando el URL del recurso colecci\u00f3n libros (e.g. `http://www.servicename.com/books/`) con el m\u00e9todo PUT e incluyendo el identificador y los nuevos datos del libro en un documento JSON incluido en el cuerpo de la petici\u00f3n."],
+    question:
+      "Suponga que est\u00e1 dise\u00f1ando un Servicio Web seg\u00fan el enfoque REST estudiado en la asignatura y ya existe una funcionalidad que permite dar de alta un libro en un repositorio. Suponga que ahora desea modelar una funcionalidad que permite reemplazar la representaci\u00f3n de un libro en el repositorio. \u00bfQu\u00e9 opci\u00f3n escoger\u00eda?",
+    options: [
+      "a) El servicio permitir\u00e1 reemplazar la representaci\u00f3n de un libro invocando el URL del recurso individual libro (e.g. `http://www.servicename.com/books/123`) con el m\u00e9todo POST e incluyendo los nuevos datos del libro en un documento JSON incluido en el cuerpo de la petici\u00f3n.",
+      "b) El servicio permitir\u00e1 reemplazar la representaci\u00f3n de un libro invocando el URL del recurso colecci\u00f3n libros (e.g. `http://www.servicename.com/books/`) con el m\u00e9todo POST e incluyendo el identificador y los nuevos datos del libro en un documento JSON incluido en el cuerpo de la petici\u00f3n.",
+      "c) El servicio permitir\u00e1 reemplazar la representaci\u00f3n de un libro invocando el URL del recurso individual libro (e.g. `http://www.servicename.com/books/123`) con el m\u00e9todo PUT e incluyendo los nuevos datos del libro en un documento JSON incluido en el cuerpo de la petici\u00f3n.",
+      "d) El servicio permitir\u00e1 reemplazar la representaci\u00f3n de un libro invocando el URL del recurso colecci\u00f3n libros (e.g. `http://www.servicename.com/books/`) con el m\u00e9todo PUT e incluyendo el identificador y los nuevos datos del libro en un documento JSON incluido en el cuerpo de la petici\u00f3n.",
+    ],
     correctAnswer: "c", // Placeholder
   },
   {
@@ -127,8 +199,14 @@ export const questions: Question[] = [
     topic: "general",
     type: "mc",
     points: 1,
-    question: "Suponga que est\u00e1 dise\u00f1ando un Servicio Web seg\u00fan el enfoque REST. Teniendo en cuenta las convenciones seguidas en la asignatura, \u00bfqu\u00e9 opci\u00f3n le parece m\u00e1s adecuada para la respuesta a una petici\u00f3n que falle debido a que la base de datos no est\u00e1 accesible en ese momento?",
-    options: ["a) En la respuesta HTTP se indicar\u00e1 el c\u00f3digo de respuesta `200 OK` para indicar que el servidor entendi\u00f3 correctamente la petici\u00f3n y que el fallo es por causas ajenas a \u00e9l.", "b) En la respuesta HTTP se indicar\u00e1 el c\u00f3digo de respuesta `400 Bad Request` para indicar que la petici\u00f3n es incorrecta.", "c) En la respuesta HTTP se indicar\u00e1 el c\u00f3digo de respuesta `500 Internal Error` para indicar que la petici\u00f3n fall\u00f3 debido a un error interno.", "d) En la respuesta HTTP se indicar\u00e1 el c\u00f3digo `404 Not Found` para indicar que no se encontr\u00f3 la base de datos."],
+    question:
+      "Suponga que est\u00e1 dise\u00f1ando un Servicio Web seg\u00fan el enfoque REST. Teniendo en cuenta las convenciones seguidas en la asignatura, \u00bfqu\u00e9 opci\u00f3n le parece m\u00e1s adecuada para la respuesta a una petici\u00f3n que falle debido a que la base de datos no est\u00e1 accesible en ese momento?",
+    options: [
+      "a) En la respuesta HTTP se indicar\u00e1 el c\u00f3digo de respuesta `200 OK` para indicar que el servidor entendi\u00f3 correctamente la petici\u00f3n y que el fallo es por causas ajenas a \u00e9l.",
+      "b) En la respuesta HTTP se indicar\u00e1 el c\u00f3digo de respuesta `400 Bad Request` para indicar que la petici\u00f3n es incorrecta.",
+      "c) En la respuesta HTTP se indicar\u00e1 el c\u00f3digo de respuesta `500 Internal Error` para indicar que la petici\u00f3n fall\u00f3 debido a un error interno.",
+      "d) En la respuesta HTTP se indicar\u00e1 el c\u00f3digo `404 Not Found` para indicar que no se encontr\u00f3 la base de datos.",
+    ],
     correctAnswer: "c", // Placeholder
   },
   {
@@ -137,8 +215,14 @@ export const questions: Question[] = [
     topic: "general",
     type: "mc",
     points: 1,
-    question: "En el contexto de Servicios Web REST, suponga un intermediario gen\u00e9rico capaz de reintentar peticiones a servicios web REST que han devuelto c\u00f3digos de respuesta de error. Considerando las convenciones vistas en la asignatura y que 500 es un error temporal, diga qu\u00e9 afirmaci\u00f3n es correcta:",
-    options: ["a) El intermediario NO reintentar\u00e1 una petici\u00f3n `POST http://www.servicename.com/books/1234` que ha devuelto el c\u00f3digo de respuesta `500 Internal Error`.", "b) El intermediario NO reintentar\u00e1 una petici\u00f3n `GET http://www.servicename.com/books/1234` que ha devuelto el c\u00f3digo de respuesta `500 Internal Error`.", "c) El intermediario NO reintentar\u00e1 una petici\u00f3n `PUT http://www.servicename.com/books/1234` que ha devuelto el c\u00f3digo de respuesta `500 Internal Error`.", "d) El intermediario NO reintentar\u00e1 una petici\u00f3n `DELETE http://www.servicename.com/books/1234` que ha devuelto el c\u00f3digo de respuesta `500 Internal Error`."],
+    question:
+      "En el contexto de Servicios Web REST, suponga un intermediario gen\u00e9rico capaz de reintentar peticiones a servicios web REST que han devuelto c\u00f3digos de respuesta de error. Considerando las convenciones vistas en la asignatura y que 500 es un error temporal, diga qu\u00e9 afirmaci\u00f3n es correcta:",
+    options: [
+      "a) El intermediario NO reintentar\u00e1 una petici\u00f3n `POST http://www.servicename.com/books/1234` que ha devuelto el c\u00f3digo de respuesta `500 Internal Error`.",
+      "b) El intermediario NO reintentar\u00e1 una petici\u00f3n `GET http://www.servicename.com/books/1234` que ha devuelto el c\u00f3digo de respuesta `500 Internal Error`.",
+      "c) El intermediario NO reintentar\u00e1 una petici\u00f3n `PUT http://www.servicename.com/books/1234` que ha devuelto el c\u00f3digo de respuesta `500 Internal Error`.",
+      "d) El intermediario NO reintentar\u00e1 una petici\u00f3n `DELETE http://www.servicename.com/books/1234` que ha devuelto el c\u00f3digo de respuesta `500 Internal Error`.",
+    ],
     correctAnswer: "a", // Placeholder
   },
   {
@@ -147,8 +231,14 @@ export const questions: Question[] = [
     topic: "general",
     type: "mc",
     points: 1,
-    question: "Considere el siguiente fragmento de c\u00f3digo e indique la respuesta correcta (asuma que `validateStatusCode` es el m\u00e9todo que se utiliza en los ejemplos de la asignatura con el mismo nombre):\n```java\nClassicHttpResponse response = (ClassicHttpResponse)\n    Request.delete(getEndpointAddress() + \"resources/\" + resourceId).\n        execute().returnResponse();\n\nvalidateStatusCode(HttpStatus.SC_NO_CONTENT, response);\n```",
-    options: ["a) Es un fragmento de un m\u00e9todo de la capa Acceso a Servicios de una aplicaci\u00f3n cliente que realiza una petici\u00f3n HTTP DELETE incluyendo el identificador del recurso a eliminar en el cuerpo de la petici\u00f3n y espera recibir una respuesta HTTP que no devuelva ning\u00fan c\u00f3digo de estado (`HttpStatus.SC_NO_CONTENT`).", "b) Es un fragmento de un m\u00e9todo de la capa Acceso a Servicios de una aplicaci\u00f3n cliente que realiza una petici\u00f3n HTTP DELETE que no incluye nada en su cuerpo y espera recibir una respuesta HTTP que tampoco incluya nada en su cuerpo (`HttpStatus.SC_NO_CONTENT`).", "c) Es un fragmento de un Servlet de la capa Servicios REST que procesa una petici\u00f3n DELETE y env\u00eda un c\u00f3digo de respuesta 204 (`HttpStatus.SC_NO_CONTENT`) para indicar que no devuelve nada en el cuerpo de la respuesta.", "d) Es un fragmento de un Servlet de la capa Servicios REST que procesa una petici\u00f3n DELETE cuyo cuerpo debe estar vac\u00edo (`HttpStatus.SC_NO_CONTENT`) para que se procese correctamente."],
+    question:
+      'Considere el siguiente fragmento de c\u00f3digo e indique la respuesta correcta (asuma que `validateStatusCode` es el m\u00e9todo que se utiliza en los ejemplos de la asignatura con el mismo nombre):\n```java\nClassicHttpResponse response = (ClassicHttpResponse)\n    Request.delete(getEndpointAddress() + "resources/" + resourceId).\n        execute().returnResponse();\n\nvalidateStatusCode(HttpStatus.SC_NO_CONTENT, response);\n```',
+    options: [
+      "a) Es un fragmento de un m\u00e9todo de la capa Acceso a Servicios de una aplicaci\u00f3n cliente que realiza una petici\u00f3n HTTP DELETE incluyendo el identificador del recurso a eliminar en el cuerpo de la petici\u00f3n y espera recibir una respuesta HTTP que no devuelva ning\u00fan c\u00f3digo de estado (`HttpStatus.SC_NO_CONTENT`).",
+      "b) Es un fragmento de un m\u00e9todo de la capa Acceso a Servicios de una aplicaci\u00f3n cliente que realiza una petici\u00f3n HTTP DELETE que no incluye nada en su cuerpo y espera recibir una respuesta HTTP que tampoco incluya nada en su cuerpo (`HttpStatus.SC_NO_CONTENT`).",
+      "c) Es un fragmento de un Servlet de la capa Servicios REST que procesa una petici\u00f3n DELETE y env\u00eda un c\u00f3digo de respuesta 204 (`HttpStatus.SC_NO_CONTENT`) para indicar que no devuelve nada en el cuerpo de la respuesta.",
+      "d) Es un fragmento de un Servlet de la capa Servicios REST que procesa una petici\u00f3n DELETE cuyo cuerpo debe estar vac\u00edo (`HttpStatus.SC_NO_CONTENT`) para que se procese correctamente.",
+    ],
     correctAnswer: "b", // Placeholder
   },
   {
@@ -157,8 +247,14 @@ export const questions: Question[] = [
     topic: "general",
     type: "mc",
     points: 1,
-    question: "Asumiendo que utilizamos la clase `es.udc.ws.util.servlet.RestHttpServletTemplate` del subproyecto de utilidades de los ejemplos de la asignatura (`ws-util`), indique la afirmaci\u00f3n INCORRECTA:",
-    options: ["a) Si queremos implementar un servlet que responda a peticiones GET y POST, tendremos que crear una clase que herede de `RestHttpServletTemplate` y redefinir los m\u00e9todos `processGet` y `processPost`.", "b) Los servlets que heredan de `RestHttpServletTemplate` no tienen que preocuparse de tratar las excepciones del m\u00f3dulo `ws-util` (`InstanceNotFoundException`, `InputValidationException` y `ParsingException`) al procesar cualquier petici\u00f3n.", "c) No hay que declarar en el fichero `web.xml` los servlets que heredan de `RestHttpServletTemplate`, puesto que ya est\u00e1 declarada su superclase.", "d) Si un servlet hereda de `RestHttpServletTemplate` y no se desea que procese peticiones DELETE, no es necesario redefinir el m\u00e9todo `processDelete`, puesto que la implementaci\u00f3n por defecto de `processDelete` en `RestHttpServletTemplate` devuelve un c\u00f3digo de respuesta indicando que esa operaci\u00f3n no est\u00e1 implementada."],
+    question:
+      "Asumiendo que utilizamos la clase `es.udc.ws.util.servlet.RestHttpServletTemplate` del subproyecto de utilidades de los ejemplos de la asignatura (`ws-util`), indique la afirmaci\u00f3n INCORRECTA:",
+    options: [
+      "a) Si queremos implementar un servlet que responda a peticiones GET y POST, tendremos que crear una clase que herede de `RestHttpServletTemplate` y redefinir los m\u00e9todos `processGet` y `processPost`.",
+      "b) Los servlets que heredan de `RestHttpServletTemplate` no tienen que preocuparse de tratar las excepciones del m\u00f3dulo `ws-util` (`InstanceNotFoundException`, `InputValidationException` y `ParsingException`) al procesar cualquier petici\u00f3n.",
+      "c) No hay que declarar en el fichero `web.xml` los servlets que heredan de `RestHttpServletTemplate`, puesto que ya est\u00e1 declarada su superclase.",
+      "d) Si un servlet hereda de `RestHttpServletTemplate` y no se desea que procese peticiones DELETE, no es necesario redefinir el m\u00e9todo `processDelete`, puesto que la implementaci\u00f3n por defecto de `processDelete` en `RestHttpServletTemplate` devuelve un c\u00f3digo de respuesta indicando que esa operaci\u00f3n no est\u00e1 implementada.",
+    ],
     correctAnswer: "c", // Placeholder
   },
   {
@@ -167,8 +263,14 @@ export const questions: Question[] = [
     topic: "general",
     type: "mc",
     points: 1,
-    question: "En el modelo de programaci\u00f3n RPC (Remote Procedure Call), indique cu\u00e1l de las siguientes afirmaciones es correcta:",
-    options: ["a) El programador de la aplicaci\u00f3n servidora modela su funcionalidad a trav\u00e9s de un conjunto de operaciones est\u00e1ndar (operaciones que no son ad hoc).", "b) Las aplicaciones cliente y servidora tienen que escribirse en el mismo lenguaje de programaci\u00f3n.", "c) En cuanto a rendimiento, la invocaci\u00f3n de una operaci\u00f3n remota es similar a la invocaci\u00f3n de un m\u00e9todo de una librer\u00eda local.", "d) Cambios en la implementaci\u00f3n del servidor no obligan a regenerar el stub si no cambia nada en la interfaz del servicio."],
+    question:
+      "En el modelo de programaci\u00f3n RPC (Remote Procedure Call), indique cu\u00e1l de las siguientes afirmaciones es correcta:",
+    options: [
+      "a) El programador de la aplicaci\u00f3n servidora modela su funcionalidad a trav\u00e9s de un conjunto de operaciones est\u00e1ndar (operaciones que no son ad hoc).",
+      "b) Las aplicaciones cliente y servidora tienen que escribirse en el mismo lenguaje de programaci\u00f3n.",
+      "c) En cuanto a rendimiento, la invocaci\u00f3n de una operaci\u00f3n remota es similar a la invocaci\u00f3n de un m\u00e9todo de una librer\u00eda local.",
+      "d) Cambios en la implementaci\u00f3n del servidor no obligan a regenerar el stub si no cambia nada en la interfaz del servicio.",
+    ],
     correctAnswer: "d", // Placeholder
   },
   {
@@ -177,8 +279,14 @@ export const questions: Question[] = [
     topic: "general",
     type: "mc",
     points: 1,
-    question: "Considere el siguiente fichero de definici\u00f3n de Apache Thrift, en el que se pretende declarar un servicio con una operaci\u00f3n, e indique la afirmaci\u00f3n correcta:\n```thrift\nnamespace java es.udc.ws.movies.thrift\n\nstruct ThriftMovieDto {\n    1: i64 movieId\n    2: string title\n}\n\nstruct ThriftInputValidationException {\n    1: string message\n}\n\nThriftMovieDto addMovie(1: ThriftMovieDto movieDto)\n    throws (1: ThriftInputValidationException e)\n```",
-    options: ["a) La operaci\u00f3n `addMovie` debe definirse dentro de un servicio (usando la palabra reservada `service`).", "b) El par\u00e1metro de la operaci\u00f3n `addMovie` no puede ser de tipo `ThriftMovieDto`.", "c) El tipo `ThriftInputValidationException` debe definirse con la palabra reservada `exception` (en lugar de `struct`).", "d) La a) y la c) son correctas."],
+    question:
+      "Considere el siguiente fichero de definici\u00f3n de Apache Thrift, en el que se pretende declarar un servicio con una operaci\u00f3n, e indique la afirmaci\u00f3n correcta:\n```thrift\nnamespace java es.udc.ws.movies.thrift\n\nstruct ThriftMovieDto {\n    1: i64 movieId\n    2: string title\n}\n\nstruct ThriftInputValidationException {\n    1: string message\n}\n\nThriftMovieDto addMovie(1: ThriftMovieDto movieDto)\n    throws (1: ThriftInputValidationException e)\n```",
+    options: [
+      "a) La operaci\u00f3n `addMovie` debe definirse dentro de un servicio (usando la palabra reservada `service`).",
+      "b) El par\u00e1metro de la operaci\u00f3n `addMovie` no puede ser de tipo `ThriftMovieDto`.",
+      "c) El tipo `ThriftInputValidationException` debe definirse con la palabra reservada `exception` (en lugar de `struct`).",
+      "d) La a) y la c) son correctas.",
+    ],
     correctAnswer: "d", // Placeholder
   },
 ];

--- a/src/theme/context-value.ts
+++ b/src/theme/context-value.ts
@@ -1,0 +1,14 @@
+import { createContext } from "react";
+import type { Theme } from "./types";
+
+export interface ThemeContextType {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  cycleTheme: () => void;
+}
+
+export const ThemeContext = createContext<ThemeContextType>({
+  theme: "system",
+  setTheme: () => {},
+  cycleTheme: () => {},
+});

--- a/src/theme/context.tsx
+++ b/src/theme/context.tsx
@@ -5,6 +5,7 @@ import {
   useCallback,
   useMemo,
   useEffect,
+  startTransition,
   type ReactNode,
 } from "react";
 import type { Theme } from "./types";
@@ -81,7 +82,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       setThemeState(applyTheme(next));
       return;
     }
-    document.startViewTransition(() => {
+    startTransition(() => {
       setThemeState(applyTheme(next));
     });
   }, []);

--- a/src/theme/context.tsx
+++ b/src/theme/context.tsx
@@ -1,6 +1,4 @@
-/* eslint-disable react-refresh/only-export-components */
 import {
-  createContext,
   useState,
   useCallback,
   useMemo,
@@ -10,18 +8,7 @@ import {
 } from "react";
 import type { Theme } from "./types";
 import { themeOrder } from "./types";
-
-export interface ThemeContextType {
-  theme: Theme;
-  setTheme: (theme: Theme) => void;
-  cycleTheme: () => void;
-}
-
-export const ThemeContext = createContext<ThemeContextType>({
-  theme: "system",
-  setTheme: () => {},
-  cycleTheme: () => {},
-});
+import { ThemeContext } from "./context-value";
 
 function getInitialTheme(): Theme {
   try {

--- a/src/theme/hooks.ts
+++ b/src/theme/hooks.ts
@@ -1,5 +1,5 @@
 import { use } from "react";
-import { ThemeContext } from "./context";
+import { ThemeContext } from "./context-value";
 
 export function useTheme() {
   return use(ThemeContext);

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -1,19 +1,11 @@
-export const themes = [
+export const themeOrder = [
   "system",
   "light",
   "dark",
   "pink",
   "catppuccin",
 ] as const;
-export type Theme = (typeof themes)[number];
-
-export const themeOrder: Theme[] = [
-  "system",
-  "light",
-  "dark",
-  "pink",
-  "catppuccin",
-];
+export type Theme = (typeof themeOrder)[number];
 
 export const themeLabels: Record<Theme, string> = {
   system: "System",


### PR DESCRIPTION
## Summary

Fixes two rounds of lint warnings across the codebase.

### Round 1 — React Review (13 files, 36 issues)
- **unused-export**: Removed `trackPageView` from umami.ts, consolidated `themes`/themeOrder in types.ts
- **design-no-bold-heading**: Changed `font-bold` → `font-semibold` on all headings
- **design-no-redundant-size-axes**: Used `size-N` shorthand for matching w-N h-N classes
- **no-array-index-key**: Stable composite keys for table rows/cells
- **js-flatmap-filter**: Replaced `.map().filter(Boolean)` with `.flatMap()`
- **control-has-associated-label**: Added `aria-label` to textarea
- **no-document-start-view-transition**: Replaced `document.startViewTransition()` with React's `startTransition()`
- **no-cascading-set-state**: Consolidated DOM meta/link operations into data-driven loops

### Round 2 — React Doctor (15 files, 8 issues → 100/100 score)
- **only-export-components**: Split non-component exports from component files (contexts, utility functions, hooks) into sibling files
- **no-giant-component**: Extracted subcomponents (`ExamStartScreen`, `ExamPlayer`, `PracticePlayer`) from large page components
- **prefer-useReducer**: Grouped related quiz state into `useExamSession` / `usePracticeSession` hooks with `useReducer`, and combined nav state into single object