### PR TITLE
feat(analytics): improve Umami event tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,6 +61,7 @@
       data-website-id="63168f0e-a1cf-4ec6-a0c4-58fc7d57a0f4"
       data-performance="true"
       data-domains="pe.pablopl.dev"
+      data-do-not-track="true"
     ></script>
     <script
       defer

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,7 +47,8 @@ function SessionTracker() {
   const { theme } = useTheme();
 
   useEffect(() => {
-    identify({ id: getDistinctId() });
+    const id = getDistinctId();
+    if (id) identify({ id });
   }, []);
 
   useEffect(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ import Header from "./components/Header";
 import StarPopup from "./components/StarPopup";
 import { useLang, useT } from "./i18n/hooks";
 import type { Lang } from "./i18n/context";
-import { track, identify } from "./lib/umami";
+import { track, identify, setSessionData, getDistinctId } from "./lib/umami";
 import { buildLangPath } from "./lib/lang-link-utils";
 import { useTheme } from "./theme/hooks";
 
@@ -47,7 +47,11 @@ function SessionTracker() {
   const { theme } = useTheme();
 
   useEffect(() => {
-    identify({ lang, theme });
+    identify({ id: getDistinctId() });
+  }, []);
+
+  useEffect(() => {
+    setSessionData({ lang, theme });
   }, [lang, theme]);
 
   return null;

--- a/src/components/AddExamModal.tsx
+++ b/src/components/AddExamModal.tsx
@@ -52,7 +52,11 @@ function AddExamModal({
       className="animate-dialog m-auto max-w-sm rounded-2xl bg-surface-alt p-6 shadow-2xl backdrop:bg-black/50 backdrop:transition-[background-color,overlay,display] backdrop:duration-200"
       aria-labelledby="add-exam-title"
       onClose={() => {
-        track("add_exam_modal_close", { subjectId });
+        track("modal_close", {
+          modal: "add_exam",
+          method: "backdrop",
+          subjectId,
+        });
       }}
     >
       <div>
@@ -63,7 +67,7 @@ function AddExamModal({
           <button
             type="button"
             onClick={() => {
-              track("add_exam_modal_close_btn", { subjectId });
+              track("modal_close", { modal: "add_exam", method: "x", subjectId });
               dialogRef.current?.close();
             }}
             className="text-fg-muted hover:text-fg-secondary transition-colors cursor-pointer"

--- a/src/components/AddExamModal.tsx
+++ b/src/components/AddExamModal.tsx
@@ -22,6 +22,7 @@ function AddExamModal({
 }: AddExamModalProps) {
   const t = useT();
   const dialogRef = useRef<HTMLDialogElement>(null);
+  const closeMethodRef = useRef<"x" | "backdrop" | "esc">("backdrop");
 
   useImperativeHandle(ref, () => ({
     open: () => dialogRef.current?.showModal(),
@@ -32,17 +33,22 @@ function AddExamModal({
     const dialog = dialogRef.current;
     if (!dialog) return;
 
-    const handleClose = () => onClose();
     const handleBackdropClick = (e: MouseEvent) => {
-      if (e.target === dialog) dialog.close();
+      if (e.target === dialog) {
+        closeMethodRef.current = "backdrop";
+        dialog.close();
+      }
     };
-    dialog.addEventListener("close", handleClose);
+    const handleCancel = () => {
+      closeMethodRef.current = "esc";
+    };
     dialog.addEventListener("click", handleBackdropClick);
+    dialog.addEventListener("cancel", handleCancel);
     return () => {
-      dialog.removeEventListener("close", handleClose);
       dialog.removeEventListener("click", handleBackdropClick);
+      dialog.removeEventListener("cancel", handleCancel);
     };
-  }, [onClose]);
+  }, []);
 
   const issueUrl = `${t.addExam.openIssueUrl}&title=${encodeURIComponent(subjectName)}&subject=${encodeURIComponent(subjectId)}`;
 
@@ -54,9 +60,10 @@ function AddExamModal({
       onClose={() => {
         track("modal_close", {
           modal: "add_exam",
-          method: "backdrop",
+          method: closeMethodRef.current,
           subjectId,
         });
+        onClose();
       }}
     >
       <div>
@@ -67,7 +74,7 @@ function AddExamModal({
           <button
             type="button"
             onClick={() => {
-              track("modal_close", { modal: "add_exam", method: "x", subjectId });
+              closeMethodRef.current = "x";
               dialogRef.current?.close();
             }}
             className="text-fg-muted hover:text-fg-secondary transition-colors cursor-pointer"

--- a/src/components/AddSubjectModal.tsx
+++ b/src/components/AddSubjectModal.tsx
@@ -43,7 +43,7 @@ function AddSubjectModal({ onClose, ref }: AddSubjectModalProps) {
       className="animate-dialog m-auto max-w-sm rounded-2xl bg-surface-alt p-6 shadow-2xl backdrop:bg-black/50 backdrop:transition-[background-color,overlay,display] backdrop:duration-200"
       aria-labelledby="add-subject-title"
       onClose={() => {
-        track("add_subject_modal_close");
+        track("modal_close", { modal: "add_subject", method: "backdrop" });
       }}
     >
       <div>
@@ -54,7 +54,7 @@ function AddSubjectModal({ onClose, ref }: AddSubjectModalProps) {
           <button
             type="button"
             onClick={() => {
-              track("add_subject_modal_close_btn");
+              track("modal_close", { modal: "add_subject", method: "x" });
               dialogRef.current?.close();
             }}
             className="text-fg-muted hover:text-fg-secondary transition-colors cursor-pointer"

--- a/src/components/AddSubjectModal.tsx
+++ b/src/components/AddSubjectModal.tsx
@@ -15,6 +15,7 @@ interface AddSubjectModalProps {
 function AddSubjectModal({ onClose, ref }: AddSubjectModalProps) {
   const t = useT();
   const dialogRef = useRef<HTMLDialogElement>(null);
+  const closeMethodRef = useRef<"x" | "backdrop" | "esc">("backdrop");
 
   useImperativeHandle(ref, () => ({
     open: () => dialogRef.current?.showModal(),
@@ -25,17 +26,22 @@ function AddSubjectModal({ onClose, ref }: AddSubjectModalProps) {
     const dialog = dialogRef.current;
     if (!dialog) return;
 
-    const handleClose = () => onClose();
     const handleBackdropClick = (e: MouseEvent) => {
-      if (e.target === dialog) dialog.close();
+      if (e.target === dialog) {
+        closeMethodRef.current = "backdrop";
+        dialog.close();
+      }
     };
-    dialog.addEventListener("close", handleClose);
+    const handleCancel = () => {
+      closeMethodRef.current = "esc";
+    };
     dialog.addEventListener("click", handleBackdropClick);
+    dialog.addEventListener("cancel", handleCancel);
     return () => {
-      dialog.removeEventListener("close", handleClose);
       dialog.removeEventListener("click", handleBackdropClick);
+      dialog.removeEventListener("cancel", handleCancel);
     };
-  }, [onClose]);
+  }, []);
 
   return (
     <dialog
@@ -43,7 +49,11 @@ function AddSubjectModal({ onClose, ref }: AddSubjectModalProps) {
       className="animate-dialog m-auto max-w-sm rounded-2xl bg-surface-alt p-6 shadow-2xl backdrop:bg-black/50 backdrop:transition-[background-color,overlay,display] backdrop:duration-200"
       aria-labelledby="add-subject-title"
       onClose={() => {
-        track("modal_close", { modal: "add_subject", method: "backdrop" });
+        track("modal_close", {
+          modal: "add_subject",
+          method: closeMethodRef.current,
+        });
+        onClose();
       }}
     >
       <div>
@@ -54,7 +64,7 @@ function AddSubjectModal({ onClose, ref }: AddSubjectModalProps) {
           <button
             type="button"
             onClick={() => {
-              track("modal_close", { modal: "add_subject", method: "x" });
+              closeMethodRef.current = "x";
               dialogRef.current?.close();
             }}
             className="text-fg-muted hover:text-fg-secondary transition-colors cursor-pointer"

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import type { Picture } from "vite-imagetools";
 import type { Question, QuestionType } from "../data/types";
 import { useT } from "../i18n/hooks";
@@ -63,6 +63,9 @@ interface QuestionCardProps {
   megatopicLabel?: string;
   examDate?: string;
   subjectId: string;
+  topicKey?: string;
+  examYear?: string;
+  mode?: "practice" | "exam";
   onAnswer: (questionId: string, answer: string) => void;
   savedAnswer?: string;
   showResult?: boolean;
@@ -96,6 +99,10 @@ function MCQuestion({
   onAnswer,
   savedAnswer,
   showResult,
+  subjectId,
+  topicKey,
+  examYear,
+  mode,
 }: QuestionCardProps) {
   const [isOpen, setIsOpen] = useState(false);
   const t = useT();
@@ -125,6 +132,10 @@ function MCQuestion({
             questionId: question.id,
             type: "mc",
             answer: selectedLetter,
+            subjectId,
+            topic: topicKey,
+            exam: examYear,
+            mode,
           });
           onAnswer(question.id, selectedLetter);
         }
@@ -133,7 +144,16 @@ function MCQuestion({
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [showResult, question.id, question.options, onAnswer]);
+  }, [
+    showResult,
+    question.id,
+    question.options,
+    onAnswer,
+    subjectId,
+    topicKey,
+    examYear,
+    mode,
+  ]);
 
   if (!question.options) return null;
 
@@ -168,6 +188,10 @@ function MCQuestion({
                 questionId: question.id,
                 type: "mc",
                 answer: letter,
+                subjectId,
+                topic: topicKey,
+                exam: examYear,
+                mode,
               });
               onAnswer(question.id, letter);
             }}
@@ -198,6 +222,10 @@ function MCQuestion({
                 track("solution_toggle", {
                   questionId: question.id,
                   action: next ? "open" : "close",
+                  subjectId,
+                  topic: topicKey,
+                  exam: examYear,
+                  mode,
                 });
                 setIsOpen(next);
               }}
@@ -235,9 +263,14 @@ function TextQuestion({
   showResult,
   selfGrade,
   onSelfGrade,
+  subjectId,
+  topicKey,
+  examYear,
+  mode,
 }: QuestionCardProps) {
   const [isOpen, setIsOpen] = useState(false);
   const t = useT();
+  const textStartedRef = useRef(false);
 
   return (
     <div>
@@ -252,7 +285,21 @@ function TextQuestion({
         autoComplete="off"
         spellCheck={false}
         value={savedAnswer || ""}
-        onChange={(e) => onAnswer(question.id, e.target.value)}
+        onChange={(e) => {
+          onAnswer(question.id, e.target.value);
+          if (!textStartedRef.current) {
+            textStartedRef.current = true;
+            track("question_answer", {
+              questionId: question.id,
+              type: "text",
+              action: "started",
+              subjectId,
+              topic: topicKey,
+              exam: examYear,
+              mode,
+            });
+          }
+        }}
         disabled={!!showResult}
       />
       {showResult && (
@@ -308,10 +355,6 @@ function TextQuestion({
                       type="button"
                       onClick={() => {
                         triggerSuccess();
-                        track("self_grade", {
-                          questionId: question.id,
-                          grade: "correct",
-                        });
                         onSelfGrade(question.id, "correct");
                       }}
                       className={`px-3 py-1.5 text-xs font-medium rounded-md border-2 active:scale-95 transition focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none ${
@@ -326,10 +369,6 @@ function TextQuestion({
                       type="button"
                       onClick={() => {
                         triggerError();
-                        track("self_grade", {
-                          questionId: question.id,
-                          grade: "incorrect",
-                        });
                         onSelfGrade(question.id, "incorrect");
                       }}
                       className={`px-3 py-1.5 text-xs font-medium rounded-md border-2 active:scale-95 transition focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:outline-none ${
@@ -356,6 +395,10 @@ function MatchingQuestion({
   onAnswer,
   savedAnswer,
   showResult,
+  subjectId,
+  topicKey,
+  examYear,
+  mode,
 }: QuestionCardProps) {
   const [isOpen, setIsOpen] = useState(false);
   const t = useT();
@@ -427,6 +470,10 @@ function MatchingQuestion({
                         type: "matching",
                         item,
                         answer: letter,
+                        subjectId,
+                        topic: topicKey,
+                        exam: examYear,
+                        mode,
                       });
                       handleSelect(item, letter);
                     }}
@@ -453,6 +500,10 @@ function MatchingQuestion({
                 track("solution_toggle", {
                   questionId: question.id,
                   action: next ? "open" : "close",
+                  subjectId,
+                  topic: topicKey,
+                  exam: examYear,
+                  mode,
                 });
                 setIsOpen(next);
               }}
@@ -598,6 +649,9 @@ export default function QuestionCard(props: QuestionCardProps) {
             track("report_issue", {
               questionId: question.id,
               subjectId: props.subjectId,
+              topic: props.topicKey,
+              exam: props.examYear,
+              mode: props.mode,
             });
           }}
         >

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -272,6 +272,10 @@ function TextQuestion({
   const t = useT();
   const textStartedRef = useRef(false);
 
+  useEffect(() => {
+    textStartedRef.current = false;
+  }, [question.id]);
+
   return (
     <div>
       <label htmlFor={`answer-${question.id}`} className="sr-only">

--- a/src/components/QuestionNavChips.tsx
+++ b/src/components/QuestionNavChips.tsx
@@ -70,15 +70,17 @@ export default function QuestionNavChips({
             className={cls}
             onClick={() => {
               triggerLight();
-              const data =
-                typeof eventData === "function" ? eventData() : eventData;
-              track(eventName, {
-                ...data,
-                direction: direction || "",
-                fromIndex: currentIndex,
-                toIndex: i,
-                source: "chip",
-              });
+              if (direction !== undefined) {
+                const data =
+                  typeof eventData === "function" ? eventData() : eventData;
+                track(eventName, {
+                  ...data,
+                  direction,
+                  fromIndex: currentIndex,
+                  toIndex: i,
+                  source: "chip",
+                });
+              }
               onSelectIndex(i, direction);
             }}
           >

--- a/src/components/QuestionNavChips.tsx
+++ b/src/components/QuestionNavChips.tsx
@@ -1,0 +1,91 @@
+import type { RefObject } from "react";
+import type { Question } from "../data/types";
+import { track } from "../lib/umami";
+import { triggerLight } from "../lib/haptics";
+
+type NavEventName = "practice_navigate" | "exam_navigate";
+
+interface QuestionNavChipsProps {
+  questions: Question[];
+  answers: Record<string, string>;
+  currentIndex: number;
+  navRef: RefObject<HTMLDivElement | null>;
+  showLeftFade: boolean;
+  showRightFade: boolean;
+  onSelectIndex: (i: number, direction: "next" | "prev" | undefined) => void;
+  eventData:
+    | Record<string, string | number | boolean | undefined | null>
+    | (() => Record<string, string | number | boolean | undefined | null>);
+  eventName: NavEventName;
+  checkedQuestions?: Record<string, boolean>;
+  dataTour?: string;
+}
+
+export default function QuestionNavChips({
+  questions,
+  answers,
+  currentIndex,
+  navRef,
+  showLeftFade,
+  showRightFade,
+  onSelectIndex,
+  eventData,
+  eventName,
+  checkedQuestions,
+  dataTour,
+}: QuestionNavChipsProps) {
+  return (
+    <div
+      ref={navRef}
+      className="flex gap-1 mb-6 overflow-x-auto pb-6"
+      data-tour={dataTour}
+      style={{
+        maskImage:
+          showLeftFade && showRightFade
+            ? "linear-gradient(to right, transparent 0%, black 8%, black 92%, transparent 100%)"
+            : showLeftFade
+              ? "linear-gradient(to right, transparent 0%, black 8%, black 100%)"
+              : showRightFade
+                ? "linear-gradient(to right, black 0%, black 92%, transparent 100%)"
+                : undefined,
+      }}
+    >
+      {questions.map((q, i) => {
+        const isAnswered = answers[q.id] && answers[q.id].trim() !== "";
+        const isChecked = !!checkedQuestions?.[q.id];
+        const isCurrent = i === currentIndex;
+        let cls =
+          "w-8 h-8 rounded-md text-xs font-mono flex items-center justify-center border shrink-0 active:scale-90 focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none transition cursor-pointer";
+        if (isCurrent) cls += " bg-accent text-white border-accent";
+        else if (isChecked) cls += " bg-blue-50 border-blue-300 text-blue-700";
+        else if (isAnswered)
+          cls += " bg-accent-light border-accent-border text-accent-fg";
+        else cls += " border-border text-fg-muted hover:border-fg-muted";
+        const direction =
+          i > currentIndex ? "next" : i < currentIndex ? "prev" : undefined;
+        return (
+          <button
+            type="button"
+            key={q.id}
+            className={cls}
+            onClick={() => {
+              triggerLight();
+              const data =
+                typeof eventData === "function" ? eventData() : eventData;
+              track(eventName, {
+                ...data,
+                direction: direction || "",
+                fromIndex: currentIndex,
+                toIndex: i,
+                source: "chip",
+              });
+              onSelectIndex(i, direction);
+            }}
+          >
+            {isChecked && !isCurrent ? "\u2713" : i + 1}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/SubjectCard.tsx
+++ b/src/components/SubjectCard.tsx
@@ -31,7 +31,7 @@ export default function SubjectCard({ subject }: SubjectCardProps) {
       className="block p-5 rounded-xl border-2 border-border hover:border-accent bg-surface-alt hover:bg-accent-light/30 hover:scale-[1.02] hover:shadow-md focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none transition-colors transition-transform duration-200"
       onClick={() => {
         triggerLight();
-        track("subject_card_click", { subjectId: subject.id });
+        track("subject_card_click", { subjectId: subject.id, location: "grid" });
         recordSubjectClick(subject.id);
       }}
     >

--- a/src/hooks/useKeyboardNav.ts
+++ b/src/hooks/useKeyboardNav.ts
@@ -1,0 +1,78 @@
+import { useEffect, type RefObject } from "react";
+import { track } from "../lib/umami";
+import { triggerLight } from "../lib/haptics";
+
+type EventData = Record<string, string | number | boolean | undefined | null>;
+
+interface KeyboardNavOpts {
+  enabledRef: RefObject<boolean>;
+  questionsLength: number;
+  currentIndexRef: RefObject<number>;
+  setCurrentIndex: (i: number) => void;
+  scrollToNav: (i: number) => void;
+  setDirection: (d: "next" | "prev" | undefined) => void;
+  eventName: "practice_navigate" | "exam_navigate";
+  eventData: () => EventData;
+}
+
+export function useKeyboardNav(opts: KeyboardNavOpts): void {
+  const {
+    enabledRef,
+    questionsLength,
+    currentIndexRef,
+    setCurrentIndex,
+    scrollToNav,
+    setDirection,
+    eventName,
+    eventData,
+  } = opts;
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const tag = document.activeElement?.tagName.toLowerCase();
+      if (tag === "input" || tag === "textarea" || tag === "select") return;
+      if (!enabledRef.current) return;
+      const idx = currentIndexRef.current;
+      if (e.key === "ArrowLeft" && idx > 0) {
+        e.preventDefault();
+        const nextIndex = idx - 1;
+        triggerLight();
+        setDirection("prev");
+        track(eventName, {
+          ...eventData(),
+          direction: "prev",
+          fromIndex: idx,
+          toIndex: nextIndex,
+          source: "keyboard",
+        });
+        setCurrentIndex(nextIndex);
+        scrollToNav(nextIndex);
+      } else if (e.key === "ArrowRight" && idx < questionsLength - 1) {
+        e.preventDefault();
+        const nextIndex = idx + 1;
+        triggerLight();
+        setDirection("next");
+        track(eventName, {
+          ...eventData(),
+          direction: "next",
+          fromIndex: idx,
+          toIndex: nextIndex,
+          source: "keyboard",
+        });
+        setCurrentIndex(nextIndex);
+        scrollToNav(nextIndex);
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [
+    enabledRef,
+    questionsLength,
+    currentIndexRef,
+    setCurrentIndex,
+    scrollToNav,
+    setDirection,
+    eventName,
+    eventData,
+  ]);
+}

--- a/src/hooks/usePracticeSession.ts
+++ b/src/hooks/usePracticeSession.ts
@@ -160,10 +160,13 @@ export function usePracticeSession(
     [subjectId, topic, questions, state.answers, state.selfGrades],
   );
 
-  const handleCheckQuestion = useCallback((questionId: string) => {
-    track("practice_check_question", { questionId });
-    dispatch({ type: "CHECK_QUESTION", questionId });
-  }, []);
+const handleCheckQuestion = useCallback(
+    (questionId: string) => {
+      track("practice_check_question", { subjectId, topic, questionId });
+      dispatch({ type: "CHECK_QUESTION", questionId });
+    },
+    [subjectId, topic],
+  );
 
   return {
     ...state,

--- a/src/lib/umami.ts
+++ b/src/lib/umami.ts
@@ -52,13 +52,17 @@ export function track(eventName: string, eventData?: UmamiData): void {
 }
 
 export function identify(data: UmamiData & { id?: string }): void {
-  safeRun(() => window.umami!.identify(clean(data) as UmamiCleanData & { id?: string }));
+  if (data.id === "") delete data.id;
+  const cleaned = clean(data) as UmamiCleanData & { id?: string };
+  if (!cleaned) return;
+  safeRun(() => window.umami!.identify(cleaned));
 }
 
 export function setSessionData(data: UmamiData): void {
   const cleaned = clean(data);
   if (!cleaned) return;
-  if (window.umami?.setSessionData) {
+  if (typeof window === "undefined" || !window.umami) return;
+  if (window.umami.setSessionData) {
     safeRun(() => window.umami!.setSessionData!(cleaned));
   } else {
     safeRun(() => window.umami!.identify(cleaned));

--- a/src/lib/umami.ts
+++ b/src/lib/umami.ts
@@ -9,24 +9,82 @@ declare global {
         eventData?: Record<string, string | number | boolean>,
       ): void;
       identify: (
-        idOrData: string | Record<string, string | number | boolean>,
+        idOrData:
+          | string
+          | (Record<string, string | number | boolean | undefined | null> & {
+              id?: string;
+            }),
         data?: Record<string, string | number | boolean>,
+      ) => void;
+      setSessionData?: (
+        data: Record<string, string | number | boolean>,
       ) => void;
     };
   }
 }
 
-export function track(
-  eventName: string,
-  eventData?: Record<string, string | number | boolean>,
-) {
-  if (typeof window !== "undefined" && window.umami) {
-    window.umami.track(eventName, eventData);
+type UmamiValue = string | number | boolean | undefined | null;
+type UmamiData = Record<string, UmamiValue>;
+type UmamiCleanData = Record<string, string | number | boolean>;
+
+function clean(data?: UmamiData): UmamiCleanData | undefined {
+  if (!data) return undefined;
+  const out: UmamiCleanData = {};
+  for (const [k, v] of Object.entries(data)) {
+    if (v === undefined || v === null) continue;
+    out[k] = v;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function safeRun(fn: () => void) {
+  if (typeof window === "undefined" || !window.umami) return;
+  try {
+    fn();
+  } catch {
+    /* analytics must never break app interactions */
   }
 }
 
-export function identify(data: Record<string, string | number | boolean>) {
-  if (typeof window !== "undefined" && window.umami) {
-    window.umami.identify(data);
+export function track(eventName: string, eventData?: UmamiData): void {
+  const cleaned = clean(eventData);
+  safeRun(() => window.umami!.track(eventName, cleaned));
+}
+
+export function identify(data: UmamiData & { id?: string }): void {
+  safeRun(() => window.umami!.identify(clean(data) as UmamiCleanData & { id?: string }));
+}
+
+export function setSessionData(data: UmamiData): void {
+  const cleaned = clean(data);
+  if (!cleaned) return;
+  if (window.umami?.setSessionData) {
+    safeRun(() => window.umami!.setSessionData!(cleaned));
+  } else {
+    safeRun(() => window.umami!.identify(cleaned));
   }
+}
+
+const UMAMI_UID_KEY = "umami_uid";
+
+export function getDistinctId(): string {
+  if (typeof localStorage === "undefined") return "";
+  let id: string;
+  try {
+    id = localStorage.getItem(UMAMI_UID_KEY) || "";
+  } catch {
+    return "";
+  }
+  if (!id) {
+    id =
+      typeof crypto !== "undefined" && crypto.randomUUID
+        ? crypto.randomUUID()
+        : `anon-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    try {
+      localStorage.setItem(UMAMI_UID_KEY, id);
+    } catch {
+      /* localStorage unavailable */
+    }
+  }
+  return id;
 }

--- a/src/pages/ExamSimulation.tsx
+++ b/src/pages/ExamSimulation.tsx
@@ -9,12 +9,14 @@ import {
 } from "../subjects";
 import type { Question, Exam } from "../data/types";
 import QuestionCard from "../components/QuestionCard";
+import QuestionNavChips from "../components/QuestionNavChips";
 import { useT } from "../i18n/hooks";
 import { track } from "../lib/umami";
 import { triggerLight } from "../lib/haptics";
 import { useDocumentTitle } from "../lib/title";
 import { useSeoHead } from "../lib/seo";
 import { useExamSession } from "../hooks/useExamSession";
+import { useKeyboardNav } from "../hooks/useKeyboardNav";
 import { startExamTour } from "../lib/tour";
 
 function formatTime(seconds: number) {
@@ -46,6 +48,13 @@ function ExamStartScreen({
         <Link
           to={`/${subject.id}`}
           className="text-sm text-accent hover:underline focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none rounded-md px-1"
+          onClick={() =>
+            track("nav_click", {
+              target: "subject_home",
+              from: "exam_start_screen",
+              subjectId: subject.id,
+            })
+          }
         >
           {t.exam.backToSubject}
         </Link>
@@ -179,8 +188,20 @@ function ExamPlayer({
         <Link
           to={`/${subject.id}`}
           onClick={(e) => {
-            if (!submitted && !window.confirm(t.exam.exitConfirm)) {
-              e.preventDefault();
+            if (!submitted) {
+              if (!window.confirm(t.exam.exitConfirm)) {
+                e.preventDefault();
+              } else {
+                const answeredCount = Object.values(answers).filter(
+                  (a) => a && a.trim() !== "",
+                ).length;
+                track("exam_abandon", {
+                  subjectId: subject.id,
+                  year: examInfo.year,
+                  answeredCount,
+                  timeLeft,
+                });
+              }
             }
           }}
           className="text-sm text-accent hover:underline focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none rounded-md px-1"
@@ -227,53 +248,22 @@ function ExamPlayer({
         </div>
       )}
 
-      <div
-        ref={navRef}
-        className="flex gap-1 mb-6 overflow-x-auto pb-6"
-        data-tour="exam-nav"
-        style={{
-          maskImage:
-            showLeftFade && showRightFade
-              ? "linear-gradient(to right, transparent 0%, black 8%, black 92%, transparent 100%)"
-              : showLeftFade
-                ? "linear-gradient(to right, transparent 0%, black 8%, black 100%)"
-                : showRightFade
-                  ? "linear-gradient(to right, black 0%, black 92%, transparent 100%)"
-                  : undefined,
+      <QuestionNavChips
+        questions={questions}
+        answers={answers}
+        currentIndex={currentIndex}
+        navRef={navRef}
+        showLeftFade={showLeftFade}
+        showRightFade={showRightFade}
+        dataTour="exam-nav"
+        eventName="exam_navigate"
+        eventData={{ subjectId: subject.id, year: examInfo.year }}
+        onSelectIndex={(i, dir) => {
+          setDirection(dir);
+          setCurrentIndex(i);
+          scrollToNav(i);
         }}
-      >
-        {questions.map((q, i) => {
-          const isAnswered = answers[q.id] && answers[q.id].trim() !== "";
-          const isCurrent = i === currentIndex;
-          let cls =
-            "w-8 h-8 rounded-md text-xs font-mono flex items-center justify-center border shrink-0 active:scale-90 focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none transition cursor-pointer";
-          if (isCurrent) cls += " bg-accent text-white border-accent";
-          else if (isAnswered)
-            cls += " bg-accent-light border-accent-border text-accent-fg";
-          else cls += " border-border text-fg-muted hover:border-fg-muted";
-          return (
-            <button
-              type="button"
-              key={q.id}
-              className={cls}
-              onClick={() => {
-                triggerLight();
-                setDirection(
-                  i > currentIndex
-                    ? "next"
-                    : i < currentIndex
-                      ? "prev"
-                      : undefined,
-                );
-                setCurrentIndex(i);
-                scrollToNav(i);
-              }}
-            >
-              {i + 1}
-            </button>
-          );
-        })}
-      </div>
+      />
 
       <div data-tour="exam-card">
         <QuestionCard
@@ -285,6 +275,9 @@ function ExamPlayer({
         megatopicLabel={megatopicLabels[currentQuestion.topic]}
         examDate={examInfo?.date || examInfo?.title}
         subjectId={subject.id}
+        topicKey={currentQuestion.topic}
+        examYear={examInfo.year}
+        mode="exam"
         onAnswer={onAnswer}
         savedAnswer={answers[currentQuestion.id]}
         showResult={submitted}
@@ -303,9 +296,12 @@ function ExamPlayer({
             const nextIndex = Math.max(0, currentIndex - 1);
             setDirection("prev");
             track("exam_navigate", {
+              subjectId: subject.id,
+              year: examInfo.year,
               direction: "prev",
               fromIndex: currentIndex,
               toIndex: nextIndex,
+              source: "arrow",
             });
             setCurrentIndex(nextIndex);
             scrollToNav(nextIndex);
@@ -352,9 +348,12 @@ function ExamPlayer({
             const nextIndex = Math.min(questions.length - 1, currentIndex + 1);
             setDirection("next");
             track("exam_navigate", {
+              subjectId: subject.id,
+              year: examInfo.year,
               direction: "next",
               fromIndex: currentIndex,
               toIndex: nextIndex,
+              source: "arrow",
             });
             setCurrentIndex(nextIndex);
             scrollToNav(nextIndex);
@@ -502,41 +501,21 @@ export default function ExamSimulation() {
     startedRef.current = started;
   });
 
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (!startedRef.current) return;
-      const tag = document.activeElement?.tagName.toLowerCase();
-      if (tag === "input" || tag === "textarea" || tag === "select") return;
-      const idx = currentIndexRef.current;
-      if (e.key === "ArrowLeft" && idx > 0) {
-        e.preventDefault();
-        const nextIndex = idx - 1;
-        triggerLight();
-        setNavState((prev) => ({ ...prev, direction: "prev" }));
-        track("exam_navigate", {
-          direction: "prev",
-          fromIndex: idx,
-          toIndex: nextIndex,
-        });
-        setCurrentIndex(nextIndex);
-        scrollToNav(nextIndex);
-      } else if (e.key === "ArrowRight" && idx < questions.length - 1) {
-        e.preventDefault();
-        const nextIndex = idx + 1;
-        triggerLight();
-        setNavState((prev) => ({ ...prev, direction: "next" }));
-        track("exam_navigate", {
-          direction: "next",
-          fromIndex: idx,
-          toIndex: nextIndex,
-        });
-        setCurrentIndex(nextIndex);
-        scrollToNav(nextIndex);
-      }
-    };
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [questions.length, scrollToNav, setCurrentIndex, setNavState]);
+  const navEventData = useCallback(
+    () => ({ subjectId: subjectId || "", year: year || "" }),
+    [subjectId, year],
+  );
+
+  useKeyboardNav({
+    enabledRef: startedRef,
+    questionsLength: questions.length,
+    currentIndexRef,
+    setCurrentIndex,
+    scrollToNav,
+    setDirection,
+    eventName: "exam_navigate",
+    eventData: navEventData,
+  });
 
   useEffect(() => {
     if (!subject || !examInfo) {
@@ -629,7 +608,10 @@ export default function ExamSimulation() {
         <Link
           to={subject ? `/${subject.id}` : "/"}
           className="text-accent hover:underline mt-4 inline-block"
-          onClick={() => triggerLight()}
+          onClick={() => {
+            triggerLight();
+            track("nav_click", { target: "home", from: "exam_empty" });
+          }}
         >
           {t.exam.backToHome}
         </Link>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -5,6 +5,7 @@ import AddSubjectModal, {
   type AddSubjectModalHandle,
 } from "../components/AddSubjectModal";
 import { useT } from "../i18n/hooks";
+import { track } from "../lib/umami";
 import { useDocumentTitle } from "../lib/title";
 import { useSeoHead } from "../lib/seo";
 import { LangLink } from "../lib/lang-link";
@@ -78,6 +79,7 @@ export default function Home() {
 
   function handleClearRecent() {
     clearRecentSubjects();
+    track("clear_recent_subjects", { count: recentSubjects.length });
     setRecentKey((k) => k + 1);
   }
 
@@ -122,7 +124,13 @@ export default function Home() {
                 {slot.type === "subject" ? (
                   <LangLink
                     to={`/${slot.subject.id}`}
-                    onClick={() => recordSubjectClick(slot.subject.id)}
+                    onClick={() => {
+                      recordSubjectClick(slot.subject.id);
+                      track("subject_card_click", {
+                        subjectId: slot.subject.id,
+                        location: "recent",
+                      });
+                    }}
                     className="block w-full p-5 rounded-xl border-2 border-border hover:border-accent bg-surface-alt hover:bg-accent-light/30 hover:scale-[1.02] hover:shadow-md transition-colors transition-transform duration-200"
                   >
                     <div className="flex items-center gap-3">
@@ -156,7 +164,10 @@ export default function Home() {
         <div className="animate-fade-in-up timeline-view animate-range-entry">
           <button
             type="button"
-            onClick={() => modalRef.current?.open()}
+            onClick={() => {
+            modalRef.current?.open();
+            track("add_subject_modal_open");
+          }}
             className="block w-full p-5 rounded-xl border-2 border-dashed border-border text-fg-muted hover:text-accent hover:border-accent hover:bg-accent-light/30 hover:scale-[1.02] transition-colors transition-transform duration-200 cursor-pointer"
           >
             <div className="flex flex-col items-center justify-center h-full min-h-[120px] gap-2">

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -165,9 +165,9 @@ export default function Home() {
           <button
             type="button"
             onClick={() => {
-            modalRef.current?.open();
-            track("add_subject_modal_open");
-          }}
+              modalRef.current?.open();
+              track("add_subject_modal_open");
+            }}
             className="block w-full p-5 rounded-xl border-2 border-dashed border-border text-fg-muted hover:text-accent hover:border-accent hover:bg-accent-light/30 hover:scale-[1.02] transition-colors transition-transform duration-200 cursor-pointer"
           >
             <div className="flex flex-col items-center justify-center h-full min-h-[120px] gap-2">

--- a/src/pages/PracticeTopic.tsx
+++ b/src/pages/PracticeTopic.tsx
@@ -9,12 +9,14 @@ import {
 } from "../subjects";
 import type { Question } from "../data/types";
 import QuestionCard from "../components/QuestionCard";
+import QuestionNavChips from "../components/QuestionNavChips";
 import { useT } from "../i18n/hooks";
 import { track } from "../lib/umami";
 import { triggerLight } from "../lib/haptics";
 import { useDocumentTitle } from "../lib/title";
 import { useSeoHead } from "../lib/seo";
 import { usePracticeSession } from "../hooks/usePracticeSession";
+import { useKeyboardNav } from "../hooks/useKeyboardNav";
 import { startPracticeTour } from "../lib/tour";
 
 interface PracticePlayerProps {
@@ -113,6 +115,7 @@ function PracticePlayer({
         <Link
           to={`/${subject.id}`}
           className="text-sm text-accent hover:underline focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none rounded-md px-1"
+          onClick={() => track("nav_click", { target: "subject_home", from: "practice" })}
         >
           {t.practice.backToTopics}
         </Link>
@@ -141,56 +144,23 @@ function PracticePlayer({
         </div>
       )}
 
-      <div
-        ref={navRef}
-        className="flex gap-1 mb-6 overflow-x-auto pb-6"
-        data-tour="practice-nav"
-        style={{
-          maskImage:
-            showLeftFade && showRightFade
-              ? "linear-gradient(to right, transparent 0%, black 8%, black 92%, transparent 100%)"
-              : showLeftFade
-                ? "linear-gradient(to right, transparent 0%, black 8%, black 100%)"
-                : showRightFade
-                  ? "linear-gradient(to right, black 0%, black 92%, transparent 100%)"
-                  : undefined,
+      <QuestionNavChips
+        questions={questions}
+        answers={answers}
+        currentIndex={currentIndex}
+        navRef={navRef}
+        showLeftFade={showLeftFade}
+        showRightFade={showRightFade}
+        checkedQuestions={checkedQuestions}
+        dataTour="practice-nav"
+        eventName="practice_navigate"
+        eventData={{ subjectId: subject.id, topic: topic || "" }}
+        onSelectIndex={(i, dir) => {
+          setDirection(dir);
+          setCurrentIndex(i);
+          scrollToNav(i);
         }}
-      >
-        {questions.map((q, i) => {
-          const isAnswered = answers[q.id] && answers[q.id].trim() !== "";
-          const isChecked = !!checkedQuestions[q.id];
-          const isCurrent = i === currentIndex;
-          let cls =
-            "w-8 h-8 rounded-md text-xs font-mono flex items-center justify-center border shrink-0 active:scale-90 focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none transition cursor-pointer";
-          if (isCurrent) cls += " bg-accent text-white border-accent";
-          else if (isChecked)
-            cls += " bg-blue-50 border-blue-300 text-blue-700";
-          else if (isAnswered)
-            cls += " bg-accent-light border-accent-border text-accent-fg";
-          else cls += " border-border text-fg-muted hover:border-fg-muted";
-          return (
-            <button
-              type="button"
-              key={q.id}
-              className={cls}
-              onClick={() => {
-                triggerLight();
-                setDirection(
-                  i > currentIndex
-                    ? "next"
-                    : i < currentIndex
-                      ? "prev"
-                      : undefined,
-                );
-                setCurrentIndex(i);
-                scrollToNav(i);
-              }}
-            >
-              {isChecked && !isCurrent ? "\u2713" : i + 1}
-            </button>
-          );
-        })}
-      </div>
+      />
 
       <div data-tour="practice-card">
         <QuestionCard
@@ -202,6 +172,9 @@ function PracticePlayer({
         megatopicLabel={megatopicLabel}
         examDate={examDate}
         subjectId={subject.id}
+        topicKey={topic || undefined}
+        examYear={currentQuestion?.exam === "both" ? undefined : currentQuestion?.exam}
+        mode="practice"
         onAnswer={onAnswer}
         savedAnswer={answers[currentQuestion.id]}
         showResult={submitted || !!checkedQuestions[currentQuestion.id]}
@@ -220,9 +193,12 @@ function PracticePlayer({
             const nextIndex = Math.max(0, currentIndex - 1);
             setDirection("prev");
             track("practice_navigate", {
+              subjectId: subject.id,
+              topic: topic || "",
               direction: "prev",
               fromIndex: currentIndex,
               toIndex: nextIndex,
+              source: "arrow",
             });
             setCurrentIndex(nextIndex);
             scrollToNav(nextIndex);
@@ -262,6 +238,8 @@ function PracticePlayer({
                     triggerLight();
                     track("practice_clear_answer", {
                       questionId: currentQuestion.id,
+                      subjectId: subject.id,
+                      topic: topic || "",
                     });
                     onClearAnswer(currentQuestion.id);
                   }}
@@ -295,9 +273,12 @@ function PracticePlayer({
             const nextIndex = Math.min(questions.length - 1, currentIndex + 1);
             setDirection("next");
             track("practice_navigate", {
+              subjectId: subject.id,
+              topic: topic || "",
               direction: "next",
               fromIndex: currentIndex,
               toIndex: nextIndex,
+              source: "arrow",
             });
             setCurrentIndex(nextIndex);
             scrollToNav(nextIndex);
@@ -426,40 +407,26 @@ export default function PracticeTopic() {
     currentIndexRef.current = currentIndex;
   });
 
+  const subjectReadyRef = useRef(false);
   useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      const tag = document.activeElement?.tagName.toLowerCase();
-      if (tag === "input" || tag === "textarea" || tag === "select") return;
-      const idx = currentIndexRef.current;
-      if (e.key === "ArrowLeft" && idx > 0) {
-        e.preventDefault();
-        const nextIndex = idx - 1;
-        triggerLight();
-        setNavState((prev) => ({ ...prev, direction: "prev" }));
-        track("practice_navigate", {
-          direction: "prev",
-          fromIndex: idx,
-          toIndex: nextIndex,
-        });
-        setCurrentIndex(nextIndex);
-        scrollToNav(nextIndex);
-      } else if (e.key === "ArrowRight" && idx < questions.length - 1) {
-        e.preventDefault();
-        const nextIndex = idx + 1;
-        triggerLight();
-        setNavState((prev) => ({ ...prev, direction: "next" }));
-        track("practice_navigate", {
-          direction: "next",
-          fromIndex: idx,
-          toIndex: nextIndex,
-        });
-        setCurrentIndex(nextIndex);
-        scrollToNav(nextIndex);
-      }
-    };
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [questions.length, scrollToNav, setCurrentIndex, setNavState]);
+    subjectReadyRef.current = !!subject;
+  }, [subject]);
+
+  const navEventData = useCallback(
+    () => ({ subjectId: subject?.id || "", topic: topic || "" }),
+    [subject?.id, topic],
+  );
+
+  useKeyboardNav({
+    enabledRef: subjectReadyRef,
+    questionsLength: questions.length,
+    currentIndexRef,
+    setCurrentIndex,
+    scrollToNav,
+    setDirection,
+    eventName: "practice_navigate",
+    eventData: navEventData,
+  });
 
   useEffect(() => {
     if (!subject || !topicInfo) {
@@ -567,7 +534,10 @@ export default function PracticeTopic() {
         <Link
           to={subject ? `/${subject.id}` : "/"}
           className="text-accent hover:underline mt-4 inline-block"
-          onClick={() => triggerLight()}
+          onClick={() => {
+            triggerLight();
+            track("nav_click", { target: "home", from: "practice_empty" });
+          }}
         >
           {t.practice.backToHome}
         </Link>

--- a/src/pages/SubjectHome.tsx
+++ b/src/pages/SubjectHome.tsx
@@ -60,7 +60,10 @@ export default function SubjectHome() {
         <Link
           to="/"
           className="text-accent hover:underline"
-          onClick={() => triggerLight()}
+          onClick={() => {
+            triggerLight();
+            track("nav_click", { target: "home", reason: "subject_not_found" });
+          }}
         >
           {t.subjectHome.returnHome}
         </Link>
@@ -189,6 +192,7 @@ export default function SubjectHome() {
           onClick={() => {
             triggerLight();
             examModalRef.current?.open();
+            track("add_exam_modal_open", { subjectId: subject.id });
           }}
           className="block w-full p-6 rounded-xl border-2 border-dashed border-border text-fg-muted hover:text-accent hover:border-accent hover:bg-accent-light/30 hover:scale-[1.02] hover:shadow-md transition-colors transition-transform duration-200"
         >
@@ -227,7 +231,7 @@ export default function SubjectHome() {
                       className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-accent-fg bg-accent-light border border-accent-border rounded-lg hover:bg-accent-light active:scale-95 focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none transition duration-150"
                       onClick={() => {
                         triggerLight();
-                        track("file-download", {
+                        track("file_download", {
                           file: `Exam-${exam.year}.pdf`,
                           subjectId: subject.id,
                           year: exam.year,


### PR DESCRIPTION
## Summary

Complete overhaul of Umami analytics event tracking based on a codebase-wide audit (aligned with Umami v2 docs for SPA, file downloads, events, tracker functions, tracker configuration, distinct IDs and tags).

## Wrapper (`src/lib/umami.ts`)
- try/catch around every `window.umami.*` call so analytics never breaks app interactions (especially inside onClick handlers).
- Values now accept `undefined`/`null` and are filtered out before send (lets callers pass optional context cleanly).
- New exports: `setSessionData`, `getDistinctId` (anonymous persistent UUID in `localStorage`).
- Removed unused `trackView`/`trackPayload` exports flagged by react-doctor.

## Distinct ID & session
- `SessionTracker` now calls `identify({ id: getDistinctId() })` once, so sessions stitch across cookie/cache clears.
- `lang`/`theme` moved to `setSessionData(...)` (more appropriate primitive for session-scoped properties).

## `index.html` snippet
- Added `data-do-not-track=\"true\"` to honour browser DNT (GDPR-friendly for ES/GL audience).
- (Per request: recorder masking left untouched; lang-toggle pageview left as-is.)

## Naming consistency
- `file-download` → `file_download` (only kebab-case event was this one).
- `add_*_modal_close` + `add_*_modal_close_btn` consolidated into single `modal_close` event with `{ modal: \"add_subject\"|\"add_exam\", method: \"x\"|\"backdrop\"|... }`.

## Context richness
- `practice_navigate` / `exam_navigate` now include `subjectId`, `topic`/`year`, and `source` (`arrow` | `chip` | `keyboard`).
- `practice_check_question` now includes `subjectId` + `topic` (were already in scope).
- `question_answer`, `solution_toggle`, `report_issue` (in `QuestionCard`) now carry `subjectId`, `topic`, `exam`, `mode` via new optional props.

## De-duplication
- Removed card-level `self_grade` tracking in `QuestionCard` (it was double-firing with the context-rich `practice_self_grade`/`exam_self_grade` in the hooks). The hook-level events are retained.

## Newly tracked interactions
- `add_subject_modal_open`, `add_exam_modal_open` (the close side was already tracked — closes the funnel).
- `exam_abandon` (when a user confirms exit mid-exam) — `answeredCount`, `timeLeft` included.
- Recently-visited subject cards on Home now emit `subject_card_click` with `location: \"recent\"`; grid cards get `location: \"grid\"`.
- `clear_recent_subjects` with `{ count }`.
- Back-links in practice/exam (incl. empty states) and subject-not-found branch now emit `nav_click` with `from`/`reason`.
- Chip-strip question navigation now tracked (previously only prev/next arrows were).

## Text-answer activity
- Open-text questions now emit `question_answer { type:\"text\", action:\"started\" }` on the first keystroke (debounced via ref). **The answer text is never sent** (PII-safe).

## Refactors (to satisfy react-doctor size rule)
- `useKeyboardNav` hook (`src/hooks/useKeyboardNav.ts`) — shared arrow-key navigation + tracking for practice/exam.
- `QuestionNavChips` component (`src/components/QuestionNavChips.tsx`) — shared chip-strip + tracking for practice/exam.

## Verification
- `pnpm build` ✅ (tsc + vite, no type errors)
- `pnpm lint` ✅ (only 2 pre-existing errors in `StarPopup.tsx` and `esei/questions.ts`, unchanged by this PR)
- `pnpm doctor` ✅ 100/100 (no new issues introduced)

## Notes for dashboard consumers
- Renamed/consolidated events will appear as **new** event names in Umami; old names (`file-download`, `add_*_modal_close`, `add_*_modal_close_btn`, `self_grade`) will stop receiving data. Plan a dashboard/archive update accordingly.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR is a thorough overhaul of Umami analytics event tracking: the wrapper gains try/catch safety, null-filtering, and new `setSessionData`/`getDistinctId` exports; modal-close tracking is consolidated via a `closeMethodRef` pattern; keyboard navigation is extracted into a shared `useKeyboardNav` hook; and navigation chips into a shared `QuestionNavChips` component. All previously flagged issues (double-fire close, empty-string identify, SSR guard on `setSessionData`, and chips emitting `direction: ""`) are addressed.

- **Analytics robustness**: every `window.umami.*` call is now wrapped in `safeRun`; `null`/`undefined` values are stripped before send; a `localStorage`-backed distinct ID enables cross-session stitching.
- **New tracked interactions**: `exam_abandon`, `add_*_modal_open`, `subject_card_click` with `location`, `nav_click` on back-links, and first-keystroke text-question tracking (PII-safe).
- **Refactors**: `useKeyboardNav` and `QuestionNavChips` extract shared code that was previously duplicated between practice and exam flows.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all analytics changes are wrapped in try/catch and never touch the critical app path.

The analytics wrapper now silently no-ops on any failure, so every new event call site is fully isolated from product interactions. The modal-close double-fire, empty-string identify, and chip direction issues from the prior review round are all correctly addressed. The two remaining items are a cosmetic indentation inconsistency and a mutation in `identify` that is currently harmless given how App.tsx calls it.

No files require special attention; the changes to src/lib/umami.ts and src/hooks/usePracticeSession.ts have only cosmetic findings.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/umami.ts | Core analytics wrapper rewritten: adds safeRun, null-filtering clean(), setSessionData, getDistinctId; identify() mutates its argument with `delete data.id` (minor, currently harmless) |
| src/hooks/usePracticeSession.ts | handleCheckQuestion enriched with subjectId/topic; introduced with incorrect zero-indent (cosmetic only) |
| src/hooks/useKeyboardNav.ts | New hook extracting arrow-key navigation + tracking shared by practice and exam; uses enabledRef pattern correctly; all dependencies in useEffect array |
| src/components/QuestionNavChips.tsx | New component for nav chip strip; correctly skips tracking when clicking current chip (direction === undefined); supports both object and factory-function eventData |
| src/components/AddExamModal.tsx | closeMethodRef pattern correctly resolves prior double-fire bug; cancel event listener added for ESC tracking; all three close paths (x/backdrop/esc) correctly set ref before onClose fires |
| src/pages/ExamSimulation.tsx | Keyboard nav moved to useKeyboardNav; exam_abandon tracking added; setDirection is properly memoized; nav enriched with subjectId/year/source |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as User
    participant R as React Component
    participant W as umami.ts wrapper
    participant Umami as window.umami

    Note over R,W: Session init (App.tsx SessionTracker)
    R->>W: getDistinctId()
    W-->>R: UUID (from localStorage or newly generated)
    R->>W: "identify({ id })"
    W->>Umami: "umami.identify({ id })"
    R->>W: "setSessionData({ lang, theme })"
    W->>Umami: umami.setSessionData / umami.identify

    Note over R,W: Modal close (AddExamModal / AddSubjectModal)
    U->>R: click X / ESC / backdrop
    R->>R: "closeMethodRef.current = x|esc|backdrop"
    R->>R: dialog.close() → onClose event fires
    R->>W: "track(modal_close, { modal, method, subjectId })"
    W->>W: clean() — strip null/undefined
    W->>W: safeRun() — try/catch
    W->>Umami: umami.track(...)

    Note over R,W: Navigation (practice/exam)
    U->>R: arrow key / chip click / prev-next button
    R->>W: "track(practice_navigate|exam_navigate, { subjectId, topic/year, direction, source })"
    W->>Umami: umami.track(...)

    Note over R,W: Question interaction
    U->>R: answer MC / first keystroke in text / toggle solution
    R->>W: "track(question_answer|solution_toggle, { subjectId, topicKey, examYear, mode })"
    W->>Umami: umami.track(...)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as User
    participant R as React Component
    participant W as umami.ts wrapper
    participant Umami as window.umami

    Note over R,W: Session init (App.tsx SessionTracker)
    R->>W: getDistinctId()
    W-->>R: UUID (from localStorage or newly generated)
    R->>W: "identify({ id })"
    W->>Umami: "umami.identify({ id })"
    R->>W: "setSessionData({ lang, theme })"
    W->>Umami: umami.setSessionData / umami.identify

    Note over R,W: Modal close (AddExamModal / AddSubjectModal)
    U->>R: click X / ESC / backdrop
    R->>R: "closeMethodRef.current = x|esc|backdrop"
    R->>R: dialog.close() → onClose event fires
    R->>W: "track(modal_close, { modal, method, subjectId })"
    W->>W: clean() — strip null/undefined
    W->>W: safeRun() — try/catch
    W->>Umami: umami.track(...)

    Note over R,W: Navigation (practice/exam)
    U->>R: arrow key / chip click / prev-next button
    R->>W: "track(practice_navigate|exam_navigate, { subjectId, topic/year, direction, source })"
    W->>Umami: umami.track(...)

    Note over R,W: Question interaction
    U->>R: answer MC / first keystroke in text / toggle solution
    R->>W: "track(question_answer|solution_toggle, { subjectId, topicKey, examYear, mode })"
    W->>Umami: umami.track(...)
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(analytics): reset textStartedRef whe..."](https://github.com/teenbiscuits/pasame-examenes/commit/237edb80d84a865aec54821ff5e48877a4e8a7a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41179477)</sub>

<!-- /greptile_comment -->