### PR TITLE
fix: serve per-subject OG images at request time for social crawlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ dist-ssr
 
 # Project Ignores
 public/sitemap.xml
+public/subjects-meta.json
 public/og
 
 # Env

--- a/index.html
+++ b/index.html
@@ -73,6 +73,7 @@
       content="Pásame Exámenes"
     />
     <meta id="og:type" property="og:type" content="website" />
+    <meta id="og:locale" property="og:locale" content="es_ES" />
     <meta
       id="twitter:title"
       name="twitter:title"

--- a/index.html
+++ b/index.html
@@ -45,12 +45,45 @@
       })();
     </script>
     <title>Pásame Exámenes</title>
-    <!-- Default OG image: serves as baseline for JS-less crawlers.
-         Per-subject og:image is set dynamically by useSeoHead at runtime. -->
+    <meta
+      id="meta-description"
+      name="description"
+      content="Practica exámenes universitarios con respuestas modelo y autocorrección. Preguntas tipo test, de desarrollo y de emparejar de exámenes anteriores."
+    />
+    <!-- Default OG/twitter tags for JS-less crawlers.
+         Per-subject tags are set dynamically by useSeoHead at runtime. -->
+    <meta id="og:title" property="og:title" content="Pásame Exámenes" />
+    <meta
+      id="og:description"
+      property="og:description"
+      content="Plataforma de código abierto para practicar exámenes universitarios por tema o simular el examen completo."
+    />
     <meta id="og:image" property="og:image" content="/og.jpg" />
     <meta id="og:image:type" property="og:image:type" content="image/jpeg" />
     <meta id="og:image:width" property="og:image:width" content="1200" />
     <meta id="og:image:height" property="og:image:height" content="630" />
+    <meta
+      id="og:url"
+      property="og:url"
+      content="https://pe.pablopl.dev"
+    />
+    <meta
+      id="og:site_name"
+      property="og:site_name"
+      content="Pásame Exámenes"
+    />
+    <meta id="og:type" property="og:type" content="website" />
+    <meta
+      id="twitter:title"
+      name="twitter:title"
+      content="Pásame Exámenes"
+    />
+    <meta
+      id="twitter:description"
+      name="twitter:description"
+      content="Plataforma de código abierto para practicar exámenes universitarios por tema o simular el examen completo."
+    />
+    <meta id="twitter:card" name="twitter:card" content="summary_large_image" />
     <meta id="twitter:image" name="twitter:image" content="/og.jpg" />
     <script
       src="https://analytics.ahrefs.com/analytics.js"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && tsx scripts/generate-sitemap.ts && tsx scripts/generate-indexnow-key.ts && tsx scripts/generate-og-images.ts && vite build && tsx scripts/generate-subject-pages.ts",
+    "build": "tsc -b && tsx scripts/generate-vercel-rewrites.ts && tsx scripts/generate-sitemap.ts && tsx scripts/generate-indexnow-key.ts && tsx scripts/generate-og-images.ts && vite build && tsx scripts/generate-subject-pages.ts",
     "lint": "eslint .",
     "preview": "vite preview",
     "format": "prettier . --write",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && tsx scripts/generate-sitemap.ts && tsx scripts/generate-indexnow-key.ts && tsx scripts/generate-og-images.ts && vite build",
+    "build": "tsc -b && tsx scripts/generate-sitemap.ts && tsx scripts/generate-indexnow-key.ts && tsx scripts/generate-og-images.ts && vite build && tsx scripts/generate-subject-pages.ts",
     "lint": "eslint .",
     "preview": "vite preview",
     "format": "prettier . --write",

--- a/scripts/generate-og-images.ts
+++ b/scripts/generate-og-images.ts
@@ -148,6 +148,18 @@ async function main() {
 
   let generated = 0;
   const failures: string[] = [];
+  const subjectsMeta: Record<
+    string,
+    {
+      name: string;
+      icon: string;
+      questionCount: number;
+      topicCount: number;
+      examCount: number;
+      university: string;
+      courseCode: string;
+    }
+  > = {};
 
   for (const dir of subjectDirs) {
     const subjectId = dir.name;
@@ -164,6 +176,8 @@ async function main() {
           icon: string;
           topics: unknown[];
           exams: unknown[];
+          university: string;
+          courseCode: string;
         };
       };
       const { meta } = mod;
@@ -181,6 +195,17 @@ async function main() {
       const outPath = resolve(ogOutputDir, `${subjectId}.png`);
       writeFileSync(outPath, png);
       console.log(`  ✓ ${subjectId}.png (${meta.name})`);
+
+      subjectsMeta[subjectId] = {
+        name: meta.name,
+        icon: meta.icon,
+        questionCount,
+        topicCount: meta.topics.length,
+        examCount: meta.exams.length,
+        university: meta.university,
+        courseCode: meta.courseCode,
+      };
+
       generated++;
     } catch (err) {
       const msg = `${subjectId}: ${err instanceof Error ? err.message : String(err)}`;
@@ -188,6 +213,10 @@ async function main() {
       failures.push(msg);
     }
   }
+
+  const metaOutPath = resolve(root, "public", "subjects-meta.json");
+  writeFileSync(metaOutPath, JSON.stringify(subjectsMeta, null, 2));
+  console.log(`\n  ✓ subjects-meta.json (${Object.keys(subjectsMeta).length} subjects)`);
 
   console.log(`\nGenerated ${generated} OG images → ${ogOutputDir}`);
 

--- a/scripts/generate-subject-pages.ts
+++ b/scripts/generate-subject-pages.ts
@@ -18,6 +18,16 @@ interface SubjectMeta {
   courseCode: string;
 }
 
+function replaceMeta(html: string, id: string, content: string): string {
+  const regex = new RegExp(
+    `<meta\\s+id="${id}"[^>]*?content="[^"]*"[^>]*?/?>`,
+    "g",
+  );
+  return html.replace(regex, (match) =>
+    match.replace(/\bcontent="[^"]*"/, `content="${content}"`),
+  );
+}
+
 function main() {
   if (!existsSync(indexHtmlPath)) {
     console.error("dist/index.html not found — run vite build first");
@@ -37,7 +47,6 @@ function main() {
 
   const baseHtml = readFileSync(indexHtmlPath, "utf-8");
 
-  // Also discover subjects from dist/og/ PNG files (in case JSON is stale)
   const ogDir = resolve(distDir, "og");
   const knownIds = new Set<string>();
   if (existsSync(ogDir)) {
@@ -56,8 +65,14 @@ function main() {
     const ogImagePath = `/og/${subjectId}.png`;
     const title = `${meta.name} \u2014 Pasame Ex\u00e1menes`;
     const description = `${meta.name} (${meta.courseCode}): ${meta.questionCount} preguntas en ${meta.topicCount} temas con ${meta.examCount} ex\u00e1menes \u2014 ${meta.university}`;
+    const ogUrl = `https://pe.pablopl.dev/es/${subjectId}`;
 
     let html = baseHtml;
+
+    html = html.replace(
+      /<title>.*?<\/title>/,
+      `<title>${title}</title>`,
+    );
 
     html = html.replace(
       /<meta id="og:image".*?\/?>/g,
@@ -72,23 +87,12 @@ function main() {
       `<meta id="twitter:image" name="twitter:image" content="${ogImagePath}" />`,
     );
 
-    html = html.replace(
-      /<title>.*?<\/title>/,
-      `<title>${title}</title>`,
-    );
-
-    const ogBlock = [
-      `<meta id="og:title" property="og:title" content="${title}" />`,
-      `<meta id="og:description" property="og:description" content="${description}" />`,
-      `<meta id="twitter:title" name="twitter:title" content="${title}" />`,
-      `<meta id="twitter:description" name="twitter:description" content="${description}" />`,
-      `<meta id="twitter:card" name="twitter:card" content="summary_large_image" />`,
-    ].join("\n    ");
-
-    html = html.replace(
-      '<meta id="og:image:height"',
-      `${ogBlock}\n    <meta id="og:image:height"`,
-    );
+    html = replaceMeta(html, "og:title", title);
+    html = replaceMeta(html, "og:description", description);
+    html = replaceMeta(html, "og:url", ogUrl);
+    html = replaceMeta(html, "twitter:title", title);
+    html = replaceMeta(html, "twitter:description", description);
+    html = replaceMeta(html, "meta-description", description);
 
     const outPath = resolve(outDir, `${subjectId}.html`);
     writeFileSync(outPath, html);

--- a/scripts/generate-subject-pages.ts
+++ b/scripts/generate-subject-pages.ts
@@ -1,0 +1,102 @@
+import { readFileSync, writeFileSync, readdirSync, existsSync, mkdirSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+
+const __dirname = dirname(new URL(import.meta.url).pathname);
+const root = resolve(__dirname, "..");
+const distDir = resolve(root, "dist");
+const indexHtmlPath = resolve(distDir, "index.html");
+const metaJsonPath = resolve(distDir, "subjects-meta.json");
+const outDir = resolve(distDir, "og-pages");
+
+interface SubjectMeta {
+  name: string;
+  icon: string;
+  questionCount: number;
+  topicCount: number;
+  examCount: number;
+  university: string;
+  courseCode: string;
+}
+
+function main() {
+  if (!existsSync(indexHtmlPath)) {
+    console.error("dist/index.html not found — run vite build first");
+    process.exit(1);
+  }
+
+  const subjectsMeta: Record<string, SubjectMeta> = existsSync(metaJsonPath)
+    ? JSON.parse(readFileSync(metaJsonPath, "utf-8"))
+    : {};
+
+  if (Object.keys(subjectsMeta).length === 0) {
+    console.error("No subjects found in dist/subjects-meta.json");
+    process.exit(1);
+  }
+
+  mkdirSync(outDir, { recursive: true });
+
+  const baseHtml = readFileSync(indexHtmlPath, "utf-8");
+
+  // Also discover subjects from dist/og/ PNG files (in case JSON is stale)
+  const ogDir = resolve(distDir, "og");
+  const knownIds = new Set<string>();
+  if (existsSync(ogDir)) {
+    for (const f of readdirSync(ogDir)) {
+      const m = f.match(/^(.+)\.png$/);
+      if (m) knownIds.add(m[1]);
+    }
+  }
+
+  let generated = 0;
+
+  for (const subjectId of knownIds) {
+    const meta = subjectsMeta[subjectId];
+    if (!meta) continue;
+
+    const ogImagePath = `/og/${subjectId}.png`;
+    const title = `${meta.name} \u2014 Pasame Ex\u00e1menes`;
+    const description = `${meta.name} (${meta.courseCode}): ${meta.questionCount} preguntas en ${meta.topicCount} temas con ${meta.examCount} ex\u00e1menes \u2014 ${meta.university}`;
+
+    let html = baseHtml;
+
+    html = html.replace(
+      /<meta id="og:image".*?\/?>/g,
+      `<meta id="og:image" property="og:image" content="${ogImagePath}" />`,
+    );
+    html = html.replace(
+      /<meta id="og:image:type".*?\/?>/g,
+      `<meta id="og:image:type" property="og:image:type" content="image/png" />`,
+    );
+    html = html.replace(
+      /<meta id="twitter:image".*?\/?>/g,
+      `<meta id="twitter:image" name="twitter:image" content="${ogImagePath}" />`,
+    );
+
+    html = html.replace(
+      /<title>.*?<\/title>/,
+      `<title>${title}</title>`,
+    );
+
+    const ogBlock = [
+      `<meta id="og:title" property="og:title" content="${title}" />`,
+      `<meta id="og:description" property="og:description" content="${description}" />`,
+      `<meta id="twitter:title" name="twitter:title" content="${title}" />`,
+      `<meta id="twitter:description" name="twitter:description" content="${description}" />`,
+      `<meta id="twitter:card" name="twitter:card" content="summary_large_image" />`,
+    ].join("\n    ");
+
+    html = html.replace(
+      '<meta id="og:image:height"',
+      `${ogBlock}\n    <meta id="og:image:height"`,
+    );
+
+    const outPath = resolve(outDir, `${subjectId}.html`);
+    writeFileSync(outPath, html);
+    console.log(`  ✓ ${subjectId}.html (${meta.name})`);
+    generated++;
+  }
+
+  console.log(`\nGenerated ${generated} subject pages → ${outDir}`);
+}
+
+main();

--- a/scripts/generate-subject-pages.ts
+++ b/scripts/generate-subject-pages.ts
@@ -115,7 +115,7 @@ async function main() {
 
       let html = baseHtml;
 
-      html = html.replace(/<title>.*?<\/title>/, `<title>${title}</title>`);
+      html = html.replace(/<title>.*?<\/title>/, `<title>${htmlEscape(title)}</title>`);
 
       html = html.replace(
         /<meta id="og:image".*?\/?>/g,
@@ -152,7 +152,7 @@ async function main() {
 
     homeHtml = homeHtml.replace(
       /<title>.*?<\/title>/,
-      `<title>${homeTitle}</title>`,
+      `<title>${htmlEscape(homeTitle)}</title>`,
     );
 
     homeHtml = replaceMetaContent(homeHtml, "og:title", homeTitle);

--- a/scripts/generate-subject-pages.ts
+++ b/scripts/generate-subject-pages.ts
@@ -18,17 +18,52 @@ interface SubjectMeta {
   courseCode: string;
 }
 
-function replaceMeta(html: string, id: string, content: string): string {
+interface Translations {
+  seo: {
+    siteName: string;
+    locale: string;
+    homeDescription: string;
+    defaultDescription: string;
+  };
+  subjectHome: {
+    description: string;
+  };
+}
+
+const LANGS = { en: "en_US", es: "es_ES", gl: "gl_ES" } as const;
+type Lang = keyof typeof LANGS;
+
+function htmlEscape(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function replaceMetaContent(html: string, id: string, content: string): string {
   const regex = new RegExp(
     `<meta\\s+id="${id}"[^>]*?content="[^"]*"[^>]*?/?>`,
     "g",
   );
   return html.replace(regex, (match) =>
-    match.replace(/\bcontent="[^"]*"/, `content="${content}"`),
+    match.replace(/\bcontent="[^"]*"/, `content="${htmlEscape(content)}"`),
   );
 }
 
-function main() {
+function buildSubjectDescription(
+  t: Translations,
+  meta: SubjectMeta,
+): string {
+  const desc = t.subjectHome.description
+    .replace("{count}", String(meta.questionCount))
+    .replace("{repeated}", "")
+    .replace("{exams}", String(meta.examCount))
+    .replace(/`/g, "");
+  return `${meta.name} (${meta.courseCode}) \u2014 ${desc} \u2014 ${meta.university}`;
+}
+
+async function main() {
   if (!existsSync(indexHtmlPath)) {
     console.error("dist/index.html not found — run vite build first");
     process.exit(1);
@@ -43,7 +78,12 @@ function main() {
     process.exit(1);
   }
 
-  mkdirSync(outDir, { recursive: true });
+  const i18nDir = resolve(root, "src", "i18n");
+  const translations: Record<Lang, Translations> = {
+    en: ((await import(resolve(i18nDir, "en.ts"))) as { en: Translations }).en,
+    es: ((await import(resolve(i18nDir, "es.ts"))) as { es: Translations }).es,
+    gl: ((await import(resolve(i18nDir, "gl.ts"))) as { gl: Translations }).gl,
+  };
 
   const baseHtml = readFileSync(indexHtmlPath, "utf-8");
 
@@ -58,49 +98,81 @@ function main() {
 
   let generated = 0;
 
-  for (const subjectId of knownIds) {
-    const meta = subjectsMeta[subjectId];
-    if (!meta) continue;
+  for (const lang of Object.keys(LANGS) as Lang[]) {
+    const t = translations[lang];
+    const locale = LANGS[lang];
 
-    const ogImagePath = `/og/${subjectId}.png`;
-    const title = `${meta.name} \u2014 Pasame Ex\u00e1menes`;
-    const description = `${meta.name} (${meta.courseCode}): ${meta.questionCount} preguntas en ${meta.topicCount} temas con ${meta.examCount} ex\u00e1menes \u2014 ${meta.university}`;
-    const ogUrl = `https://pe.pablopl.dev/es/${subjectId}`;
+    mkdirSync(resolve(outDir, lang), { recursive: true });
 
-    let html = baseHtml;
+    for (const subjectId of knownIds) {
+      const meta = subjectsMeta[subjectId];
+      if (!meta) continue;
 
-    html = html.replace(
+      const imagePath = `/og/${subjectId}.png`;
+      const title = `${meta.name} \u2014 Pasame Ex\u00e1menes`;
+      const description = buildSubjectDescription(t, meta);
+      const ogUrl = `https://pe.pablopl.dev/${lang}/${subjectId}`;
+
+      let html = baseHtml;
+
+      html = html.replace(/<title>.*?<\/title>/, `<title>${title}</title>`);
+
+      html = html.replace(
+        /<meta id="og:image".*?\/?>/g,
+        `<meta id="og:image" property="og:image" content="${imagePath}" />`,
+      );
+      html = html.replace(
+        /<meta id="og:image:type".*?\/?>/g,
+        `<meta id="og:image:type" property="og:image:type" content="image/png" />`,
+      );
+      html = html.replace(
+        /<meta id="twitter:image".*?\/?>/g,
+        `<meta id="twitter:image" name="twitter:image" content="${imagePath}" />`,
+      );
+
+      html = replaceMetaContent(html, "og:title", title);
+      html = replaceMetaContent(html, "og:description", description);
+      html = replaceMetaContent(html, "og:url", ogUrl);
+      html = replaceMetaContent(html, "og:locale", locale);
+      html = replaceMetaContent(html, "twitter:title", title);
+      html = replaceMetaContent(html, "twitter:description", description);
+      html = replaceMetaContent(html, "meta-description", description);
+
+      const outPath = resolve(outDir, lang, `${subjectId}.html`);
+      writeFileSync(outPath, html);
+      generated++;
+    }
+
+    const homeTitle = "Pásame Exámenes";
+    const homeDescription = t.seo.homeDescription;
+    const homeMetaDesc = t.seo.defaultDescription;
+    const homeUrl = `https://pe.pablopl.dev/${lang}`;
+
+    let homeHtml = baseHtml;
+
+    homeHtml = homeHtml.replace(
       /<title>.*?<\/title>/,
-      `<title>${title}</title>`,
+      `<title>${homeTitle}</title>`,
     );
 
-    html = html.replace(
-      /<meta id="og:image".*?\/?>/g,
-      `<meta id="og:image" property="og:image" content="${ogImagePath}" />`,
-    );
-    html = html.replace(
-      /<meta id="og:image:type".*?\/?>/g,
-      `<meta id="og:image:type" property="og:image:type" content="image/png" />`,
-    );
-    html = html.replace(
-      /<meta id="twitter:image".*?\/?>/g,
-      `<meta id="twitter:image" name="twitter:image" content="${ogImagePath}" />`,
-    );
+    homeHtml = replaceMetaContent(homeHtml, "og:title", homeTitle);
+    homeHtml = replaceMetaContent(homeHtml, "og:description", homeDescription);
+    homeHtml = replaceMetaContent(homeHtml, "og:url", homeUrl);
+    homeHtml = replaceMetaContent(homeHtml, "og:locale", locale);
+    homeHtml = replaceMetaContent(homeHtml, "twitter:title", homeTitle);
+    homeHtml = replaceMetaContent(homeHtml, "twitter:description", homeDescription);
+    homeHtml = replaceMetaContent(homeHtml, "meta-description", homeMetaDesc);
 
-    html = replaceMeta(html, "og:title", title);
-    html = replaceMeta(html, "og:description", description);
-    html = replaceMeta(html, "og:url", ogUrl);
-    html = replaceMeta(html, "twitter:title", title);
-    html = replaceMeta(html, "twitter:description", description);
-    html = replaceMeta(html, "meta-description", description);
-
-    const outPath = resolve(outDir, `${subjectId}.html`);
-    writeFileSync(outPath, html);
-    console.log(`  ✓ ${subjectId}.html (${meta.name})`);
+    const homePath = resolve(outDir, lang, "home.html");
+    writeFileSync(homePath, homeHtml);
     generated++;
+    console.log(`  ✓ ${lang}/home.html`);
   }
 
-  console.log(`\nGenerated ${generated} subject pages → ${outDir}`);
+  console.log(`\nGenerated ${generated} subject+home pages → ${outDir}`);
 }
 
-main();
+main().catch((err) => {
+  console.error("Failed to generate subject pages:", err);
+  process.exit(1);
+});

--- a/scripts/generate-vercel-rewrites.ts
+++ b/scripts/generate-vercel-rewrites.ts
@@ -1,0 +1,51 @@
+import { readFileSync, writeFileSync, readdirSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+
+const __dirname = dirname(new URL(import.meta.url).pathname);
+const root = resolve(__dirname, "..");
+const subjectsDir = resolve(root, "src", "subjects");
+const templatePath = resolve(root, "vercel.template.json");
+const outputPath = resolve(root, "vercel.json");
+
+function main() {
+  const entries = readdirSync(subjectsDir, { withFileTypes: true });
+  const subjectDirs = entries.filter(
+    (e) => e.isDirectory() && e.name !== "_template",
+  );
+  const subjectIds = subjectDirs.map((d) => d.name).sort();
+
+  const langPattern = "(en|es|gl)";
+  const subjectPattern = `(${subjectIds.join("|")})`;
+
+  const rewrites = [
+    {
+      source: `/:lang${langPattern}`,
+      destination: "/og-pages/:lang/home.html",
+    },
+    {
+      source: `/:lang${langPattern}/:subjectId${subjectPattern}`,
+      destination: "/og-pages/:lang/:subjectId.html",
+    },
+    {
+      source: `/:lang${langPattern}/:subjectId${subjectPattern}/practice/:topic*`,
+      destination: "/og-pages/:lang/:subjectId.html",
+    },
+    {
+      source: `/:lang${langPattern}/:subjectId${subjectPattern}/exam/:year`,
+      destination: "/og-pages/:lang/:subjectId.html",
+    },
+    { source: "/en/(.*)", destination: "/index.html" },
+    { source: "/es/(.*)", destination: "/index.html" },
+    { source: "/gl/(.*)", destination: "/index.html" },
+    { source: "/(.*)", destination: "/index.html" },
+  ];
+
+  const template = readFileSync(templatePath, "utf-8");
+  const rewritesJson = JSON.stringify(rewrites, null, 4);
+  const output = template.replace("__REWRITES__", rewritesJson);
+
+  writeFileSync(outputPath, output);
+  console.log(`✓ Generated vercel.json with ${subjectIds.length} subjects`);
+}
+
+main();

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "rewrites": [
+    { "source": "/:lang/:subjectId", "destination": "/og-pages/:subjectId.html" },
+    { "source": "/:lang/:subjectId/practice/:topic", "destination": "/og-pages/:subjectId.html" },
+    { "source": "/:lang/:subjectId/exam/:year", "destination": "/og-pages/:subjectId.html" },
     { "source": "/en/(.*)", "destination": "/index.html" },
     { "source": "/es/(.*)", "destination": "/index.html" },
     { "source": "/gl/(.*)", "destination": "/index.html" },

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,10 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "rewrites": [
-    { "source": "/:lang/:subjectId", "destination": "/og-pages/:subjectId.html" },
-    { "source": "/:lang/:subjectId/practice/:topic", "destination": "/og-pages/:subjectId.html" },
-    { "source": "/:lang/:subjectId/exam/:year", "destination": "/og-pages/:subjectId.html" },
+    { "source": "/:lang", "destination": "/og-pages/:lang/home.html" },
+    { "source": "/:lang/:subjectId", "destination": "/og-pages/:lang/:subjectId.html" },
+    { "source": "/:lang/:subjectId/practice/:topic", "destination": "/og-pages/:lang/:subjectId.html" },
+    { "source": "/:lang/:subjectId/exam/:year", "destination": "/og-pages/:lang/:subjectId.html" },
     { "source": "/en/(.*)", "destination": "/index.html" },
     { "source": "/es/(.*)", "destination": "/index.html" },
     { "source": "/gl/(.*)", "destination": "/index.html" },

--- a/vercel.template.json
+++ b/vercel.template.json
@@ -1,39 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "rewrites": [
-    {
-        "source": "/:lang(en|es|gl)",
-        "destination": "/og-pages/:lang/home.html"
-    },
-    {
-        "source": "/:lang(en|es|gl)/:subjectId(cepe|ece|emeele|equisi|equispe|esei|eseo|iesede|pei)",
-        "destination": "/og-pages/:lang/:subjectId.html"
-    },
-    {
-        "source": "/:lang(en|es|gl)/:subjectId(cepe|ece|emeele|equisi|equispe|esei|eseo|iesede|pei)/practice/:topic*",
-        "destination": "/og-pages/:lang/:subjectId.html"
-    },
-    {
-        "source": "/:lang(en|es|gl)/:subjectId(cepe|ece|emeele|equisi|equispe|esei|eseo|iesede|pei)/exam/:year",
-        "destination": "/og-pages/:lang/:subjectId.html"
-    },
-    {
-        "source": "/en/(.*)",
-        "destination": "/index.html"
-    },
-    {
-        "source": "/es/(.*)",
-        "destination": "/index.html"
-    },
-    {
-        "source": "/gl/(.*)",
-        "destination": "/index.html"
-    },
-    {
-        "source": "/(.*)",
-        "destination": "/index.html"
-    }
-],
+  "rewrites": __REWRITES__,
   "headers": [
     {
       "source": "/assets/(.*)",


### PR DESCRIPTION
## Problem

Las OG images por asignatura (`/og/{subjectId}.png`) se generan en build y se setean en runtime con `useSeoHead()`. Pero al ser una SPA desplegada en Vercel con rewrite de todo a `/index.html`, los crawlers sociales (Twitter, Facebook, WhatsApp, Telegram, Discord...) que no ejecutan JS ven siempre la OG image por defecto (`/og.jpg`).

## Solución

Pipeline en 4 pasos, todo en build, sin dependencias nuevas:

### 1. Metadata de asignaturas

`generate-og-images.ts` ahora también escribe `public/subjects-meta.json` con metadata de cada asignatura (nombre, nº preguntas/temas/exámenes, universidad, etc.).

### 2. Rewrites restringidos

`generate-vercel-rewrites.ts` (nuevo) lee los subject IDs de `src/subjects/` y genera `vercel.json` con reglas que usan path-to-regexp para restringir `:lang` a `(en|es|gl)` y `:subjectId` a los IDs conocidos. Así rutas como `/fr` o `/en/inexistente` no matchean y caen al SPA catch-all.

```json
"/:lang(en|es|gl)" → "/og-pages/:lang/home.html"
"/:lang(en|es|gl)/:subjectId(cepe|ece|...)" → "/og-pages/:lang/:subjectId.html"
"/:lang(en|es|gl)/:subjectId(cepe|ece|...)/practice/:topic*" → "/og-pages/:lang/:subjectId.html"
"/:lang(en|es|gl)/:subjectId(cepe|ece|...)/exam/:year" → "/og-pages/:lang/:subjectId.html"
```

### 3. Páginas HTML por idioma

`generate-subject-pages.ts` (nuevo, post-vite-build) importa las traducciones de `src/i18n/` y genera 30 páginas en `dist/og-pages/`:
- 3 home (`en/home.html`, `es/home.html`, `gl/home.html`) con títulos y descripciones en el idioma correspondiente
- 27 de asignatura (9 subjects × 3 idiomas) con `og:image`, `og:title`, `og:description`, `og:url`, `og:locale`, `twitter:*` y `<meta name="description">` específicos por idioma

Los metadatos de asignatura (`name`, `courseCode`, `university`) se escapan con `htmlEscape()` para evitar HTML malformado si contuvieran `"`, `<` o `&`.

### 4. Fallback en index.html

`index.html` ahora incluye los meta tags OG/Twitter completos como baseline para JS-less crawlers cuando visitan la home o cualquier ruta sin página generada.

## Efecto

- Crawler visita `/en/cepe` → recibe HTML con `<meta property="og:image" content="/og/cepe.png">` y descripción en inglés
- Crawler visita `/es` → recibe HTML con descripción en español
- Crawler visita `/gl/esei` → recibe HTML con descripción en gallego
- Crawler visita `/fr` o `/en/inexistente` → rewrite no matchea, cae al SPA catch-all, la app carga y redirige/muestra not-found
- Usuarios reales: el SPA carga normalmente, `useSeoHead()` sobreescribe los meta tags con las versiones completas (locale, canonical, hreflang)
- Sin cambios en runtime, sin dependencias nuevas, sin añadir latencia