### PR TITLE
Add disclaimer to topic practice and exam pages

### DIFF
--- a/src/components/Disclaimer.tsx
+++ b/src/components/Disclaimer.tsx
@@ -7,6 +7,7 @@ function buildDisclaimerReportUrl(subjectId: string): string {
   const params = new URLSearchParams();
   params.set("template", "report-question.yml");
   params.set("subject", subjectId);
+  params.set("question-id", "");
   return `${base}?${params.toString()}`;
 }
 
@@ -46,6 +47,7 @@ export default function Disclaimer({ subjectId }: { subjectId: string }) {
           </svg>
           {t.disclaimer.reportLink}
         </a>
+        {t.disclaimer.postLinkText}
       </p>
     </div>
   );

--- a/src/components/Disclaimer.tsx
+++ b/src/components/Disclaimer.tsx
@@ -1,0 +1,52 @@
+import { useT } from "../i18n/hooks";
+import { track } from "../lib/umami";
+import { triggerLight } from "../lib/haptics";
+
+function buildDisclaimerReportUrl(subjectId: string): string {
+  const base = "https://github.com/TeenBiscuits/Pasame-Examenes/issues/new";
+  const params = new URLSearchParams();
+  params.set("template", "report-question.yml");
+  params.set("subject", subjectId);
+  return `${base}?${params.toString()}`;
+}
+
+export default function Disclaimer({ subjectId }: { subjectId: string }) {
+  const t = useT();
+  return (
+    <div className="mt-8 pt-6 border-t border-border">
+      <p className="text-xs text-fg-muted leading-relaxed">
+        {t.disclaimer.text}{" "}
+        <a
+          href={buildDisclaimerReportUrl(subjectId)}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 text-xs text-fg-muted hover:text-red-500 transition-colors focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:outline-none rounded"
+          onClick={() => {
+            triggerLight();
+            track("report_issue", {
+              subjectId,
+              source: "disclaimer",
+            });
+          }}
+        >
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+            <line x1="12" y1="9" x2="12" y2="13" />
+            <line x1="12" y1="17" x2="12.01" y2="17" />
+          </svg>
+          {t.disclaimer.reportLink}
+        </a>
+      </p>
+    </div>
+  );
+}

--- a/src/components/Disclaimer.tsx
+++ b/src/components/Disclaimer.tsx
@@ -3,7 +3,15 @@ import { track } from "../lib/umami";
 import { triggerLight } from "../lib/haptics";
 
 import type { QuestionType } from "../data/types";
-import { getQuestionTypeLabel } from "./QuestionCard";
+
+function getQuestionTypeLabel(type: QuestionType): string {
+  const map: Record<QuestionType, string> = {
+    mc: "Multiple Choice (mc)",
+    text: "Open Text (text)",
+    matching: "Matching (matching)",
+  };
+  return map[type];
+}
 
 function buildDisclaimerReportUrl(
   subjectId: string,

--- a/src/components/Disclaimer.tsx
+++ b/src/components/Disclaimer.tsx
@@ -2,23 +2,39 @@ import { useT } from "../i18n/hooks";
 import { track } from "../lib/umami";
 import { triggerLight } from "../lib/haptics";
 
-function buildDisclaimerReportUrl(subjectId: string): string {
+import type { QuestionType } from "../data/types";
+import { getQuestionTypeLabel } from "./QuestionCard";
+
+function buildDisclaimerReportUrl(
+  subjectId: string,
+  questionId: string,
+  questionType: QuestionType,
+): string {
   const base = "https://github.com/TeenBiscuits/Pasame-Examenes/issues/new";
   const params = new URLSearchParams();
   params.set("template", "report-question.yml");
   params.set("subject", subjectId);
-  params.set("question-id", "");
+  params.set("question-id", questionId);
+  params.set("question-type", getQuestionTypeLabel(questionType));
   return `${base}?${params.toString()}`;
 }
 
-export default function Disclaimer({ subjectId }: { subjectId: string }) {
+export default function Disclaimer({
+  subjectId,
+  questionId,
+  questionType,
+}: {
+  subjectId: string;
+  questionId: string;
+  questionType: QuestionType;
+}) {
   const t = useT();
   return (
     <div className="mt-8 pt-6 border-t border-border">
       <p className="text-xs text-fg-muted leading-relaxed">
         {t.disclaimer.text}{" "}
         <a
-          href={buildDisclaimerReportUrl(subjectId)}
+          href={buildDisclaimerReportUrl(subjectId, questionId, questionType)}
           target="_blank"
           rel="noopener noreferrer"
           className="inline-flex items-center gap-1 text-xs text-fg-muted hover:text-red-500 transition-colors focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:outline-none rounded"

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -74,7 +74,7 @@ interface QuestionCardProps {
   direction?: "next" | "prev";
 }
 
-export function getQuestionTypeLabel(type: QuestionType): string {
+function getQuestionTypeLabel(type: QuestionType): string {
   const map: Record<QuestionType, string> = {
     mc: "Multiple Choice (mc)",
     text: "Open Text (text)",

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -74,7 +74,7 @@ interface QuestionCardProps {
   direction?: "next" | "prev";
 }
 
-function getQuestionTypeLabel(type: QuestionType): string {
+export function getQuestionTypeLabel(type: QuestionType): string {
   const map: Record<QuestionType, string> = {
     mc: "Multiple Choice (mc)",
     text: "Open Text (text)",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -161,8 +161,9 @@ export const en = {
     dismiss: "Not now",
   },
   disclaimer: {
-    text: "Questions have been extracted from reference materials through automated processes and may contain errors. In some cases you can review the original material directly from the website. If you find an error, please",
+    text: "Questions have been extracted from reference materials through automated processes and may contain errors. If you find an error, please",
     reportLink: "Report the question",
+    postLinkText: ". In some cases you can review the original material directly from the website.",
   },
   seo: {
     siteName: "Pásame Exámenes",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -160,6 +160,10 @@ export const en = {
     starButton: "Give us a star!",
     dismiss: "Not now",
   },
+  disclaimer: {
+    text: "Questions have been extracted from reference materials through automated processes and may contain errors. In some cases you can review the original material directly from the website. If you find an error, please",
+    reportLink: "Report the question",
+  },
   seo: {
     siteName: "Pásame Exámenes",
     locale: "en_US",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -163,8 +163,9 @@ export const es: Translations = {
     dismiss: "Ahora no",
   },
   disclaimer: {
-    text: "Las preguntas han sido extraídas de los materiales de referencia por procesos automatizados y podrían contener errores. En algunos casos puede revisar el material original directamente desde la web. Si encuentra algún error no dude en",
+    text: "Las preguntas han sido extraídas de los materiales de referencia por procesos automatizados y podrían contener errores. Si encuentra algún error no dude en",
     reportLink: "Reportar la pregunta",
+    postLinkText: ". En algunos casos puede revisar el material original directamente desde la web.",
   },
   seo: {
     siteName: "Pásame Exámenes",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -162,6 +162,10 @@ export const es: Translations = {
     starButton: "¡Dame una estrella!",
     dismiss: "Ahora no",
   },
+  disclaimer: {
+    text: "Las preguntas han sido extraídas de los materiales de referencia por procesos automatizados y podrían contener errores. En algunos casos puede revisar el material original directamente desde la web. Si encuentra algún error no dude en",
+    reportLink: "Reportar la pregunta",
+  },
   seo: {
     siteName: "Pásame Exámenes",
     locale: "es_ES",

--- a/src/i18n/gl.ts
+++ b/src/i18n/gl.ts
@@ -161,6 +161,10 @@ export const gl: Translations = {
     starButton: "Dame unha estrela!",
     dismiss: "Agora non",
   },
+  disclaimer: {
+    text: "As preguntas foron extraídas dos materiais de referencia por procesos automatizados e poderían conter erros. Nalgúns casos pode revisar o material orixinal directamente desde a web. Se atopa algún erro non dubide en",
+    reportLink: "Reportar a pregunta",
+  },
   seo: {
     siteName: "Pásame Exámenes",
     locale: "gl_ES",

--- a/src/i18n/gl.ts
+++ b/src/i18n/gl.ts
@@ -162,8 +162,9 @@ export const gl: Translations = {
     dismiss: "Agora non",
   },
   disclaimer: {
-    text: "As preguntas foron extraídas dos materiais de referencia por procesos automatizados e poderían conter erros. Nalgúns casos pode revisar o material orixinal directamente desde a web. Se atopa algún erro non dubide en",
+    text: "As preguntas foron extraídas dos materiais de referencia por procesos automatizados e poderían conter erros. Se atopa algún erro non dubide en",
     reportLink: "Reportar a pregunta",
+    postLinkText: ". Nalgúns casos pode revisar o material orixinal directamente desde a web.",
   },
   seo: {
     siteName: "Pásame Exámenes",

--- a/src/pages/ExamSimulation.tsx
+++ b/src/pages/ExamSimulation.tsx
@@ -384,7 +384,7 @@ function ExamPlayer({
         </button>
       </div>
 
-      <Disclaimer subjectId={subject.id} />
+      <Disclaimer subjectId={subject.id} questionId={currentQuestion.id} questionType={currentQuestion.type} />
     </div>
   );
 }

--- a/src/pages/ExamSimulation.tsx
+++ b/src/pages/ExamSimulation.tsx
@@ -10,6 +10,7 @@ import {
 import type { Question, Exam } from "../data/types";
 import QuestionCard from "../components/QuestionCard";
 import QuestionNavChips from "../components/QuestionNavChips";
+import Disclaimer from "../components/Disclaimer";
 import { useT } from "../i18n/hooks";
 import { track } from "../lib/umami";
 import { triggerLight } from "../lib/haptics";
@@ -382,6 +383,8 @@ function ExamPlayer({
           </span>
         </button>
       </div>
+
+      <Disclaimer subjectId={subject.id} />
     </div>
   );
 }

--- a/src/pages/PracticeTopic.tsx
+++ b/src/pages/PracticeTopic.tsx
@@ -309,7 +309,7 @@ function PracticePlayer({
         </button>
       </div>
 
-      <Disclaimer subjectId={subject.id} />
+      <Disclaimer subjectId={subject.id} questionId={currentQuestion.id} questionType={currentQuestion.type} />
     </div>
   );
 }

--- a/src/pages/PracticeTopic.tsx
+++ b/src/pages/PracticeTopic.tsx
@@ -10,6 +10,7 @@ import {
 import type { Question } from "../data/types";
 import QuestionCard from "../components/QuestionCard";
 import QuestionNavChips from "../components/QuestionNavChips";
+import Disclaimer from "../components/Disclaimer";
 import { useT } from "../i18n/hooks";
 import { track } from "../lib/umami";
 import { triggerLight } from "../lib/haptics";
@@ -307,6 +308,8 @@ function PracticePlayer({
           </span>
         </button>
       </div>
+
+      <Disclaimer subjectId={subject.id} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Adds a disclaimer at the bottom of topic practice pages and exam simulation pages with a link to report errors.

### Changes

- **New  component** (`src/components/Disclaimer.tsx`) — Reusable component showing the disclaimer text with a pre-filled GitHub issue link using the `report-question.yml` template. Uses the same exclamation triangle SVG as the per-question report link in `QuestionCard`.
- **i18n additions** — Added `disclaimer.text` and `disclaimer.reportLink` keys to `en.ts`, `es.ts`, and `gl.ts`.
- **PracticeTopic** — Renders `<Disclaimer>` at the bottom of `PracticePlayer`.
- **ExamSimulation** — Renders `<Disclaimer>` at the bottom of `ExamPlayer`.

### Screenshot

The disclaimer appears at the bottom of both practice and exam pages, above the footer.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a shared disclaimer to practice and exam pages. The main changes are:

- New reusable disclaimer component with a report link.
- Practice and exam pages pass the current question into the disclaimer.
- English, Spanish, and Galician disclaimer text.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/Disclaimer.tsx | Adds the disclaimer and builds a report URL with subject, question id, and question type. |
| src/pages/PracticeTopic.tsx | Renders the disclaimer in the practice player using the current question. |
| src/pages/ExamSimulation.tsx | Renders the disclaimer in the exam player using the current question. |
| src/i18n/en.ts | Adds English copy for the disclaimer. |
| src/i18n/es.ts | Adds Spanish copy for the disclaimer. |
| src/i18n/gl.ts | Adds Galician copy for the disclaimer. |

</details>

<sub>Reviews (4): Last reviewed commit: ["Fix React Doctor warning: inline getQues..."](https://github.com/teenbiscuits/pasame-examenes/commit/20adeb4572e82ac5639d1bcea144a9b8e9def28a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41320926)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/pablopl/github/TeenBiscuits/pasame-examenes/-/custom-context?memory=3af31e3e-b81f-42ea-a877-22300621eac1))

<!-- /greptile_comment -->