### PR TITLE
Distinguish authorized and community content

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-exam.yml
+++ b/.github/ISSUE_TEMPLATE/add-exam.yml
@@ -1,18 +1,29 @@
-name: Añadir nuevos exámenes/pruebas/recopilatorios
-description: Solicitar añadir exámenes/pruebas/recopilatorios de años anteriores a una asignatura existente
+name: Añadir material de práctica autorizado
+description: Solicitar añadir exámenes autorizados, pruebas, recopilatorios o ejercicios originales a una asignatura existente
 title: "[Nuevo Examen]"
 labels: ["new-exam", "enhancement"]
 body:
   - type: markdown
     attributes:
       value: |
-        ¡Gracias por ayudar a ampliar Pásame Exámenes! Usa esta plantilla para solicitar que se añadan exámenes/pruebas/recopilatorios de años anteriores a una asignatura que ya existe en la plataforma.
+        ¡Gracias por ayudar a ampliar Pásame Exámenes! Usa esta plantilla para solicitar que se añadan exámenes autorizados, pruebas, recopilatorios o ejercicios originales a una asignatura que ya existe en la plataforma.
+
+        No envíes enunciados, PDFs o materiales docentes protegidos si no tienes permiso para compartirlos.
+
+  - type: checkboxes
+    id: rights-confirmation
+    attributes:
+      label: Derechos de uso
+      description: Confirma que el material puede compartirse en la plataforma.
+      options:
+        - label: El material es original, tengo autorización para compartirlo, o procede de una fuente pública/permitida.
+          required: true
 
   - type: input
     id: subject
     attributes:
       label: Asignatura
-      description: ¿A qué asignatura pertenece este examen? (ej. "eseo", "emeele")
+      description: ¿A qué asignatura pertenece este material? (ej. "eseo", "emeele")
       placeholder: "ej: eseo"
     validations:
       required: true
@@ -20,8 +31,8 @@ body:
   - type: input
     id: exam-year
     attributes:
-      label: Año del examen
-      description: El año (y opcionalmente mes) del examen a añadir
+      label: Año o identificador
+      description: El año, mes o identificador del examen/prueba/recopilatorio a añadir
       placeholder: "ej: 2025 o 2024-06"
     validations:
       required: true
@@ -55,15 +66,15 @@ body:
   - type: checkboxes
     id: has-pdf
     attributes:
-      label: ¿Tienes el PDF del examen?
-      description: Marca esta casilla si dispones del PDF del examen para compartir, de tenerlo, adjuntalo más adelante.
+      label: ¿Tienes un PDF autorizado?
+      description: Marca esta casilla solo si dispones de un PDF que puede compartirse públicamente o con autorización.
       options:
-        - label: Tengo el PDF del examen (o similar)
+        - label: Tengo un PDF autorizado o público que puede compartirse
 
   - type: textarea
     id: questions
     attributes:
       label: Preguntas y soluciones (opcional)
       description: |
-        Si dispones de las preguntas y sus soluciones, puedes detallarlas aquí.
-        Cuanta más información proporciones, más rápido se podrá añadir el examen.
+        Si dispones de preguntas y soluciones originales o autorizadas, puedes detallarlas aquí.
+        Cuanta más información proporciones, más rápido se podrá revisar y añadir el material.

--- a/.github/ISSUE_TEMPLATE/add-exam.yml
+++ b/.github/ISSUE_TEMPLATE/add-exam.yml
@@ -1,12 +1,12 @@
-name: Añadir nuevos exámenes
-description: Solicitar añadir exámenes de años anteriores a una asignatura existente
+name: Añadir nuevos exámenes/pruebas/recopilatorios
+description: Solicitar añadir exámenes/pruebas/recopilatorios de años anteriores a una asignatura existente
 title: "[Nuevo Examen]"
 labels: ["new-exam", "enhancement"]
 body:
   - type: markdown
     attributes:
       value: |
-        ¡Gracias por ayudar a ampliar Pásame Exámenes! Usa esta plantilla para solicitar que se añadan exámenes de años anteriores a una asignatura que ya existe en la plataforma.
+        ¡Gracias por ayudar a ampliar Pásame Exámenes! Usa esta plantilla para solicitar que se añadan exámenes/pruebas/recopilatorios de años anteriores a una asignatura que ya existe en la plataforma.
 
   - type: input
     id: subject

--- a/.github/ISSUE_TEMPLATE/suggest-subject.yml
+++ b/.github/ISSUE_TEMPLATE/suggest-subject.yml
@@ -48,9 +48,9 @@ body:
   - type: textarea
     id: exam-info
     attributes:
-      label: Información sobre los exámenes
+      label: Información sobre los exámenes/pruebas/recopilatorios
       description: |
-        ¿De qué años hay exámenes disponibles? ¿Cuánto duran? ¿Cuántos puntos valen?
+        ¿De qué años hay exámenes/pruebas/recopilatorios disponibles? ¿Cuánto duran? ¿Cuántos puntos valen?
         Si tienes los PDFs, puedes mencionarlo aquí.
       placeholder: |
         - Examen 2024: 60 puntos, 3 horas, 15 preguntas

--- a/.github/ISSUE_TEMPLATE/suggest-subject.yml
+++ b/.github/ISSUE_TEMPLATE/suggest-subject.yml
@@ -8,6 +8,8 @@ body:
       value: |
         ¡Gracias por sugerir una nueva asignatura para Pásame Exámenes! Cuanta más información proporciones, más fácil será añadirla.
 
+        No envíes enunciados, PDFs o materiales docentes protegidos si no tienes permiso para compartirlos.
+
   - type: input
     id: subject-name
     attributes:
@@ -48,10 +50,10 @@ body:
   - type: textarea
     id: exam-info
     attributes:
-      label: Información sobre los exámenes/pruebas/recopilatorios
+      label: Información sobre exámenes autorizados/pruebas/recopilatorios
       description: |
-        ¿De qué años hay exámenes/pruebas/recopilatorios disponibles? ¿Cuánto duran? ¿Cuántos puntos valen?
-        Si tienes los PDFs, puedes mencionarlo aquí.
+        ¿De qué años hay exámenes autorizados, pruebas o recopilatorios disponibles? ¿Cuánto duran? ¿Cuántos puntos valen?
+        Si tienes PDFs que pueden compartirse públicamente o con autorización, puedes mencionarlo aquí.
       placeholder: |
         - Examen 2024: 60 puntos, 3 horas, 15 preguntas
         - Examen 2023: 50 puntos, 2.5 horas, 12 preguntas

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,17 @@
 # Contribuir a Pásame Exámenes
 
-¡Gracias por ayudar a hacer crecer esta plataforma open source de práctica de exámenes!
+¡Gracias por ayudar a hacer crecer esta plataforma open source de práctica universitaria!
+
+## Derechos de autor y fuentes
+
+Solo se aceptan contenidos que cumplan al menos una de estas condiciones:
+
+- Son ejercicios originales creados por quien contribuye.
+- Proceden de exámenes o materiales publicados oficialmente con permiso para compartirse.
+- Han sido proporcionados o autorizados por el profesorado o la institución.
+- Proceden de una fuente pública compatible con su uso en la plataforma.
+
+No envíes enunciados, PDFs, soluciones o materiales docentes protegidos si no tienes autorización para compartirlos. Si una asignatura no comparte sus exámenes, aporta ejercicios originales basados en el temario en lugar de recreaciones exactas.
 
 ## Cómo contribuir
 
@@ -31,6 +42,7 @@ export const meta: SubjectMeta = {
   icon: "📚",
   acknowledgments:
     "Preguntas proporcionadas por el departamento de... Respuestas por...", // opcional, se muestra al final de la página
+  contentPolicy: "community-practice", // "authorized-exams" solo si los exámenes pueden compartirse
   topics: [
     {
       key: "tema-slug",
@@ -155,15 +167,15 @@ Pista: recuerda que \`foo()\` se llama recursivamente.`,
 
 **Preguntas repetidas:** Si una misma pregunta (o una variante casi idéntica) aparece en varios exámenes con distinto `exam`, marca `repeated: true` en cada ocurrencia. La interfaz mostrará un contador de repetidas en la página de la asignatura.
 
-#### 4. Añade los PDFs de los exámenes
+#### 4. Añade PDFs autorizados, si los hay
 
-Copia los PDFs originales a `public/exams/{subject-id}/`:
+Copia únicamente PDFs que puedan compartirse públicamente o con autorización a `public/exams/{subject-id}/`:
 
 ```
 public/exams/{subject-id}/Exam-2024.pdf
 ```
 
-La convención es `Exam-{year}.pdf`. Si un examen no tiene PDF, marca `hasPdf: false` en su entrada de `meta.ts` para que el enlace de descarga no aparezca. Si ningún examen tiene PDF, la sección entera se oculta automáticamente.
+La convención es `Exam-{year}.pdf`. Si un examen o recopilatorio no tiene PDF autorizado, marca `hasPdf: false` en su entrada de `meta.ts` para que el enlace de descarga no aparezca. Si ningún elemento tiene PDF, la sección entera se oculta automáticamente.
 
 #### 5. Añade imágenes (si las hay)
 
@@ -222,15 +234,16 @@ pnpm dev
 
 La asignatura debe aparecer en la pantalla principal y todas las funcionalidades deben funcionar.
 
-### Flujo de trabajo para extraer preguntas de PDFs
+### Flujo de trabajo para añadir preguntas desde material autorizado
 
-1. Abre el PDF e identifica cada pregunta
-2. Clasifícala como `mc`, `text` o `matching`
-3. Asígnale un tema de tu array `topics` en `meta.ts`
-4. Para MC: escribe las opciones exactamente como aparecen, marca la letra correcta
-5. Para text: escribe una solución modelo
-6. Para matching: crea el mapeo ítem → letra
-7. Incluye notas explicativas en `explanation` cuando aporten contexto adicional
+1. Comprueba que tienes permiso para usar el material o redacta preguntas originales basadas en el temario
+2. Abre el PDF autorizado o tus notas e identifica cada pregunta
+3. Clasifícala como `mc`, `text` o `matching`
+4. Asígnale un tema de tu array `topics` en `meta.ts`
+5. Para MC: escribe opciones originales o autorizadas, marca la letra correcta
+6. Para text: escribe una solución modelo
+7. Para matching: crea el mapeo ítem → letra
+8. Incluye notas explicativas en `explanation` cuando aporten contexto adicional
 
 ## Estructura del proyecto
 
@@ -303,7 +316,7 @@ src/
 public/
 ├── favicon.svg
 ├── og.jpg
-└── exams/                    # PDFs originales; no todas las asignaturas tienen PDFs
+└── exams/                    # PDFs autorizados; no todas las asignaturas tienen PDFs
     ├── cepe/
     ├── ece/
     ├── emeele/
@@ -330,7 +343,8 @@ No hay script `test` ni `typecheck` separado: `pnpm build` es la verificación d
 - [ ] Todas las `topic` en `questions.ts` existen en `meta.ts`
 - [ ] Las preguntas MC tienen opciones y una letra válida (`"a"`–`"e"`)
 - [ ] Los bloques de código usan `\`\`\`` en template literals de TypeScript
-- [ ] Los PDFs están en `public/exams/{subject-id}/` o los exámenes sin PDF tienen `hasPdf: false`
+- [ ] El contenido es original, autorizado o procede de una fuente pública compatible
+- [ ] Los PDFs autorizados están en `public/exams/{subject-id}/` o los elementos sin PDF tienen `hasPdf: false`
 - [ ] Las imágenes están en `src/subjects/{subject-id}/assets/` e importadas correctamente (usa `image` para el enunciado y `explanationImage` para la solución)
 - [ ] Las preguntas repetidas están marcadas con `repeated: true`
 - [ ] Si añadiste una asignatura, sus exports están registrados en `src/subjects/_visibility.ts`

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 <div align="center">
 <br/>
-<b>Pásame Exámenes</b> es una plataforma open source para practicar "exámenes" universitarios por tema o simular el examen completo con temporizador y autocorrección.
+<b>Pásame Exámenes</b> es una plataforma open source para practicar preguntas universitarias por tema o en modo cronometrado con temporizador y autocorrección.
 <br/>
 </div>
 
@@ -38,9 +38,9 @@ Cada asignatura es una carpeta autónoma dentro de `src/subjects/`. Solo necesit
 
 Elige un tema y practica pregunta a pregunta. Cada pregunta se corrige individualmente, con explicaciones detalladas y posibilidad de auto-evaluarte en las preguntas abiertas. Tu progreso por tema se guarda automáticamente.
 
-### Modo Examen
+### Modo cronometrado
 
-Simula el examen real: temporizador en cuenta atrás, puntuación en directo, y auto-entrega opcional. Al terminar, revisas todas las respuestas y ves si apruebas o suspendes.
+Practica con temporizador, puntuación en directo y auto-entrega opcional. En asignaturas con exámenes autorizados puede reflejar el formato real; en el resto usa recopilatorios o ejercicios originales con estructura orientativa.
 
 ### Tipos de pregunta
 
@@ -90,13 +90,16 @@ El build genera automáticamente imágenes Open Graph por asignatura y página p
 
 ¡Toda contribución es bienvenida! Puedes:
 
-- Añadir **nuevas asignaturas** con sus exámenes/pruebas/recopilatorios
+- Añadir **nuevas asignaturas** con exámenes autorizados, pruebas, recopilatorios o ejercicios originales
 - Corregir **errores** en preguntas existentes
 - Reportar **issues** directamente desde cualquier pregunta
 - Mejorar la **web** (features, diseño, accesibilidad)
 
 > [!IMPORTANT]  
 > Lee la [guía de contribución](./CONTRIBUTING.md) para empezar.
+
+> [!CAUTION]
+> No se aceptan enunciados, PDFs o materiales docentes protegidos sin autorización para compartirlos.
 
 ## Licencia
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 <div align="center">
 <br/>
-<b>Pásame Exámenes</b> es una plataforma open source para practicar exámenes universitarios por tema o simular el examen completo con temporizador y autocorrección.
+<b>Pásame Exámenes</b> es una plataforma open source para practicar "exámenes" universitarios por tema o simular el examen completo con temporizador y autocorrección.
 <br/>
 </div>
 
@@ -50,7 +50,7 @@ Simula el examen real: temporizador en cuenta atrás, puntuación en directo, y 
 
 ## Asignaturas
 
-| Asignatura                          | Universidad            | Exámenes       |
+| Asignatura                          | Universidad            | Exámenes/etc   |
 | ----------------------------------- | ---------------------- | -------------- |
 | 💽 Sistemas Operativos              | Universidade da Coruña | 9 (2020–2024)  |
 | 🧠 Sistemas Intelixentes            | Universidade da Coruña | 5 (2023–2026)  |
@@ -90,7 +90,7 @@ El build genera automáticamente imágenes Open Graph por asignatura y página p
 
 ¡Toda contribución es bienvenida! Puedes:
 
-- Añadir **nuevas asignaturas** con sus exámenes
+- Añadir **nuevas asignaturas** con sus exámenes/pruebas/recopilatorios
 - Corregir **errores** en preguntas existentes
 - Reportar **issues** directamente desde cualquier pregunta
 - Mejorar la **web** (features, diseño, accesibilidad)

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
     <meta
       id="meta-description"
       name="description"
-      content="Practica exámenes universitarios con respuestas modelo y autocorrección. Preguntas tipo test, de desarrollo y de emparejar de exámenes anteriores."
+      content='Practica "exámenes" universitarios con respuestas modelo y autocorrección. Preguntas tipo test, de desarrollo y de emparejar de exámenes anteriores.'
     />
     <!-- Default OG/twitter tags for JS-less crawlers.
          Per-subject tags are set dynamically by useSeoHead at runtime. -->
@@ -56,7 +56,7 @@
     <meta
       id="og:description"
       property="og:description"
-      content="Plataforma de código abierto para practicar exámenes universitarios por tema o simular el examen completo."
+      content='Plataforma de código abierto para practicar "exámenes" universitarios por tema o simular el examen completo.'
     />
     <meta id="og:image" property="og:image" content="/og.jpg" />
     <meta id="og:image:type" property="og:image:type" content="image/jpeg" />
@@ -70,7 +70,7 @@
     <meta
       id="twitter:description"
       name="twitter:description"
-      content="Plataforma de código abierto para practicar exámenes universitarios por tema o simular el examen completo."
+      content='Plataforma de código abierto para practicar "exámenes" universitarios por tema o simular el examen completo.'
     />
     <meta id="twitter:card" name="twitter:card" content="summary_large_image" />
     <meta id="twitter:image" name="twitter:image" content="/og.jpg" />

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
     <meta
       id="meta-description"
       name="description"
-      content='Practica "exámenes" universitarios con respuestas modelo y autocorrección. Preguntas tipo test, de desarrollo y de emparejar de exámenes anteriores.'
+      content="Practica preguntas universitarias con respuestas modelo y autocorrección. Preguntas tipo test, de desarrollo y de emparejar."
     />
     <!-- Default OG/twitter tags for JS-less crawlers.
          Per-subject tags are set dynamically by useSeoHead at runtime. -->
@@ -56,7 +56,7 @@
     <meta
       id="og:description"
       property="og:description"
-      content='Plataforma de código abierto para practicar "exámenes" universitarios por tema o simular el examen completo.'
+      content="Plataforma de código abierto para practicar preguntas universitarias por tema o en modo cronometrado."
     />
     <meta id="og:image" property="og:image" content="/og.jpg" />
     <meta id="og:image:type" property="og:image:type" content="image/jpeg" />
@@ -70,7 +70,7 @@
     <meta
       id="twitter:description"
       name="twitter:description"
-      content='Plataforma de código abierto para practicar "exámenes" universitarios por tema o simular el examen completo.'
+      content="Plataforma de código abierto para practicar preguntas universitarias por tema o en modo cronometrado."
     />
     <meta id="twitter:card" name="twitter:card" content="summary_large_image" />
     <meta id="twitter:image" name="twitter:image" content="/og.jpg" />

--- a/scripts/generate-og-images.ts
+++ b/scripts/generate-og-images.ts
@@ -24,6 +24,16 @@ const TEXT_PRIMARY = "#111827";
 const TEXT_SECONDARY = "#6B7280";
 const BUTTON_BG = "#16A34A";
 const BUTTON_TEXT = "#FFFFFF";
+const BADGE_BORDER = "#D1D5DB";
+const BADGE_BG = "#FFFFFF";
+const BADGE_AUTHORIZED_TEXT = "#15803D";
+const BADGE_COMMUNITY_TEXT = "#2563EB";
+const BADGE_AUTHORIZED_BG = "#F0FDF4";
+const BADGE_AUTHORIZED_BORDER = "#BBF7D0";
+const BADGE_COMMUNITY_BG = "#EFF6FF";
+const BADGE_COMMUNITY_BORDER = "#93C5FD";
+
+type ContentPolicy = "authorized-exams" | "community-practice";
 
 GlobalFonts.registerFromPath(resolve(fontsDir, "inter-regular.ttf"), "Inter");
 GlobalFonts.registerFromPath(resolve(fontsDir, "inter-bold.ttf"), "Inter");
@@ -64,12 +74,81 @@ function roundedRectPath(
   ctx.closePath();
 }
 
+function drawMortarboardIcon(
+  ctx: ReturnType<ReturnType<typeof createCanvas>["getContext"]>,
+  x: number,
+  y: number,
+) {
+  ctx.beginPath();
+  ctx.moveTo(x + 14, y + 2);
+  ctx.bezierCurveTo(x + 13.4, y + 1.7, x + 12.6, y + 1.7, x + 12, y + 2);
+  ctx.lineTo(x + 2.2, y + 6.9);
+  ctx.bezierCurveTo(x + 1.4, y + 7.3, x + 1.4, y + 8.7, x + 2.2, y + 9.1);
+  ctx.lineTo(x + 12, y + 14);
+  ctx.bezierCurveTo(x + 12.6, y + 14.3, x + 13.4, y + 14.3, x + 14, y + 14);
+  ctx.lineTo(x + 21.8, y + 10.1);
+  ctx.lineTo(x + 21.8, y + 16);
+  ctx.bezierCurveTo(x + 21.8, y + 17.1, x + 22.7, y + 18, x + 23.8, y + 18);
+  ctx.bezierCurveTo(x + 24.9, y + 18, x + 25.8, y + 17.1, x + 25.8, y + 16);
+  ctx.lineTo(x + 25.8, y + 8);
+  ctx.bezierCurveTo(x + 25.8, y + 7.4, x + 25.4, y + 6.9, x + 24.8, y + 6.7);
+  ctx.lineTo(x + 14, y + 2);
+  ctx.closePath();
+  ctx.fill();
+
+  ctx.beginPath();
+  ctx.roundRect(x + 5.5, y + 12.7, 15, 8.3, 3);
+  ctx.fill();
+}
+
+function drawCommunityIcon(
+  ctx: ReturnType<ReturnType<typeof createCanvas>["getContext"]>,
+  x: number,
+  y: number,
+) {
+  ctx.beginPath();
+  ctx.arc(x + 9.5, y + 7.5, 5.4, 0, Math.PI * 2);
+  ctx.arc(x + 20.5, y + 8, 4.8, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.beginPath();
+  ctx.roundRect(x + 1, y + 16, 18, 10.5, 4.5);
+  ctx.roundRect(x + 16.5, y + 17, 13.5, 9.5, 4.5);
+  ctx.fill();
+}
+
+function drawPolicyBadgeIcon(
+  ctx: ReturnType<ReturnType<typeof createCanvas>["getContext"]>,
+  x: number,
+  y: number,
+  isAuthorized: boolean,
+) {
+  roundedRectPath(ctx, x, y, 36, 36, 7);
+  ctx.fillStyle = isAuthorized ? BADGE_AUTHORIZED_BG : BADGE_COMMUNITY_BG;
+  ctx.fill();
+  ctx.strokeStyle = isAuthorized
+    ? BADGE_AUTHORIZED_BORDER
+    : BADGE_COMMUNITY_BORDER;
+  ctx.lineWidth = 2;
+  ctx.stroke();
+
+  ctx.fillStyle = isAuthorized
+    ? BADGE_AUTHORIZED_TEXT
+    : BADGE_COMMUNITY_TEXT;
+  if (isAuthorized) {
+    drawMortarboardIcon(ctx, x + 5, y + 7);
+  } else {
+    drawCommunityIcon(ctx, x + 3, y + 5);
+  }
+}
+
 async function generateOgImage(
   icon: string,
   title: string,
   questionCount: number,
   topicCount: number,
   examCount: number,
+  contentPolicy: ContentPolicy,
   faviconSvg: Buffer,
 ): Promise<Buffer> {
   const canvas = createCanvas(W, H);
@@ -116,14 +195,39 @@ async function generateOgImage(
   ctx.font = `400 37px Inter`;
   ctx.fillStyle = TEXT_SECONDARY;
   ctx.textAlign = "left";
-  const stats = `${questionCount} preguntas · ${topicCount} temas · ${examCount} "exámenes"`;
-  ctx.fillText(stats, 71, 437);
+  const hasAuthorizedExams = contentPolicy === "authorized-exams";
+  const examLabel = hasAuthorizedExams ? "exámenes" : "recopilatorios";
+  const stats = `${questionCount} preguntas · ${topicCount} temas · ${examCount} ${examLabel}`;
+  const statsY = 421;
+  ctx.fillText(stats, 71, statsY);
+
+  const policyLabel = hasAuthorizedExams
+    ? "Exámenes verificados"
+    : "Recopilatorios comunitarios";
+  const badgeX = 71;
+  const badgeY = 476;
+  const badgeH = 45;
+  ctx.font = `600 24px Inter`;
+  const badgeW = Math.ceil(ctx.measureText(policyLabel).width) + 91;
+  roundedRectPath(ctx, badgeX, badgeY, badgeW, badgeH, 12);
+  ctx.fillStyle = BADGE_BG;
+  ctx.fill();
+  ctx.strokeStyle = BADGE_BORDER;
+  ctx.lineWidth = 2;
+  ctx.stroke();
+
+  drawPolicyBadgeIcon(ctx, badgeX + 5, badgeY + 4.5, hasAuthorizedExams);
+  ctx.fillStyle = hasAuthorizedExams
+    ? BADGE_AUTHORIZED_TEXT
+    : BADGE_COMMUNITY_TEXT;
+  ctx.textBaseline = "middle";
+  ctx.fillText(policyLabel, badgeX + 58, badgeY + badgeH / 2);
 
   ctx.textAlign = "center";
   const btnX = 827;
-  const btnY = 437;
+  const btnY = statsY;
   const btnW = 299;
-  const btnH = 84;
+  const btnH = badgeY + badgeH - statsY;
   roundedRectPath(ctx, btnX, btnY, btnW, btnH, 12);
   ctx.fillStyle = BUTTON_BG;
   ctx.fill();
@@ -178,6 +282,7 @@ async function main() {
           icon: string;
           topics: unknown[];
           exams: unknown[];
+          contentPolicy?: ContentPolicy;
           university: string;
           courseCode: string;
         };
@@ -185,12 +290,14 @@ async function main() {
       const { meta } = mod;
 
       const questionCount = countQuestions(questionsPath);
+      const contentPolicy = meta.contentPolicy ?? "community-practice";
       const png = await generateOgImage(
         meta.icon,
         meta.name,
         questionCount,
         meta.topics.length,
         meta.exams.length,
+        contentPolicy,
         faviconSvg,
       );
 
@@ -204,6 +311,7 @@ async function main() {
         questionCount,
         topicCount: meta.topics.length,
         examCount: meta.exams.length,
+        contentPolicy,
         university: meta.university,
         courseCode: meta.courseCode,
       };

--- a/scripts/generate-og-images.ts
+++ b/scripts/generate-og-images.ts
@@ -116,7 +116,7 @@ async function generateOgImage(
   ctx.font = `400 37px Inter`;
   ctx.fillStyle = TEXT_SECONDARY;
   ctx.textAlign = "left";
-  const stats = `${questionCount} preguntas · ${topicCount} temas · ${examCount} exámenes`;
+  const stats = `${questionCount} preguntas · ${topicCount} temas · ${examCount} "exámenes"`;
   ctx.fillText(stats, 71, 437);
 
   ctx.textAlign = "center";

--- a/scripts/generate-og-images.ts
+++ b/scripts/generate-og-images.ts
@@ -108,6 +108,7 @@ function drawCommunityIcon(
 ) {
   ctx.beginPath();
   ctx.arc(x + 9.5, y + 7.5, 5.4, 0, Math.PI * 2);
+  ctx.moveTo(x + 20.5 + 4.8, y + 8);
   ctx.arc(x + 20.5, y + 8, 4.8, 0, Math.PI * 2);
   ctx.fill();
 
@@ -262,6 +263,7 @@ async function main() {
       questionCount: number;
       topicCount: number;
       examCount: number;
+      contentPolicy: ContentPolicy;
       university: string;
       courseCode: string;
     }

--- a/src/components/AddExamModal.tsx
+++ b/src/components/AddExamModal.tsx
@@ -96,6 +96,10 @@ function AddExamModal({
         </div>
 
         <div className="space-y-3">
+          <p className="rounded-xl border border-border bg-surface/50 p-3 text-xs text-fg-muted">
+            {t.addExam.legalNotice}
+          </p>
+
           <a
             href={issueUrl}
             target="_blank"

--- a/src/components/ContentPolicyIcon.tsx
+++ b/src/components/ContentPolicyIcon.tsx
@@ -1,0 +1,66 @@
+import type { SubjectMeta } from "../data/types";
+import { useT } from "../i18n/hooks";
+import { hasAuthorizedExamContent } from "../lib/content-policy";
+
+interface ContentPolicyIconProps {
+  subject: SubjectMeta;
+  className?: string;
+  svgOnly?: boolean;
+}
+
+export default function ContentPolicyIcon({
+  subject,
+  className = "",
+  svgOnly = false,
+}: ContentPolicyIconProps) {
+  const t = useT();
+  const isAuthorized = hasAuthorizedExamContent(subject);
+  const label = isAuthorized
+    ? t.contentPolicy.authorized
+    : t.contentPolicy.community;
+  const icon = isAuthorized ? (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      className={svgOnly ? className : "size-4"}
+      role={svgOnly ? "img" : undefined}
+      aria-label={svgOnly ? label : undefined}
+      aria-hidden={svgOnly ? undefined : "true"}
+    >
+      <path d="M10 3.25a1 1 0 00-.447.106l-7 3.5a1 1 0 000 1.788l7 3.5a1 1 0 00.894 0l5.553-2.776V13a1 1 0 102 0V7.75a1 1 0 00-.553-.894l-7-3.5A1 1 0 0010 3.25z" />
+      <path d="M5 10.35v2.15c0 1.933 2.239 3.5 5 3.5s5-1.567 5-3.5v-2.15l-3.658 1.829a3 3 0 01-2.684 0L5 10.35z" />
+    </svg>
+  ) : (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      className={svgOnly ? className : "size-4"}
+      role={svgOnly ? "img" : undefined}
+      aria-label={svgOnly ? label : undefined}
+      aria-hidden={svgOnly ? undefined : "true"}
+    >
+      <path d="M7 8a3 3 0 100-6 3 3 0 000 6zM13 9a2.5 2.5 0 100-5 2.5 2.5 0 000 5zM7 10c-2.761 0-5 1.79-5 4v1a1 1 0 001 1h8a1 1 0 001-1v-1c0-2.21-2.239-4-5-4zM13.5 11c-.587 0-1.146.104-1.657.293A4.78 4.78 0 0114 15v1h3a1 1 0 001-1v-.5c0-1.933-2.015-3.5-4.5-3.5z" />
+    </svg>
+  );
+
+  if (svgOnly) {
+    return icon;
+  }
+
+  return (
+    <span
+      className={`inline-flex size-6 shrink-0 items-center justify-center rounded border ${
+        isAuthorized
+          ? "border-accent-border bg-accent-light text-accent-fg"
+          : "border-contribute-border bg-contribute-bg text-contribute-fg"
+      } ${className}`}
+      role="img"
+      aria-label={label}
+      title={label}
+    >
+      {icon}
+    </span>
+  );
+}

--- a/src/components/CopyrightReportModal.tsx
+++ b/src/components/CopyrightReportModal.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useImperativeHandle, useRef, type Ref } from "react";
+import { useT } from "../i18n/hooks";
+import { track } from "../lib/umami";
+
+export interface CopyrightReportModalHandle {
+  open: () => void;
+  close: () => void;
+}
+
+interface CopyrightReportModalProps {
+  onClose: () => void;
+  subjectId: string;
+  subjectName: string;
+  ref: Ref<CopyrightReportModalHandle>;
+}
+
+function CopyrightReportModal({
+  onClose,
+  subjectId,
+  subjectName,
+  ref,
+}: CopyrightReportModalProps) {
+  const t = useT();
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const closeMethodRef = useRef<"x" | "backdrop" | "esc">("backdrop");
+
+  useImperativeHandle(ref, () => ({
+    open: () => dialogRef.current?.showModal(),
+    close: () => dialogRef.current?.close(),
+  }));
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    const handleBackdropClick = (e: MouseEvent) => {
+      if (e.target === dialog) {
+        closeMethodRef.current = "backdrop";
+        dialog.close();
+      }
+    };
+    const handleCancel = () => {
+      closeMethodRef.current = "esc";
+    };
+    dialog.addEventListener("click", handleBackdropClick);
+    dialog.addEventListener("cancel", handleCancel);
+    return () => {
+      dialog.removeEventListener("click", handleBackdropClick);
+      dialog.removeEventListener("cancel", handleCancel);
+    };
+  }, []);
+
+  const emailSubject = t.copyrightReport.emailSubject.replace(
+    "{subjectName}",
+    subjectName,
+  );
+  const emailBody = t.copyrightReport.emailBody
+    .replace("{subjectName}", subjectName)
+    .replace("{subjectId}", subjectId);
+  const mailtoUrl = `mailto:pablo.portas@udc.es?subject=${encodeURIComponent(emailSubject)}&body=${encodeURIComponent(emailBody)}`;
+
+  return (
+    <dialog
+      ref={dialogRef}
+      className="animate-dialog m-auto max-w-sm rounded-2xl bg-surface-alt p-6 shadow-2xl backdrop:bg-black/50 backdrop:transition-[background-color,overlay,display] backdrop:duration-200"
+      aria-labelledby="copyright-report-title"
+      onClose={() => {
+        track("modal_close", {
+          modal: "copyright_report",
+          method: closeMethodRef.current,
+          subjectId,
+        });
+        onClose();
+      }}
+    >
+      <div>
+        <div className="flex items-center justify-between mb-5">
+          <h2
+            id="copyright-report-title"
+            className="text-lg font-semibold text-fg"
+          >
+            {t.copyrightReport.title}
+          </h2>
+          <button
+            type="button"
+            onClick={() => {
+              closeMethodRef.current = "x";
+              dialogRef.current?.close();
+            }}
+            className="text-fg-muted hover:text-fg-secondary transition-colors cursor-pointer"
+            aria-label={t.copyrightReport.close}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="size-5"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+            >
+              <path
+                fillRule="evenodd"
+                d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </button>
+        </div>
+
+        <div className="space-y-4">
+          <p className="text-sm text-fg-secondary">
+            {t.copyrightReport.description}
+          </p>
+          <p className="text-sm text-fg-muted">
+            {t.copyrightReport.includeDetails}
+          </p>
+
+          <a
+            href={mailtoUrl}
+            onClick={() => track("copyright_report_email", { subjectId })}
+            className="flex items-center gap-3 p-3 rounded-xl border-2 border-t-red-border bg-t-red-bg/70 hover:bg-t-red-bg hover:border-t-red-hover transition-colors cursor-pointer text-left no-underline text-fg"
+          >
+            <span className="text-xl text-t-red-hover" aria-hidden="true">
+              !
+            </span>
+            <div>
+              <div className="font-medium text-sm">
+                {t.copyrightReport.email}
+              </div>
+              <div className="text-xs text-fg-muted">pablo.portas@udc.es</div>
+            </div>
+          </a>
+        </div>
+      </div>
+    </dialog>
+  );
+}
+
+export default CopyrightReportModal;

--- a/src/components/CopyrightReportModal.tsx
+++ b/src/components/CopyrightReportModal.tsx
@@ -2,6 +2,8 @@ import { useEffect, useImperativeHandle, useRef, type Ref } from "react";
 import { useT } from "../i18n/hooks";
 import { track } from "../lib/umami";
 
+const CONTACT_EMAIL = "pablo.portas@udc.es";
+
 export interface CopyrightReportModalHandle {
   open: () => void;
   close: () => void;
@@ -57,7 +59,7 @@ function CopyrightReportModal({
   const emailBody = t.copyrightReport.emailBody
     .replace("{subjectName}", subjectName)
     .replace("{subjectId}", subjectId);
-  const mailtoUrl = `mailto:pablo.portas@udc.es?subject=${encodeURIComponent(emailSubject)}&body=${encodeURIComponent(emailBody)}`;
+  const mailtoUrl = `mailto:${CONTACT_EMAIL}?subject=${encodeURIComponent(emailSubject)}&body=${encodeURIComponent(emailBody)}`;
 
   return (
     <dialog
@@ -125,7 +127,7 @@ function CopyrightReportModal({
               <div className="font-medium text-sm">
                 {t.copyrightReport.email}
               </div>
-              <div className="text-xs text-fg-muted">pablo.portas@udc.es</div>
+              <div className="text-xs text-fg-muted">{CONTACT_EMAIL}</div>
             </div>
           </a>
         </div>

--- a/src/components/SubjectCard.tsx
+++ b/src/components/SubjectCard.tsx
@@ -14,6 +14,9 @@ interface SubjectCardProps {
 export default function SubjectCard({ subject }: SubjectCardProps) {
   const t = useT();
   const [questionCount, setQuestionCount] = useState<number | null>(null);
+  const availableExamCount = subject.exams.filter(
+    (exam) => !exam.deleteRights,
+  ).length;
 
   useEffect(() => {
     let mounted = true;
@@ -59,7 +62,7 @@ export default function SubjectCard({ subject }: SubjectCardProps) {
         </span>
         <span>&middot;</span>
         <span>
-          {subject.exams.length} {t.subjectCard.exams}
+          {availableExamCount} {t.subjectCard.exams}
         </span>
       </div>
     </Link>

--- a/src/components/SubjectCard.tsx
+++ b/src/components/SubjectCard.tsx
@@ -6,6 +6,8 @@ import { track } from "../lib/umami";
 import { triggerLight } from "../lib/haptics";
 import { recordSubjectClick } from "../lib/recent";
 import { getAllQuestions } from "../subjects";
+import { hasAuthorizedExamContent } from "../lib/content-policy";
+import ContentPolicyIcon from "./ContentPolicyIcon";
 
 interface SubjectCardProps {
   subject: SubjectMeta;
@@ -17,6 +19,9 @@ export default function SubjectCard({ subject }: SubjectCardProps) {
   const availableExamCount = subject.exams.filter(
     (exam) => !exam.deleteRights,
   ).length;
+  const examCountLabel = hasAuthorizedExamContent(subject)
+    ? t.subjectCard.exams
+    : t.subjectCard.practiceSets;
 
   useEffect(() => {
     let mounted = true;
@@ -45,9 +50,12 @@ export default function SubjectCard({ subject }: SubjectCardProps) {
         <span className="text-2xl" aria-hidden="true">
           {subject.icon}
         </span>
-        <span className="text-xs font-mono font-semibold bg-code text-fg-secondary px-2 py-0.5 rounded">
-          {subject.courseCode}
-        </span>
+        <div className="flex items-center gap-2">
+          <ContentPolicyIcon subject={subject} />
+          <span className="inline-flex h-6 items-center rounded bg-code px-2 font-mono text-xs font-semibold text-fg-secondary">
+            {subject.courseCode}
+          </span>
+        </div>
       </div>
       <h2 className="font-semibold text-fg text-base mb-1">{subject.name}</h2>
       <p className="text-sm text-fg-muted mb-4">{subject.university}</p>
@@ -62,7 +70,7 @@ export default function SubjectCard({ subject }: SubjectCardProps) {
         </span>
         <span>&middot;</span>
         <span>
-          {availableExamCount} {t.subjectCard.exams}
+          {availableExamCount} {examCountLabel}
         </span>
       </div>
     </Link>

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -43,6 +43,8 @@ export interface MegaTopic {
   topics: string[];
 }
 
+export type ContentPolicy = "authorized-exams" | "community-practice";
+
 export interface Exam {
   year: string;
   title: string;
@@ -62,6 +64,7 @@ export interface SubjectMeta {
   university: string;
   courseCode: string;
   icon: string;
+  contentPolicy?: ContentPolicy;
   acknowledgments?: string;
   topics: Topic[];
   megatopics?: MegaTopic[];

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -53,6 +53,7 @@ export interface Exam {
   description: string;
   hasPdf?: boolean;
   daypoUrl?: string;
+  deleteRights?: boolean;
 }
 
 export interface SubjectMeta {

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -2,7 +2,7 @@ export const en = {
   home: {
     title: "Pásame Exámenes",
     subtitle:
-      "Open-source platform for practicing university exams. Choose a subject below to start drilling questions from past exams.",
+      'Open-source platform for practicing university "exams". Choose a subject below to start drilling questions from past exams.',
     addSubject: "Add Subject?",
     recentlyVisited: "Recently visited",
     clearRecent: "Clear recent subjects",
@@ -13,7 +13,7 @@ export const en = {
     description:
       "Practice {count} questions{repeated} from {exams} exams with model answers and self-grading.",
     practiceByTopic: "Practice by Topic",
-    examSimulations: "Full Exam Simulations",
+    examSimulations: "Complete exam simulations/tests/compilations",
     originalExams: "Original Exam Documents",
     examDocsDescription:
       "Download or view the original PDF exams that these practice questions and simulations are based on.",
@@ -22,8 +22,8 @@ export const en = {
       "Open the original Daypo tests used as the source for these practice questions.",
     daypo: "Daypo",
     pdf: "PDF",
-    acknowledgments: "Acknowledgments",
-    addExam: "Add Exam?",
+    acknowledgments: "Acknowledgments and Disclaimer",
+    addExam: "Add exam/test/compilation?",
     repeatedSuffix: "{count} repeated questions across years",
   },
   practiceHome: {
@@ -101,14 +101,13 @@ export const en = {
     topics: "topics",
     questions: "questions",
     points: "points",
-    exams: "exams",
+    exams: '"exams"',
   },
   addSubject: {
     title: "Add a Subject",
     close: "Close",
     openIssue: "Open an Issue",
-    openIssueDesc:
-      "Request a new subject via a pre-filled GitHub issue template",
+    openIssueDesc: "Request a new test via a pre-filled GitHub issue template",
     openIssueUrl:
       "https://github.com/TeenBiscuits/Pasame-Examenes/issues/new?template=suggest-subject.yml",
     contribute: "Contribute!",
@@ -184,7 +183,7 @@ export const en = {
     siteName: "Pásame Exámenes",
     locale: "en_US",
     homeDescription:
-      "Open-source platform for practicing university exams by topic or simulating the full exam.",
+      'Open-source platform for practicing university "exams" by topic or simulating the full exam.',
     defaultDescription:
       "Practice university exams with model answers and self-grading. Multiple-choice, text, and matching questions from past exams.",
   },

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -23,7 +23,9 @@ export const en = {
     daypo: "Daypo",
     pdf: "PDF",
     acknowledgments: "Acknowledgments and Disclaimer",
-    addExam: "Add exam/test/compilation?",
+    addExam: "Add?",
+    reportCopyright: "Report copyright",
+    copyrightRemoved: "Removed for copyright reasons",
     repeatedSuffix: "{count} repeated questions across years",
   },
   practiceHome: {
@@ -127,6 +129,18 @@ export const en = {
     contributeDesc:
       "Follow the contribution guide to add it yourself via pull request",
     email: "Send an email",
+  },
+  copyrightReport: {
+    title: "Report copyright",
+    close: "Close",
+    description:
+      "If an exam, test, compilation, or question should be removed for copyright reasons, send an email to pablo.portas@udc.es.",
+    includeDetails:
+      "Please include the subject, exam/year or affected question, and the reason for the removal request.",
+    email: "Send removal request",
+    emailSubject: "Copyright removal request - {subjectName}",
+    emailBody:
+      "Subject: {subjectName}\nSubject ID: {subjectId}\n\nAffected exam/year or question:\n\nReason for removal request:\n",
   },
   tour: {
     next: "Next",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -2,7 +2,7 @@ export const en = {
   home: {
     title: "Pásame Exámenes",
     subtitle:
-      'Open-source platform for practicing university "exams". Choose a subject below to start drilling questions from past exams.',
+      "Open-source platform for practicing university questions. Choose a subject below to study by topic or timed practice set.",
     addSubject: "Add Subject?",
     recentlyVisited: "Recently visited",
     clearRecent: "Clear recent subjects",
@@ -12,11 +12,17 @@ export const en = {
     returnHome: "Return to Home",
     description:
       "Practice {count} questions{repeated} from {exams} exams with model answers and self-grading.",
+    communityDescription:
+      "Practice {count} questions{repeated} from {exams} compilations with model answers and self-grading.",
     practiceByTopic: "Practice by Topic",
-    examSimulations: "Complete exam simulations/tests/compilations",
+    examSimulations: "Exams",
+    practiceSimulations: "Compilations",
     originalExams: "Original Exam Documents",
     examDocsDescription:
       "Download or view the original PDF exams that these practice questions and simulations are based on.",
+    sourceMaterials: "Source Materials",
+    sourceMaterialsDescription:
+      "Open the authorized or public source materials used for these practice questions.",
     originalDaypos: "Original Daypo Tests",
     daypoDocsDescription:
       "Open the original Daypo tests used as the source for these practice questions.",
@@ -72,6 +78,8 @@ export const en = {
     startExam: "Start Exam",
     simulationNote:
       "This simulation mirrors the real exam format. For open-ended questions, self-grade your answers against the model solutions shown after submission. MC and matching questions are auto-graded.",
+    practiceNote:
+      "This timed practice uses an indicative structure for studying. For open-ended questions, self-grade your answers against the model solutions shown after submission. MC and matching questions are auto-graded.",
     submitted: "Exam Submitted.",
     passThreshold: "Pass threshold",
     reviewNote:
@@ -103,13 +111,18 @@ export const en = {
     topics: "topics",
     questions: "questions",
     points: "points",
-    exams: '"exams"',
+    exams: "exams",
+    practiceSets: "compilations",
+  },
+  contentPolicy: {
+    authorized: "Verified exam materials",
+    community: "Community practice materials",
   },
   addSubject: {
     title: "Add a Subject",
     close: "Close",
     openIssue: "Open an Issue",
-    openIssueDesc: "Request a new test via a pre-filled GitHub issue template",
+    openIssueDesc: "Request a new subject via a pre-filled GitHub issue template",
     openIssueUrl:
       "https://github.com/TeenBiscuits/Pasame-Examenes/issues/new?template=suggest-subject.yml",
     contribute: "Contribute!",
@@ -118,17 +131,19 @@ export const en = {
     email: "Send an email",
   },
   addExam: {
-    title: "Add an Exam",
+    title: "Add Practice Material",
     close: "Close",
     openIssue: "Open an Issue",
     openIssueDesc:
-      "Request a new exam for this subject via a pre-filled GitHub issue template",
+      "Propose an authorized exam, practice set, or original exercises via a GitHub issue template",
     openIssueUrl:
       "https://github.com/TeenBiscuits/Pasame-Examenes/issues/new?template=add-exam.yml",
     contribute: "Contribute!",
     contributeDesc:
-      "Follow the contribution guide to add it yourself via pull request",
+      "Follow the contribution guide to add authorized or original content via pull request",
     email: "Send an email",
+    legalNotice:
+      "Only submit original content, authorized materials, or public sources with permission to share.",
   },
   copyrightReport: {
     title: "Report copyright",
@@ -170,6 +185,8 @@ export const en = {
       step1Title: "Exam Simulation",
       step1Desc:
         "This simulates the real exam format. The timer is counting down, so manage your time wisely! The pass threshold is shown here.",
+      practiceStep1Desc:
+        "This is a timed practice set with an indicative structure. The timer is counting down, so manage your time wisely! The pass threshold is shown here.",
       step2Title: "Question Navigator",
       step2Desc:
         "Click numbered buttons to jump between questions. Answered questions are highlighted so you can track your progress.",
@@ -197,9 +214,9 @@ export const en = {
     siteName: "Pásame Exámenes",
     locale: "en_US",
     homeDescription:
-      'Open-source platform for practicing university "exams" by topic or simulating the full exam.',
+      "Open-source platform for practicing university questions by topic or timed practice set.",
     defaultDescription:
-      "Practice university exams with model answers and self-grading. Multiple-choice, text, and matching questions from past exams.",
+      "Practice university questions with model answers and self-grading. Multiple-choice, text, and matching questions.",
   },
 };
 

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -4,7 +4,7 @@ export const es: Translations = {
   home: {
     title: "Pásame Exámenes",
     subtitle:
-      "Plataforma de código abierto para practicar exámenes universitarios. Elige una asignatura para empezar a practicar con preguntas de exámenes anteriores.",
+      'Plataforma de código abierto para practicar "exámenes" universitarios. Elige una asignatura para empezar a practicar con preguntas de exámenes anteriores.',
     addSubject: "¿Añadir asignatura?",
     recentlyVisited: "Visitadas recientemente",
     clearRecent: "Limpiar asignaturas recientes",
@@ -15,7 +15,8 @@ export const es: Translations = {
     description:
       "Practica {count} preguntas{repeated} de {exams} exámenes con respuestas modelo y autocorrección.",
     practiceByTopic: "Practicar por tema",
-    examSimulations: "Simulaciones de examen completas",
+    examSimulations:
+      "Simulaciones de exámenes/pruebas/recopilatorios completas",
     originalExams: "Documentos originales de examen",
     examDocsDescription:
       "Descarga o visualiza los PDFs originales en los que se basan estas preguntas y simulaciones.",
@@ -24,8 +25,8 @@ export const es: Translations = {
       "Abre los tests Daypo originales usados como fuente para estas preguntas de práctica.",
     daypo: "Daypo",
     pdf: "PDF",
-    acknowledgments: "Agradecimientos",
-    addExam: "¿Añadir examen?",
+    acknowledgments: "Agradecimientos y exención de responsabilidad",
+    addExam: "¿Añadir examen/prueba/recopilatorio?",
     repeatedSuffix: "{count} repetidas a lo largo de los años",
   },
   practiceHome: {
@@ -103,7 +104,7 @@ export const es: Translations = {
     topics: "temas",
     questions: "preguntas",
     points: "puntos",
-    exams: "exámenes",
+    exams: '"exámenes"',
   },
   addSubject: {
     title: "Añadir asignatura",
@@ -119,11 +120,11 @@ export const es: Translations = {
     email: "Escribe un correo",
   },
   addExam: {
-    title: "Añadir examen",
+    title: "Añadir examen/prueba/recopilatorio",
     close: "Cerrar",
     openIssue: "Abrir un issue",
     openIssueDesc:
-      "Solicita un nuevo examen para esta asignatura usando la plantilla de GitHub",
+      "Solicita una nueva prueba para esta asignatura usando la plantilla de GitHub",
     openIssueUrl:
       "https://github.com/TeenBiscuits/Pasame-Examenes/issues/new?template=add-exam.yml",
     contribute: "¡Contribuye!",
@@ -156,7 +157,7 @@ export const es: Translations = {
         "Usa los botones Anterior / Siguiente o las teclas de flecha (← →) para moverte entre preguntas.",
     },
     exam: {
-      step1Title: "Simulación de examen",
+      step1Title: "Simulación de prueba",
       step1Desc:
         "Esto simula el formato real del examen. ¡El temporizador está en marcha, gestiona bien tu tiempo! El umbral de aprobado se muestra aquí.",
       step2Title: "Navegador de preguntas",
@@ -186,7 +187,7 @@ export const es: Translations = {
     siteName: "Pásame Exámenes",
     locale: "es_ES",
     homeDescription:
-      "Plataforma de código abierto para practicar exámenes universitarios por tema o simular el examen completo.",
+      'Plataforma de código abierto para practicar "exámenes" universitarios por tema o simular el examen completo.',
     defaultDescription:
       "Practica exámenes universitarios con respuestas modelo y autocorrección. Preguntas tipo test, de desarrollo y de emparejar de exámenes anteriores.",
   },

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -26,7 +26,9 @@ export const es: Translations = {
     daypo: "Daypo",
     pdf: "PDF",
     acknowledgments: "Agradecimientos y exención de responsabilidad",
-    addExam: "¿Añadir examen/prueba/recopilatorio?",
+    addExam: "¿Añadir?",
+    reportCopyright: "Reportar derechos de autor",
+    copyrightRemoved: "Retirada por derechos de autor",
     repeatedSuffix: "{count} repetidas a lo largo de los años",
   },
   practiceHome: {
@@ -131,6 +133,18 @@ export const es: Translations = {
     contributeDesc:
       "Sigue la guía de contribución para añadirlo tú mismo con un pull request",
     email: "Escribe un correo",
+  },
+  copyrightReport: {
+    title: "Reportar derechos de autor",
+    close: "Cerrar",
+    description:
+      "Si un examen, prueba, recopilatorio o pregunta debe retirarse por derechos de autor, envía un correo a pablo.portas@udc.es.",
+    includeDetails:
+      "Incluye la asignatura, el examen/año o pregunta afectada y el motivo de la solicitud de retirada.",
+    email: "Enviar solicitud de retirada",
+    emailSubject: "Solicitud de retirada por derechos de autor - {subjectName}",
+    emailBody:
+      "Asignatura: {subjectName}\nID de asignatura: {subjectId}\n\nExamen/año o pregunta afectada:\n\nMotivo de la solicitud de retirada:\n",
   },
   tour: {
     next: "Siguiente",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -4,7 +4,7 @@ export const es: Translations = {
   home: {
     title: "Pásame Exámenes",
     subtitle:
-      'Plataforma de código abierto para practicar "exámenes" universitarios. Elige una asignatura para empezar a practicar con preguntas de exámenes anteriores.',
+      "Plataforma de código abierto para practicar preguntas universitarias. Elige una asignatura para estudiar por tema o en modo cronometrado.",
     addSubject: "¿Añadir asignatura?",
     recentlyVisited: "Visitadas recientemente",
     clearRecent: "Limpiar asignaturas recientes",
@@ -14,12 +14,17 @@ export const es: Translations = {
     returnHome: "Volver al inicio",
     description:
       "Practica {count} preguntas{repeated} de {exams} exámenes con respuestas modelo y autocorrección.",
+    communityDescription:
+      "Practica {count} preguntas{repeated} de {exams} recopilatorios con respuestas modelo y autocorrección.",
     practiceByTopic: "Practicar por tema",
-    examSimulations:
-      "Simulaciones de exámenes/pruebas/recopilatorios completas",
+    examSimulations: "Exámenes",
+    practiceSimulations: "Recopilatorios",
     originalExams: "Documentos originales de examen",
     examDocsDescription:
       "Descarga o visualiza los PDFs originales en los que se basan estas preguntas y simulaciones.",
+    sourceMaterials: "Materiales fuente",
+    sourceMaterialsDescription:
+      "Abre los materiales autorizados o públicos usados como fuente para estas preguntas de práctica.",
     originalDaypos: "Tests Daypo originales",
     daypoDocsDescription:
       "Abre los tests Daypo originales usados como fuente para estas preguntas de práctica.",
@@ -75,6 +80,8 @@ export const es: Translations = {
     startExam: "Comenzar examen",
     simulationNote:
       "Esta simulación refleja el formato real del examen. Para las preguntas abiertas, autoevalúa tus respuestas con las soluciones modelo que se muestran tras enviar. Las preguntas de test y emparejar se autocorrigen.",
+    practiceNote:
+      "Esta práctica cronometrada usa una estructura orientativa para estudiar. Para las preguntas abiertas, autoevalúa tus respuestas con las soluciones modelo que se muestran tras enviar. Las preguntas de test y emparejar se autocorrigen.",
     submitted: "Examen enviado.",
     passThreshold: "Umbral de aprobado",
     reviewNote:
@@ -106,7 +113,12 @@ export const es: Translations = {
     topics: "temas",
     questions: "preguntas",
     points: "puntos",
-    exams: '"exámenes"',
+    exams: "exámenes",
+    practiceSets: "recopilatorios",
+  },
+  contentPolicy: {
+    authorized: "Materiales de examen verificados",
+    community: "Materiales de práctica de la comunidad",
   },
   addSubject: {
     title: "Añadir asignatura",
@@ -122,17 +134,19 @@ export const es: Translations = {
     email: "Escribe un correo",
   },
   addExam: {
-    title: "Añadir examen/prueba/recopilatorio",
+    title: "Añadir material de práctica",
     close: "Cerrar",
     openIssue: "Abrir un issue",
     openIssueDesc:
-      "Solicita una nueva prueba para esta asignatura usando la plantilla de GitHub",
+      "Propón un examen autorizado, recopilatorio o ejercicios originales usando la plantilla de GitHub",
     openIssueUrl:
       "https://github.com/TeenBiscuits/Pasame-Examenes/issues/new?template=add-exam.yml",
     contribute: "¡Contribuye!",
     contributeDesc:
-      "Sigue la guía de contribución para añadirlo tú mismo con un pull request",
+      "Sigue la guía de contribución para añadir contenido autorizado u original con un pull request",
     email: "Escribe un correo",
+    legalNotice:
+      "Envía solo contenido original, materiales autorizados o fuentes públicas con permiso para compartirse.",
   },
   copyrightReport: {
     title: "Reportar derechos de autor",
@@ -174,6 +188,8 @@ export const es: Translations = {
       step1Title: "Simulación de prueba",
       step1Desc:
         "Esto simula el formato real del examen. ¡El temporizador está en marcha, gestiona bien tu tiempo! El umbral de aprobado se muestra aquí.",
+      practiceStep1Desc:
+        "Esto es una práctica cronometrada con estructura orientativa. ¡El temporizador está en marcha, gestiona bien tu tiempo! El umbral de aprobado se muestra aquí.",
       step2Title: "Navegador de preguntas",
       step2Desc:
         "Haz clic en los botones numerados para saltar entre preguntas. Las respondidas se resaltan para seguir tu progreso.",
@@ -201,8 +217,8 @@ export const es: Translations = {
     siteName: "Pásame Exámenes",
     locale: "es_ES",
     homeDescription:
-      'Plataforma de código abierto para practicar "exámenes" universitarios por tema o simular el examen completo.',
+      "Plataforma de código abierto para practicar preguntas universitarias por tema o en modo cronometrado.",
     defaultDescription:
-      "Practica exámenes universitarios con respuestas modelo y autocorrección. Preguntas tipo test, de desarrollo y de emparejar de exámenes anteriores.",
+      "Practica preguntas universitarias con respuestas modelo y autocorrección. Preguntas tipo test, de desarrollo y de emparejar.",
   },
 };

--- a/src/i18n/gl.ts
+++ b/src/i18n/gl.ts
@@ -4,7 +4,7 @@ export const gl: Translations = {
   home: {
     title: "Pásame Exámenes",
     subtitle:
-      "Plataforma de código aberto para practicar exames universitarios. Elixe unha materia para comezar a practicar con preguntas de exames anteriores.",
+      'Plataforma de código aberto para practicar "exames" universitarios. Elixe unha materia para comezar a practicar con preguntas de exames anteriores.',
     addSubject: "Engadir materia?",
     recentlyVisited: "Visitadas recentemente",
     clearRecent: "Limpar materias recentes",
@@ -15,7 +15,7 @@ export const gl: Translations = {
     description:
       "Practica {count} preguntas{repeated} de {exams} exames con respostas modelo e autocorrección.",
     practiceByTopic: "Practicar por tema",
-    examSimulations: "Simulacións de exame completas",
+    examSimulations: "Simulacións/probas/compilacións de exames completos",
     originalExams: "Documentos orixinais de exame",
     examDocsDescription:
       "Descarga ou visualiza os PDFs orixinais nos que se basean estas preguntas e simulacións.",
@@ -24,8 +24,8 @@ export const gl: Translations = {
       "Abre os tests Daypo orixinais usados como fonte para estas preguntas de práctica.",
     daypo: "Daypo",
     pdf: "PDF",
-    acknowledgments: "Agradecementos",
-    addExam: "Engadir exame?",
+    acknowledgments: "Agradecementos e exención de responsabilidade",
+    addExam: "Engadir exame/proba/compilación?",
     repeatedSuffix: "{count} repetidas ao longo dos anos",
   },
   practiceHome: {
@@ -103,7 +103,7 @@ export const gl: Translations = {
     topics: "temas",
     questions: "preguntas",
     points: "puntos",
-    exams: "exames",
+    exams: '"exames"',
   },
   addSubject: {
     title: "Engadir materia",
@@ -122,7 +122,7 @@ export const gl: Translations = {
     close: "Pechar",
     openIssue: "Abrir un issue",
     openIssueDesc:
-      "Solicita un novo exame para esta materia usando o modelo de GitHub",
+      "Solicita unha nova proba para esta materia usando o modelo de GitHub",
     openIssueUrl:
       "https://github.com/TeenBiscuits/Pasame-Examenes/issues/new?template=add-exam.yml",
     contribute: "Contribúe!",
@@ -155,7 +155,7 @@ export const gl: Translations = {
         "Usa os botóns Anterior / Seguinte ou as teclas de frecha (← →) para moverte entre preguntas.",
     },
     exam: {
-      step1Title: "Simulación de exame",
+      step1Title: "Simulación de proba",
       step1Desc:
         "Isto simula o formato real do exame. O temporizador está en marcha, xestiona ben o teu tempo! O limiar de aprobado móstrase aquí.",
       step2Title: "Navegador de preguntas",
@@ -185,7 +185,7 @@ export const gl: Translations = {
     siteName: "Pásame Exámenes",
     locale: "gl_ES",
     homeDescription:
-      "Plataforma de código aberto para practicar exames universitarios por tema ou simular o exame completo.",
+      'Plataforma de código aberto para practicar "exames" universitarios por tema ou simular o exame completo.',
     defaultDescription:
       "Practica exames universitarios con respostas modelo e autocorrección. Preguntas tipo test, de desenvolvemento e de emparellar de exames anteriores.",
   },

--- a/src/i18n/gl.ts
+++ b/src/i18n/gl.ts
@@ -4,7 +4,7 @@ export const gl: Translations = {
   home: {
     title: "Pásame Exámenes",
     subtitle:
-      'Plataforma de código aberto para practicar "exames" universitarios. Elixe unha materia para comezar a practicar con preguntas de exames anteriores.',
+      "Plataforma de código aberto para practicar preguntas universitarias. Elixe unha materia para estudar por tema ou en modo cronometrado.",
     addSubject: "Engadir materia?",
     recentlyVisited: "Visitadas recentemente",
     clearRecent: "Limpar materias recentes",
@@ -14,11 +14,17 @@ export const gl: Translations = {
     returnHome: "Volver ao inicio",
     description:
       "Practica {count} preguntas{repeated} de {exams} exames con respostas modelo e autocorrección.",
+    communityDescription:
+      "Practica {count} preguntas{repeated} de {exams} recompilacións con respostas modelo e autocorrección.",
     practiceByTopic: "Practicar por tema",
-    examSimulations: "Simulacións/probas/compilacións de exames completos",
+    examSimulations: "Exames",
+    practiceSimulations: "Recompilacións",
     originalExams: "Documentos orixinais de exame",
     examDocsDescription:
       "Descarga ou visualiza os PDFs orixinais nos que se basean estas preguntas e simulacións.",
+    sourceMaterials: "Materiais fonte",
+    sourceMaterialsDescription:
+      "Abre os materiais autorizados ou públicos usados como fonte para estas preguntas de práctica.",
     originalDaypos: "Tests Daypo orixinais",
     daypoDocsDescription:
       "Abre os tests Daypo orixinais usados como fonte para estas preguntas de práctica.",
@@ -74,6 +80,8 @@ export const gl: Translations = {
     startExam: "Comezar exame",
     simulationNote:
       "Esta simulación reflicte o formato real do exame. Para as preguntas abertas, autoavalia as túas respostas coas solucións modelo que se mostran tras enviar. As preguntas de test e emparellar autocorríxense.",
+    practiceNote:
+      "Esta práctica cronometrada usa unha estrutura orientativa para estudar. Para as preguntas abertas, autoavalia as túas respostas coas solucións modelo que se mostran tras enviar. As preguntas de test e emparellar autocorríxense.",
     submitted: "Exame enviado.",
     passThreshold: "Limiar de aprobado",
     reviewNote:
@@ -105,7 +113,12 @@ export const gl: Translations = {
     topics: "temas",
     questions: "preguntas",
     points: "puntos",
-    exams: '"exames"',
+    exams: "exames",
+    practiceSets: "recompilacións",
+  },
+  contentPolicy: {
+    authorized: "Materiais de exame verificados",
+    community: "Materiais de práctica da comunidade",
   },
   addSubject: {
     title: "Engadir materia",
@@ -120,17 +133,19 @@ export const gl: Translations = {
     email: "Escribe un correo",
   },
   addExam: {
-    title: "Engadir exame",
+    title: "Engadir material de práctica",
     close: "Pechar",
     openIssue: "Abrir un issue",
     openIssueDesc:
-      "Solicita unha nova proba para esta materia usando o modelo de GitHub",
+      "Propón un exame autorizado, recompilación ou exercicios orixinais usando o modelo de GitHub",
     openIssueUrl:
       "https://github.com/TeenBiscuits/Pasame-Examenes/issues/new?template=add-exam.yml",
     contribute: "Contribúe!",
     contributeDesc:
-      "Segue a guía de contribución para engadilo ti mesmo cun pull request",
+      "Segue a guía de contribución para engadir contido autorizado ou orixinal cun pull request",
     email: "Escribe un correo",
+    legalNotice:
+      "Envía só contido orixinal, materiais autorizados ou fontes públicas con permiso para compartirse.",
   },
   copyrightReport: {
     title: "Reportar dereitos de autor",
@@ -172,6 +187,8 @@ export const gl: Translations = {
       step1Title: "Simulación de proba",
       step1Desc:
         "Isto simula o formato real do exame. O temporizador está en marcha, xestiona ben o teu tempo! O limiar de aprobado móstrase aquí.",
+      practiceStep1Desc:
+        "Isto é unha práctica cronometrada cunha estrutura orientativa. O temporizador está en marcha, xestiona ben o teu tempo! O limiar de aprobado móstrase aquí.",
       step2Title: "Navegador de preguntas",
       step2Desc:
         "Fai clic nos botóns numerados para saltar entre preguntas. As respondidas resáltanse para seguir o teu progreso.",
@@ -199,8 +216,8 @@ export const gl: Translations = {
     siteName: "Pásame Exámenes",
     locale: "gl_ES",
     homeDescription:
-      'Plataforma de código aberto para practicar "exames" universitarios por tema ou simular o exame completo.',
+      "Plataforma de código aberto para practicar preguntas universitarias por tema ou en modo cronometrado.",
     defaultDescription:
-      "Practica exames universitarios con respostas modelo e autocorrección. Preguntas tipo test, de desenvolvemento e de emparellar de exames anteriores.",
+      "Practica preguntas universitarias con respostas modelo e autocorrección. Preguntas tipo test, de desenvolvemento e de emparellar.",
   },
 };

--- a/src/i18n/gl.ts
+++ b/src/i18n/gl.ts
@@ -25,7 +25,9 @@ export const gl: Translations = {
     daypo: "Daypo",
     pdf: "PDF",
     acknowledgments: "Agradecementos e exención de responsabilidade",
-    addExam: "Engadir exame/proba/compilación?",
+    addExam: "Engadir?",
+    reportCopyright: "Reportar dereitos de autor",
+    copyrightRemoved: "Retirada por dereitos de autor",
     repeatedSuffix: "{count} repetidas ao longo dos anos",
   },
   practiceHome: {
@@ -129,6 +131,18 @@ export const gl: Translations = {
     contributeDesc:
       "Segue a guía de contribución para engadilo ti mesmo cun pull request",
     email: "Escribe un correo",
+  },
+  copyrightReport: {
+    title: "Reportar dereitos de autor",
+    close: "Pechar",
+    description:
+      "Se un exame, proba, compilación ou pregunta debe retirarse por dereitos de autor, envía un correo a pablo.portas@udc.es.",
+    includeDetails:
+      "Inclúe a materia, o exame/ano ou pregunta afectada e o motivo da solicitude de retirada.",
+    email: "Enviar solicitude de retirada",
+    emailSubject: "Solicitude de retirada por dereitos de autor - {subjectName}",
+    emailBody:
+      "Materia: {subjectName}\nID da materia: {subjectId}\n\nExame/ano ou pregunta afectada:\n\nMotivo da solicitude de retirada:\n",
   },
   tour: {
     next: "Seguinte",

--- a/src/index.css
+++ b/src/index.css
@@ -33,6 +33,7 @@ body {
   --color-code-block: #111827;
   /* Contribute button */
   --color-contribute-bg: #eff6ff;
+  --color-contribute-fg: #2563eb;
   --color-contribute-border: #93c5fd;
   --color-contribute-hover-bg: #dbeafe;
   --color-contribute-hover-border: #60a5fa;
@@ -83,6 +84,7 @@ html[data-theme="dark"] {
   --color-code-block: #030712;
   /* Contribute button */
   --color-contribute-bg: #172554;
+  --color-contribute-fg: #93c5fd;
   --color-contribute-border: #1e3a8a;
   --color-contribute-hover-bg: #1e3a8a;
   --color-contribute-hover-border: #2563eb;
@@ -150,6 +152,7 @@ html[data-theme="catppuccin"] {
   --color-code-block: #11111b;
   /* Contribute button */
   --color-contribute-bg: #313244;
+  --color-contribute-fg: #89b4fa;
   --color-contribute-border: #45475a;
   --color-contribute-hover-bg: #45475a;
   --color-contribute-hover-border: #89b4fa;
@@ -201,6 +204,7 @@ html[data-theme="catppuccin"] {
     --color-code-block: #030712;
     /* Contribute button */
     --color-contribute-bg: #172554;
+    --color-contribute-fg: #93c5fd;
     --color-contribute-border: #1e3a8a;
     --color-contribute-hover-bg: #1e3a8a;
     --color-contribute-hover-border: #2563eb;

--- a/src/lib/content-policy.ts
+++ b/src/lib/content-policy.ts
@@ -1,0 +1,5 @@
+import type { SubjectMeta } from "../data/types";
+
+export function hasAuthorizedExamContent(subject: SubjectMeta): boolean {
+  return subject.contentPolicy === "authorized-exams";
+}

--- a/src/pages/ExamSimulation.tsx
+++ b/src/pages/ExamSimulation.tsx
@@ -416,7 +416,7 @@ export default function ExamSimulation() {
     Record<string, string>
   >({});
   const examInfo = useMemo(
-    () => subject?.exams.find((e: Exam) => e.year === year),
+    () => subject?.exams.find((e: Exam) => e.year === year && !e.deleteRights),
     [subject, year],
   );
   useEffect(() => {
@@ -541,8 +541,10 @@ export default function ExamSimulation() {
   });
 
   useEffect(() => {
-    if (!subject || !examInfo) {
+    if (!subject) {
       navigate(langTo("/"), { replace: true });
+    } else if (!examInfo) {
+      navigate(langTo(`/${subject.id}`), { replace: true });
     }
   }, [subject, examInfo, navigate, langTo]);
 

--- a/src/pages/ExamSimulation.tsx
+++ b/src/pages/ExamSimulation.tsx
@@ -20,6 +20,7 @@ import { buildExamMeta } from "../seo/meta";
 import { useExamSession } from "../hooks/useExamSession";
 import { useKeyboardNav } from "../hooks/useKeyboardNav";
 import { startExamTour } from "../lib/tour";
+import { hasAuthorizedExamContent } from "../lib/content-policy";
 
 function formatTime(seconds: number) {
   const h = Math.floor(seconds / 3600);
@@ -44,6 +45,9 @@ function ExamStartScreen({
   onStart,
 }: ExamStartScreenProps) {
   const t = useT();
+  const simulationNote = hasAuthorizedExamContent(subject)
+    ? t.exam.simulationNote
+    : t.exam.practiceNote;
   return (
     <div className="max-w-2xl mx-auto px-4 py-16 animate-fade-in animate-duration-fast">
       <div className="mb-6">
@@ -91,7 +95,7 @@ function ExamStartScreen({
           </div>
         </div>
         <div className="bg-amber-50 border border-amber-200 rounded-lg p-4 text-sm text-amber-800">
-          {t.exam.simulationNote}
+          {simulationNote}
         </div>
         <button
           type="button"
@@ -570,6 +574,10 @@ export default function ExamSimulation() {
 
   useEffect(() => {
     if (!started || questions.length === 0) return;
+    const step1Description =
+      subject && hasAuthorizedExamContent(subject)
+        ? t.tour.exam.step1Desc
+        : t.tour.exam.practiceStep1Desc;
     const timer = setTimeout(() => {
       startExamTour(
         [
@@ -577,7 +585,7 @@ export default function ExamSimulation() {
             element: '[data-tour="exam-header"]',
             popover: {
               title: t.tour.exam.step1Title,
-              description: t.tour.exam.step1Desc,
+              description: step1Description,
               side: "bottom",
             },
           },
@@ -622,7 +630,7 @@ export default function ExamSimulation() {
       );
     }, 500);
     return () => clearTimeout(timer);
-  }, [started, questions.length, t]);
+  }, [started, questions.length, subject, t]);
 
   const totalPoints = questions.reduce((s, q) => s + q.points, 0);
 

--- a/src/pages/SubjectHome.tsx
+++ b/src/pages/SubjectHome.tsx
@@ -10,6 +10,7 @@ import AddExamModal, {
 import CopyrightReportModal, {
   type CopyrightReportModalHandle,
 } from "../components/CopyrightReportModal";
+import ContentPolicyIcon from "../components/ContentPolicyIcon";
 import type { Question, Topic } from "../data/types";
 import { useLang, useT } from "../i18n/hooks";
 import { track } from "../lib/umami";
@@ -17,6 +18,7 @@ import { triggerLight } from "../lib/haptics";
 import { useDocumentTitle } from "../lib/title";
 import { useSeoHead } from "../lib/seo";
 import { buildSubjectMeta } from "../seo/meta";
+import { hasAuthorizedExamContent } from "../lib/content-policy";
 
 export default function SubjectHome() {
   const { subjectId } = useParams<{ subjectId: string }>();
@@ -81,6 +83,7 @@ export default function SubjectHome() {
 
   const repeatedCount = allQuestions.filter((q) => q.repeated).length;
   const availableExams = subject.exams.filter((exam) => !exam.deleteRights);
+  const hasAuthorizedExams = hasAuthorizedExamContent(subject);
   const progress = getTopicProgress(
     subject.id,
     allQuestions.map((q) => ({ topic: q.topic, points: q.points })),
@@ -91,7 +94,10 @@ export default function SubjectHome() {
       ? ` (${t.subjectHome.repeatedSuffix.replace("{count}", String(repeatedCount))})`
       : "";
 
-  const description = t.subjectHome.description
+  const descriptionTemplate = hasAuthorizedExams
+    ? t.subjectHome.description
+    : t.subjectHome.communityDescription;
+  const description = descriptionTemplate
     .replace("{count}", String(allQuestions.length))
     .replace("{repeated}", repeatedText)
     .replace("{exams}", String(availableExams.length));
@@ -116,8 +122,11 @@ export default function SubjectHome() {
   return (
     <div className="max-w-6xl mx-auto px-4 py-8 animate-fade-in animate-duration-fast">
       <div className="text-center mb-10">
-        <p className="text-xs font-mono uppercase tracking-widest text-fg-muted mb-3">
-          {subject.courseCode} &middot; {subject.university}
+        <p className="flex items-center justify-center gap-2 text-xs font-mono uppercase tracking-widest text-fg-muted mb-3">
+          <ContentPolicyIcon subject={subject} className="size-4" svgOnly />
+          <span>
+            {subject.courseCode} &middot; {subject.university}
+          </span>
         </p>
         <h1 className="text-3xl font-semibold text-fg mb-3">{subject.name}</h1>
         <p className="text-fg-secondary max-w-xl mx-auto">{description}</p>
@@ -171,7 +180,9 @@ export default function SubjectHome() {
       )}
 
       <h2 className="text-lg font-semibold text-fg mb-4">
-        {t.subjectHome.examSimulations}
+        {hasAuthorizedExams
+          ? t.subjectHome.examSimulations
+          : t.subjectHome.practiceSimulations}
       </h2>
       <div
         className={`grid grid-cols-1 sm:grid-cols-2 gap-4 mb-10 ${subject.exams.length > 4 ? "lg:grid-cols-3" : "lg:grid-cols-2"}`}
@@ -265,10 +276,14 @@ export default function SubjectHome() {
       ) && (
         <div className="bg-surface rounded-xl p-6 border border-border mb-10">
           <h3 className="font-semibold text-fg mb-2">
-            {t.subjectHome.originalExams}
+            {hasAuthorizedExams
+              ? t.subjectHome.originalExams
+              : t.subjectHome.sourceMaterials}
           </h3>
           <p className="text-sm text-fg-secondary mb-4">
-            {t.subjectHome.examDocsDescription}
+            {hasAuthorizedExams
+              ? t.subjectHome.examDocsDescription
+              : t.subjectHome.sourceMaterialsDescription}
           </p>
           <div className="flex flex-wrap gap-4">
             {subject.exams.flatMap((exam) =>
@@ -302,10 +317,14 @@ export default function SubjectHome() {
       {subject.exams.some((exam) => !exam.deleteRights && exam.daypoUrl) && (
         <div className="bg-surface rounded-xl p-6 border border-border mb-10">
           <h3 className="font-semibold text-fg mb-2">
-            {t.subjectHome.originalDaypos}
+            {hasAuthorizedExams
+              ? t.subjectHome.originalDaypos
+              : t.subjectHome.sourceMaterials}
           </h3>
           <p className="text-sm text-fg-secondary mb-4">
-            {t.subjectHome.daypoDocsDescription}
+            {hasAuthorizedExams
+              ? t.subjectHome.daypoDocsDescription
+              : t.subjectHome.sourceMaterialsDescription}
           </p>
           <div className="flex flex-wrap gap-4">
             {subject.exams.flatMap((exam) =>

--- a/src/pages/SubjectHome.tsx
+++ b/src/pages/SubjectHome.tsx
@@ -7,6 +7,9 @@ import TopicCard from "../components/TopicCard";
 import AddExamModal, {
   type AddExamModalHandle,
 } from "../components/AddExamModal";
+import CopyrightReportModal, {
+  type CopyrightReportModalHandle,
+} from "../components/CopyrightReportModal";
 import type { Question, Topic } from "../data/types";
 import { useLang, useT } from "../i18n/hooks";
 import { track } from "../lib/umami";
@@ -20,6 +23,7 @@ export default function SubjectHome() {
   const t = useT();
   const { lang } = useLang();
   const examModalRef = useRef<AddExamModalHandle>(null);
+  const copyrightModalRef = useRef<CopyrightReportModalHandle>(null);
   const subject = subjectId ? getSubject(subjectId) : undefined;
   const [allQuestions, setAllQuestions] = useState<Question[]>([]);
   const [questionsLoadedFor, setQuestionsLoadedFor] = useState<string | null>(
@@ -76,6 +80,7 @@ export default function SubjectHome() {
   }
 
   const repeatedCount = allQuestions.filter((q) => q.repeated).length;
+  const availableExams = subject.exams.filter((exam) => !exam.deleteRights);
   const progress = getTopicProgress(
     subject.id,
     allQuestions.map((q) => ({ topic: q.topic, points: q.points })),
@@ -89,7 +94,7 @@ export default function SubjectHome() {
   const description = t.subjectHome.description
     .replace("{count}", String(allQuestions.length))
     .replace("{repeated}", repeatedText)
-    .replace("{exams}", String(subject.exams.length));
+    .replace("{exams}", String(availableExams.length));
 
   const renderTopicCard = (topic: Topic) => {
     const topicQs = allQuestions.filter((q) => q.topic === topic.key);
@@ -171,40 +176,75 @@ export default function SubjectHome() {
       <div
         className={`grid grid-cols-1 sm:grid-cols-2 gap-4 mb-10 ${subject.exams.length > 4 ? "lg:grid-cols-3" : "lg:grid-cols-2"}`}
       >
-        {subject.exams.map((exam) => (
-          <Link
-            key={exam.year}
-            to={`/${subject.id}/exam/${exam.year}`}
-            className="block p-6 rounded-xl border-2 border-border hover:border-accent bg-surface-alt hover:bg-accent-light/30 hover:scale-[1.02] hover:shadow-md focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none transition-colors transition-transform duration-200"
+        {subject.exams.map((exam) =>
+          exam.deleteRights ? (
+            <div
+              key={exam.year}
+              className="block p-6 rounded-xl border-2 border-dashed border-t-red-border bg-t-red-bg/70"
+            >
+              <div className="text-2xl text-t-red-hover mb-2" aria-hidden="true">
+                !
+              </div>
+              <h2 className="font-semibold text-fg">{exam.title}</h2>
+              <p className="text-sm font-medium text-fg-secondary mt-2">
+                {t.subjectHome.copyrightRemoved}
+              </p>
+            </div>
+          ) : (
+            <Link
+              key={exam.year}
+              to={`/${subject.id}/exam/${exam.year}`}
+              className="block p-6 rounded-xl border-2 border-border hover:border-accent bg-surface-alt hover:bg-accent-light/30 hover:scale-[1.02] hover:shadow-md focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none transition-colors transition-transform duration-200"
+              onClick={() => {
+                triggerLight();
+                track("exam_card_click", {
+                  subjectId: subject.id,
+                  year: exam.year,
+                });
+              }}
+            >
+              <div className="text-2xl mb-2" aria-hidden="true">
+                📝
+              </div>
+              <h2 className="font-semibold text-fg">{exam.title}</h2>
+              <p className="text-sm text-fg-muted mt-1">{exam.description}</p>
+            </Link>
+          ),
+        )}
+        <div className="grid grid-cols-2 gap-4">
+          <button
+            type="button"
             onClick={() => {
               triggerLight();
-              track("exam_card_click", {
-                subjectId: subject.id,
-                year: exam.year,
-              });
+              examModalRef.current?.open();
+              track("add_exam_modal_open", { subjectId: subject.id });
             }}
+            className="block w-full p-4 rounded-xl border-2 border-dashed border-border text-fg-muted hover:text-accent hover:border-accent hover:bg-accent-light/30 hover:scale-[1.02] hover:shadow-md transition-colors transition-transform duration-200"
           >
-            <div className="text-2xl mb-2" aria-hidden="true">
-              📝
+            <div className="flex h-full min-h-28 flex-col items-center justify-center gap-2">
+              <span className="text-4xl font-light leading-none">+</span>
+              <span className="text-sm font-medium">{t.subjectHome.addExam}</span>
             </div>
-            <h2 className="font-semibold text-fg">{exam.title}</h2>
-            <p className="text-sm text-fg-muted mt-1">{exam.description}</p>
-          </Link>
-        ))}
-        <button
-          type="button"
-          onClick={() => {
-            triggerLight();
-            examModalRef.current?.open();
-            track("add_exam_modal_open", { subjectId: subject.id });
-          }}
-          className="block w-full p-6 rounded-xl border-2 border-dashed border-border text-fg-muted hover:text-accent hover:border-accent hover:bg-accent-light/30 hover:scale-[1.02] hover:shadow-md transition-colors transition-transform duration-200"
-        >
-          <div className="flex flex-col items-center justify-center gap-2">
-            <span className="text-4xl font-light leading-none">+</span>
-            <span className="text-sm font-medium">{t.subjectHome.addExam}</span>
-          </div>
-        </button>
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              triggerLight();
+              copyrightModalRef.current?.open();
+              track("copyright_report_modal_open", { subjectId: subject.id });
+            }}
+            className="block w-full p-4 rounded-xl border-2 border-dashed border-t-red-border text-fg-secondary bg-t-red-bg/40 hover:text-fg hover:border-t-red-hover hover:bg-t-red-bg hover:scale-[1.02] hover:shadow-md transition-colors transition-transform duration-200"
+          >
+            <div className="flex h-full min-h-28 flex-col items-center justify-center gap-2">
+              <span className="text-4xl font-light leading-none text-t-red-hover">
+                !
+              </span>
+              <span className="text-sm font-medium">
+                {t.subjectHome.reportCopyright}
+              </span>
+            </div>
+          </button>
+        </div>
       </div>
 
       <AddExamModal
@@ -213,8 +253,16 @@ export default function SubjectHome() {
         subjectId={subject.id}
         subjectName={subject.name}
       />
+      <CopyrightReportModal
+        ref={copyrightModalRef}
+        onClose={() => {}}
+        subjectId={subject.id}
+        subjectName={subject.name}
+      />
 
-      {subject.exams.some((exam) => exam.hasPdf !== false) && (
+      {subject.exams.some(
+        (exam) => !exam.deleteRights && exam.hasPdf !== false,
+      ) && (
         <div className="bg-surface rounded-xl p-6 border border-border mb-10">
           <h3 className="font-semibold text-fg mb-2">
             {t.subjectHome.originalExams}
@@ -224,7 +272,7 @@ export default function SubjectHome() {
           </p>
           <div className="flex flex-wrap gap-4">
             {subject.exams.flatMap((exam) =>
-              exam.hasPdf === false
+              exam.deleteRights || exam.hasPdf === false
                 ? []
                 : [
                     <a
@@ -251,7 +299,7 @@ export default function SubjectHome() {
         </div>
       )}
 
-      {subject.exams.some((exam) => exam.daypoUrl) && (
+      {subject.exams.some((exam) => !exam.deleteRights && exam.daypoUrl) && (
         <div className="bg-surface rounded-xl p-6 border border-border mb-10">
           <h3 className="font-semibold text-fg mb-2">
             {t.subjectHome.originalDaypos}
@@ -261,7 +309,7 @@ export default function SubjectHome() {
           </p>
           <div className="flex flex-wrap gap-4">
             {subject.exams.flatMap((exam) =>
-              exam.daypoUrl == null
+              exam.deleteRights || exam.daypoUrl == null
                 ? []
                 : [
                     <a

--- a/src/pages/SubjectHome.tsx
+++ b/src/pages/SubjectHome.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useEffect, useMemo } from "react";
+import { useRef, useState, useEffect, useMemo, type ReactNode } from "react";
 import { useParams } from "react-router-dom";
 import { LangLink as Link } from "../lib/lang-link";
 import { getSubject, getAllQuestions } from "../subjects";
@@ -11,7 +11,7 @@ import CopyrightReportModal, {
   type CopyrightReportModalHandle,
 } from "../components/CopyrightReportModal";
 import ContentPolicyIcon from "../components/ContentPolicyIcon";
-import type { Question, Topic } from "../data/types";
+import type { Question, SubjectMeta, Topic } from "../data/types";
 import { useLang, useT } from "../i18n/hooks";
 import { track } from "../lib/umami";
 import { triggerLight } from "../lib/haptics";
@@ -62,23 +62,7 @@ export default function SubjectHome() {
   });
 
   if (!subject) {
-    return (
-      <div className="max-w-6xl mx-auto px-4 py-16 text-center">
-        <h1 className="text-2xl font-semibold text-fg mb-4">
-          {t.subjectHome.notFound}
-        </h1>
-        <Link
-          to="/"
-          className="text-accent hover:underline"
-          onClick={() => {
-            triggerLight();
-            track("nav_click", { target: "home", reason: "subject_not_found" });
-          }}
-        >
-          {t.subjectHome.returnHome}
-        </Link>
-      </div>
-    );
+    return <SubjectNotFound />;
   }
 
   const repeatedCount = allQuestions.filter((q) => q.repeated).length;
@@ -102,161 +86,20 @@ export default function SubjectHome() {
     .replace("{repeated}", repeatedText)
     .replace("{exams}", String(availableExams.length));
 
-  const renderTopicCard = (topic: Topic) => {
-    const topicQs = allQuestions.filter((q) => q.topic === topic.key);
-    const tp = progress[topic.key];
-    const progressPct =
-      tp && tp.total > 0 ? (tp.attempted / tp.total) * 100 : 0;
-    return (
-      <TopicCard
-        key={topic.key}
-        subjectId={subject.id}
-        topic={topic}
-        questionCount={topicQs.length}
-        pointsCount={topicQs.reduce((s, q) => s + q.points, 0)}
-        progress={progressPct}
-      />
-    );
-  };
-
   return (
     <div className="max-w-6xl mx-auto px-4 py-8 animate-fade-in animate-duration-fast">
-      <div className="text-center mb-10">
-        <p className="flex items-center justify-center gap-2 text-xs font-mono uppercase tracking-widest text-fg-muted mb-3">
-          <ContentPolicyIcon subject={subject} className="size-4" svgOnly />
-          <span>
-            {subject.courseCode} &middot; {subject.university}
-          </span>
-        </p>
-        <h1 className="text-3xl font-semibold text-fg mb-3">{subject.name}</h1>
-        <p className="text-fg-secondary max-w-xl mx-auto">{description}</p>
-      </div>
-
-      <h2 className="text-lg font-semibold text-fg mb-4">
-        {t.subjectHome.practiceByTopic}
-      </h2>
-
-      {subject.megatopics ? (
-        <>
-          {subject.megatopics.map((mt) => {
-            const mtTopics = subject.topics.filter((t) =>
-              mt.topics.includes(t.key),
-            );
-            if (mtTopics.length === 0) return null;
-            return (
-              <div key={mt.key} className="mb-8">
-                <h2 className="text-md font-medium text-fg-secondary mt-2 mb-3">
-                  {mt.label}
-                </h2>
-                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-                  {mtTopics.map(renderTopicCard)}
-                </div>
-              </div>
-            );
-          })}
-          {(() => {
-            const groupedKeys = new Set(
-              subject.megatopics.flatMap((mt) => mt.topics),
-            );
-            const ungrouped = subject.topics.filter(
-              (t) => !groupedKeys.has(t.key),
-            );
-            if (ungrouped.length === 0) return null;
-            return (
-              <div className="mb-10">
-                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-                  {ungrouped.map(renderTopicCard)}
-                </div>
-              </div>
-            );
-          })()}
-        </>
-      ) : (
-        <div
-          className={`grid grid-cols-1 sm:grid-cols-2 gap-4 mb-10 ${subject.topics.length > 4 ? "lg:grid-cols-3" : "lg:grid-cols-2"}`}
-        >
-          {subject.topics.map(renderTopicCard)}
-        </div>
-      )}
-
-      <h2 className="text-lg font-semibold text-fg mb-4">
-        {hasAuthorizedExams
-          ? t.subjectHome.examSimulations
-          : t.subjectHome.practiceSimulations}
-      </h2>
-      <div
-        className={`grid grid-cols-1 sm:grid-cols-2 gap-4 mb-10 ${subject.exams.length > 4 ? "lg:grid-cols-3" : "lg:grid-cols-2"}`}
-      >
-        {subject.exams.map((exam) =>
-          exam.deleteRights ? (
-            <div
-              key={exam.year}
-              className="block p-6 rounded-xl border-2 border-dashed border-t-red-border bg-t-red-bg/70"
-            >
-              <div className="text-2xl text-t-red-hover mb-2" aria-hidden="true">
-                !
-              </div>
-              <h2 className="font-semibold text-fg">{exam.title}</h2>
-              <p className="text-sm font-medium text-fg-secondary mt-2">
-                {t.subjectHome.copyrightRemoved}
-              </p>
-            </div>
-          ) : (
-            <Link
-              key={exam.year}
-              to={`/${subject.id}/exam/${exam.year}`}
-              className="block p-6 rounded-xl border-2 border-border hover:border-accent bg-surface-alt hover:bg-accent-light/30 hover:scale-[1.02] hover:shadow-md focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none transition-colors transition-transform duration-200"
-              onClick={() => {
-                triggerLight();
-                track("exam_card_click", {
-                  subjectId: subject.id,
-                  year: exam.year,
-                });
-              }}
-            >
-              <div className="text-2xl mb-2" aria-hidden="true">
-                📝
-              </div>
-              <h2 className="font-semibold text-fg">{exam.title}</h2>
-              <p className="text-sm text-fg-muted mt-1">{exam.description}</p>
-            </Link>
-          ),
-        )}
-        <div className="grid grid-cols-2 gap-4">
-          <button
-            type="button"
-            onClick={() => {
-              triggerLight();
-              examModalRef.current?.open();
-              track("add_exam_modal_open", { subjectId: subject.id });
-            }}
-            className="block w-full p-4 rounded-xl border-2 border-dashed border-border text-fg-muted hover:text-accent hover:border-accent hover:bg-accent-light/30 hover:scale-[1.02] hover:shadow-md transition-colors transition-transform duration-200"
-          >
-            <div className="flex h-full min-h-28 flex-col items-center justify-center gap-2">
-              <span className="text-4xl font-light leading-none">+</span>
-              <span className="text-sm font-medium">{t.subjectHome.addExam}</span>
-            </div>
-          </button>
-          <button
-            type="button"
-            onClick={() => {
-              triggerLight();
-              copyrightModalRef.current?.open();
-              track("copyright_report_modal_open", { subjectId: subject.id });
-            }}
-            className="block w-full p-4 rounded-xl border-2 border-dashed border-t-red-border text-fg-secondary bg-t-red-bg/40 hover:text-fg hover:border-t-red-hover hover:bg-t-red-bg hover:scale-[1.02] hover:shadow-md transition-colors transition-transform duration-200"
-          >
-            <div className="flex h-full min-h-28 flex-col items-center justify-center gap-2">
-              <span className="text-4xl font-light leading-none text-t-red-hover">
-                !
-              </span>
-              <span className="text-sm font-medium">
-                {t.subjectHome.reportCopyright}
-              </span>
-            </div>
-          </button>
-        </div>
-      </div>
+      <SubjectHeader subject={subject} description={description} />
+      <TopicsSection
+        subject={subject}
+        questions={allQuestions}
+        progress={progress}
+      />
+      <ExamSimulationsSection
+        subject={subject}
+        hasAuthorizedExams={hasAuthorizedExams}
+        onAddExam={() => examModalRef.current?.open()}
+        onReportCopyright={() => copyrightModalRef.current?.open()}
+      />
 
       <AddExamModal
         ref={examModalRef}
@@ -271,97 +114,409 @@ export default function SubjectHome() {
         subjectName={subject.name}
       />
 
-      {subject.exams.some(
-        (exam) => !exam.deleteRights && exam.hasPdf !== false,
-      ) && (
-        <div className="bg-surface rounded-xl p-6 border border-border mb-10">
-          <h3 className="font-semibold text-fg mb-2">
-            {hasAuthorizedExams
-              ? t.subjectHome.originalExams
-              : t.subjectHome.sourceMaterials}
-          </h3>
-          <p className="text-sm text-fg-secondary mb-4">
-            {hasAuthorizedExams
-              ? t.subjectHome.examDocsDescription
-              : t.subjectHome.sourceMaterialsDescription}
-          </p>
-          <div className="flex flex-wrap gap-4">
-            {subject.exams.flatMap((exam) =>
-              exam.deleteRights || exam.hasPdf === false
-                ? []
-                : [
-                    <a
-                      key={exam.year}
-                      href={`/exams/${subject.id}/Exam-${exam.year}.pdf`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-accent-fg bg-accent-light border border-accent-border rounded-lg hover:bg-accent-light active:scale-95 focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none transition duration-150"
-                      onClick={() => {
-                        triggerLight();
-                        track("file_download", {
-                          file: `Exam-${exam.year}.pdf`,
-                          subjectId: subject.id,
-                          year: exam.year,
-                        });
-                      }}
-                    >
-                      <span aria-hidden="true">📄</span> {exam.title}{" "}
-                      {t.subjectHome.pdf}
-                    </a>,
-                  ],
-            )}
-          </div>
-        </div>
-      )}
+      <PdfLinksSection subject={subject} hasAuthorizedExams={hasAuthorizedExams} />
+      <DaypoLinksSection
+        subject={subject}
+        hasAuthorizedExams={hasAuthorizedExams}
+      />
+      <Acknowledgments subject={subject} />
+    </div>
+  );
+}
 
-      {subject.exams.some((exam) => !exam.deleteRights && exam.daypoUrl) && (
-        <div className="bg-surface rounded-xl p-6 border border-border mb-10">
-          <h3 className="font-semibold text-fg mb-2">
-            {hasAuthorizedExams
-              ? t.subjectHome.originalDaypos
-              : t.subjectHome.sourceMaterials}
-          </h3>
-          <p className="text-sm text-fg-secondary mb-4">
-            {hasAuthorizedExams
-              ? t.subjectHome.daypoDocsDescription
-              : t.subjectHome.sourceMaterialsDescription}
-          </p>
-          <div className="flex flex-wrap gap-4">
-            {subject.exams.flatMap((exam) =>
-              exam.deleteRights || exam.daypoUrl == null
-                ? []
-                : [
-                    <a
-                      key={exam.year}
-                      href={exam.daypoUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-accent-fg bg-accent-light border border-accent-border rounded-lg hover:bg-accent-light active:scale-95 focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none transition duration-150"
-                      onClick={() => {
-                        triggerLight();
-                        track("daypo_open", {
-                          subjectId: subject.id,
-                          year: exam.year,
-                        });
-                      }}
-                    >
-                      <span aria-hidden="true">🌐</span> {exam.title}{" "}
-                      {t.subjectHome.daypo}
-                    </a>,
-                  ],
-            )}
-          </div>
-        </div>
-      )}
+function SubjectNotFound() {
+  const t = useT();
 
-      {subject.acknowledgments && (
-        <div className="text-right text-sm text-fg-muted mt-10">
-          <p className="font-semibold text-fg-muted mb-1">
-            {t.subjectHome.acknowledgments}
-          </p>
-          <p>{subject.acknowledgments}</p>
+  return (
+    <div className="max-w-6xl mx-auto px-4 py-16 text-center">
+      <h1 className="text-2xl font-semibold text-fg mb-4">
+        {t.subjectHome.notFound}
+      </h1>
+      <Link
+        to="/"
+        className="text-accent hover:underline"
+        onClick={() => {
+          triggerLight();
+          track("nav_click", { target: "home", reason: "subject_not_found" });
+        }}
+      >
+        {t.subjectHome.returnHome}
+      </Link>
+    </div>
+  );
+}
+
+function SubjectHeader({
+  subject,
+  description,
+}: {
+  subject: SubjectMeta;
+  description: string;
+}) {
+  return (
+    <div className="text-center mb-10">
+      <p className="flex items-center justify-center gap-2 text-xs font-mono uppercase tracking-widest text-fg-muted mb-3">
+        <ContentPolicyIcon subject={subject} className="size-4" svgOnly />
+        <span>
+          {subject.courseCode} &middot; {subject.university}
+        </span>
+      </p>
+      <h1 className="text-3xl font-semibold text-fg mb-3">{subject.name}</h1>
+      <p className="text-fg-secondary max-w-xl mx-auto">{description}</p>
+    </div>
+  );
+}
+
+function TopicsSection({
+  subject,
+  questions,
+  progress,
+}: {
+  subject: SubjectMeta;
+  questions: Question[];
+  progress: ReturnType<typeof getTopicProgress>;
+}) {
+  const t = useT();
+  const renderTopicCard = (topic: Topic) => {
+    const topicQuestions = questions.filter((q) => q.topic === topic.key);
+    const topicProgress = progress[topic.key];
+    const progressPct =
+      topicProgress && topicProgress.total > 0
+        ? (topicProgress.attempted / topicProgress.total) * 100
+        : 0;
+
+    return (
+      <TopicCard
+        key={topic.key}
+        subjectId={subject.id}
+        topic={topic}
+        questionCount={topicQuestions.length}
+        pointsCount={topicQuestions.reduce((sum, q) => sum + q.points, 0)}
+        progress={progressPct}
+      />
+    );
+  };
+
+  return (
+    <>
+      <h2 className="text-lg font-semibold text-fg mb-4">
+        {t.subjectHome.practiceByTopic}
+      </h2>
+      {subject.megatopics ? (
+        <>
+          {subject.megatopics.map((megatopic) => {
+            const megatopicTopics = subject.topics.filter((topic) =>
+              megatopic.topics.includes(topic.key),
+            );
+            if (megatopicTopics.length === 0) return null;
+            return (
+              <div key={megatopic.key} className="mb-8">
+                <h2 className="text-md font-medium text-fg-secondary mt-2 mb-3">
+                  {megatopic.label}
+                </h2>
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                  {megatopicTopics.map(renderTopicCard)}
+                </div>
+              </div>
+            );
+          })}
+          <UngroupedTopics subject={subject} renderTopicCard={renderTopicCard} />
+        </>
+      ) : (
+        <div
+          className={`grid grid-cols-1 sm:grid-cols-2 gap-4 mb-10 ${subject.topics.length > 4 ? "lg:grid-cols-3" : "lg:grid-cols-2"}`}
+        >
+          {subject.topics.map(renderTopicCard)}
         </div>
       )}
+    </>
+  );
+}
+
+function UngroupedTopics({
+  subject,
+  renderTopicCard,
+}: {
+  subject: SubjectMeta;
+  renderTopicCard: (topic: Topic) => ReactNode;
+}) {
+  const groupedKeys = new Set(subject.megatopics?.flatMap((mt) => mt.topics));
+  const ungroupedTopics = subject.topics.filter(
+    (topic) => !groupedKeys.has(topic.key),
+  );
+
+  if (ungroupedTopics.length === 0) return null;
+
+  return (
+    <div className="mb-10">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {ungroupedTopics.map(renderTopicCard)}
+      </div>
+    </div>
+  );
+}
+
+function ExamSimulationsSection({
+  subject,
+  hasAuthorizedExams,
+  onAddExam,
+  onReportCopyright,
+}: {
+  subject: SubjectMeta;
+  hasAuthorizedExams: boolean;
+  onAddExam: () => void;
+  onReportCopyright: () => void;
+}) {
+  const t = useT();
+
+  return (
+    <>
+      <h2 className="text-lg font-semibold text-fg mb-4">
+        {hasAuthorizedExams
+          ? t.subjectHome.examSimulations
+          : t.subjectHome.practiceSimulations}
+      </h2>
+      <div
+        className={`grid grid-cols-1 sm:grid-cols-2 gap-4 mb-10 ${subject.exams.length > 4 ? "lg:grid-cols-3" : "lg:grid-cols-2"}`}
+      >
+        {subject.exams.map((exam) =>
+          exam.deleteRights ? (
+            <RemovedExamCard key={exam.year} title={exam.title} />
+          ) : (
+            <ExamCard key={exam.year} subject={subject} exam={exam} />
+          ),
+        )}
+        <ExamActionButtons
+          subjectId={subject.id}
+          onAddExam={onAddExam}
+          onReportCopyright={onReportCopyright}
+        />
+      </div>
+    </>
+  );
+}
+
+function RemovedExamCard({ title }: { title: string }) {
+  const t = useT();
+
+  return (
+    <div className="block p-6 rounded-xl border-2 border-dashed border-t-red-border bg-t-red-bg/70">
+      <div className="text-2xl text-t-red-hover mb-2" aria-hidden="true">
+        !
+      </div>
+      <h2 className="font-semibold text-fg">{title}</h2>
+      <p className="text-sm font-medium text-fg-secondary mt-2">
+        {t.subjectHome.copyrightRemoved}
+      </p>
+    </div>
+  );
+}
+
+function ExamCard({
+  subject,
+  exam,
+}: {
+  subject: SubjectMeta;
+  exam: SubjectMeta["exams"][number];
+}) {
+  return (
+    <Link
+      to={`/${subject.id}/exam/${exam.year}`}
+      className="block p-6 rounded-xl border-2 border-border hover:border-accent bg-surface-alt hover:bg-accent-light/30 hover:scale-[1.02] hover:shadow-md focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none transition-colors transition-transform duration-200"
+      onClick={() => {
+        triggerLight();
+        track("exam_card_click", {
+          subjectId: subject.id,
+          year: exam.year,
+        });
+      }}
+    >
+      <div className="text-2xl mb-2" aria-hidden="true">
+        📝
+      </div>
+      <h2 className="font-semibold text-fg">{exam.title}</h2>
+      <p className="text-sm text-fg-muted mt-1">{exam.description}</p>
+    </Link>
+  );
+}
+
+function ExamActionButtons({
+  subjectId,
+  onAddExam,
+  onReportCopyright,
+}: {
+  subjectId: string;
+  onAddExam: () => void;
+  onReportCopyright: () => void;
+}) {
+  const t = useT();
+
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      <button
+        type="button"
+        onClick={() => {
+          triggerLight();
+          onAddExam();
+          track("add_exam_modal_open", { subjectId });
+        }}
+        className="block w-full p-4 rounded-xl border-2 border-dashed border-border text-fg-muted hover:text-accent hover:border-accent hover:bg-accent-light/30 hover:scale-[1.02] hover:shadow-md transition-colors transition-transform duration-200"
+      >
+        <div className="flex h-full min-h-28 flex-col items-center justify-center gap-2">
+          <span className="text-4xl font-light leading-none">+</span>
+          <span className="text-sm font-medium">{t.subjectHome.addExam}</span>
+        </div>
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          triggerLight();
+          onReportCopyright();
+          track("copyright_report_modal_open", { subjectId });
+        }}
+        className="block w-full p-4 rounded-xl border-2 border-dashed border-t-red-border text-fg-secondary bg-t-red-bg/40 hover:text-fg hover:border-t-red-hover hover:bg-t-red-bg hover:scale-[1.02] hover:shadow-md transition-colors transition-transform duration-200"
+      >
+        <div className="flex h-full min-h-28 flex-col items-center justify-center gap-2">
+          <span className="text-4xl font-light leading-none text-t-red-hover">
+            !
+          </span>
+          <span className="text-sm font-medium">
+            {t.subjectHome.reportCopyright}
+          </span>
+        </div>
+      </button>
+    </div>
+  );
+}
+
+function PdfLinksSection({
+  subject,
+  hasAuthorizedExams,
+}: {
+  subject: SubjectMeta;
+  hasAuthorizedExams: boolean;
+}) {
+  const t = useT();
+  const pdfExams = subject.exams.filter(
+    (exam) => !exam.deleteRights && exam.hasPdf !== false,
+  );
+
+  if (pdfExams.length === 0) return null;
+
+  return (
+    <ResourceLinksShell
+      title={
+        hasAuthorizedExams
+          ? t.subjectHome.originalExams
+          : t.subjectHome.sourceMaterials
+      }
+      description={
+        hasAuthorizedExams
+          ? t.subjectHome.examDocsDescription
+          : t.subjectHome.sourceMaterialsDescription
+      }
+    >
+      {pdfExams.map((exam) => (
+        <a
+          key={exam.year}
+          href={`/exams/${subject.id}/Exam-${exam.year}.pdf`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-accent-fg bg-accent-light border border-accent-border rounded-lg hover:bg-accent-light active:scale-95 focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none transition duration-150"
+          onClick={() => {
+            triggerLight();
+            track("file_download", {
+              file: `Exam-${exam.year}.pdf`,
+              subjectId: subject.id,
+              year: exam.year,
+            });
+          }}
+        >
+          <span aria-hidden="true">📄</span> {exam.title} {t.subjectHome.pdf}
+        </a>
+      ))}
+    </ResourceLinksShell>
+  );
+}
+
+function DaypoLinksSection({
+  subject,
+  hasAuthorizedExams,
+}: {
+  subject: SubjectMeta;
+  hasAuthorizedExams: boolean;
+}) {
+  const t = useT();
+  const daypoExams = subject.exams.filter(
+    (exam) => !exam.deleteRights && exam.daypoUrl != null,
+  );
+
+  if (daypoExams.length === 0) return null;
+
+  return (
+    <ResourceLinksShell
+      title={
+        hasAuthorizedExams
+          ? t.subjectHome.originalDaypos
+          : t.subjectHome.sourceMaterials
+      }
+      description={
+        hasAuthorizedExams
+          ? t.subjectHome.daypoDocsDescription
+          : t.subjectHome.sourceMaterialsDescription
+      }
+    >
+      {daypoExams.map((exam) => (
+        <a
+          key={exam.year}
+          href={exam.daypoUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-accent-fg bg-accent-light border border-accent-border rounded-lg hover:bg-accent-light active:scale-95 focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none transition duration-150"
+          onClick={() => {
+            triggerLight();
+            track("daypo_open", {
+              subjectId: subject.id,
+              year: exam.year,
+            });
+          }}
+        >
+          <span aria-hidden="true">🌐</span> {exam.title} {t.subjectHome.daypo}
+        </a>
+      ))}
+    </ResourceLinksShell>
+  );
+}
+
+function ResourceLinksShell({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="bg-surface rounded-xl p-6 border border-border mb-10">
+      <h3 className="font-semibold text-fg mb-2">{title}</h3>
+      <p className="text-sm text-fg-secondary mb-4">{description}</p>
+      <div className="flex flex-wrap gap-4">{children}</div>
+    </div>
+  );
+}
+
+function Acknowledgments({ subject }: { subject: SubjectMeta }) {
+  const t = useT();
+
+  if (!subject.acknowledgments) return null;
+
+  return (
+    <div className="text-right text-sm text-fg-muted mt-10">
+      <p className="font-semibold text-fg-muted mb-1">
+        {t.subjectHome.acknowledgments}
+      </p>
+      <p>{subject.acknowledgments}</p>
     </div>
   );
 }

--- a/src/seo/meta.ts
+++ b/src/seo/meta.ts
@@ -184,11 +184,14 @@ export function buildSubjectMeta(
     es: `${subject.name}: "exámenes" y preguntas resueltas`,
     gl: `${subject.name}: "exames" e preguntas resoltas`,
   };
+  const availableExamCount = subject.exams.filter(
+    (exam) => !exam.deleteRights,
+  ).length;
   const count = stats.questionCount;
   const descriptionByLang: Record<Lang, string> = {
-    en: `Practice ${count ? `${count} ` : ""}${subject.name} questions from ${subject.exams.length} past "exams" with model answers and self-grading. ${subject.courseCode}, ${subject.university}.`,
-    es: `Practica ${count ? `${count} ` : ""}preguntas de ${subject.name} de ${subject.exams.length} "exámenes" anteriores con respuestas modelo y autocorrección. ${subject.courseCode}, ${subject.university}.`,
-    gl: `Practica ${count ? `${count} ` : ""}preguntas de ${subject.name} de ${subject.exams.length} "exames" anteriores con respostas modelo e autocorrección. ${subject.courseCode}, ${subject.university}.`,
+    en: `Practice ${count ? `${count} ` : ""}${subject.name} questions from ${availableExamCount} past "exams" with model answers and self-grading. ${subject.courseCode}, ${subject.university}.`,
+    es: `Practica ${count ? `${count} ` : ""}preguntas de ${subject.name} de ${availableExamCount} "exámenes" anteriores con respuestas modelo y autocorrección. ${subject.courseCode}, ${subject.university}.`,
+    gl: `Practica ${count ? `${count} ` : ""}preguntas de ${subject.name} de ${availableExamCount} "exames" anteriores con respostas modelo e autocorrección. ${subject.courseCode}, ${subject.university}.`,
   };
   const title = appendBrand(titleStem[lang], tr.seo.siteName);
   const description = descriptionByLang[lang];

--- a/src/seo/meta.ts
+++ b/src/seo/meta.ts
@@ -180,15 +180,15 @@ export function buildSubjectMeta(
   const tr = t(lang);
   const pathWithoutLang = `/${subject.id}`;
   const titleStem: Record<Lang, string> = {
-    en: `${subject.name}: past exams and solved questions`,
-    es: `${subject.name}: exámenes y preguntas resueltas`,
-    gl: `${subject.name}: exames e preguntas resoltas`,
+    en: `${subject.name}: past "exams" and solved questions`,
+    es: `${subject.name}: "exámenes" y preguntas resueltas`,
+    gl: `${subject.name}: "exames" e preguntas resoltas`,
   };
   const count = stats.questionCount;
   const descriptionByLang: Record<Lang, string> = {
-    en: `Practice ${count ? `${count} ` : ""}${subject.name} questions from ${subject.exams.length} past exams with model answers and self-grading. ${subject.courseCode}, ${subject.university}.`,
-    es: `Practica ${count ? `${count} ` : ""}preguntas de ${subject.name} de ${subject.exams.length} exámenes anteriores con respuestas modelo y autocorrección. ${subject.courseCode}, ${subject.university}.`,
-    gl: `Practica ${count ? `${count} ` : ""}preguntas de ${subject.name} de ${subject.exams.length} exames anteriores con respostas modelo e autocorrección. ${subject.courseCode}, ${subject.university}.`,
+    en: `Practice ${count ? `${count} ` : ""}${subject.name} questions from ${subject.exams.length} past "exams" with model answers and self-grading. ${subject.courseCode}, ${subject.university}.`,
+    es: `Practica ${count ? `${count} ` : ""}preguntas de ${subject.name} de ${subject.exams.length} "exámenes" anteriores con respuestas modelo y autocorrección. ${subject.courseCode}, ${subject.university}.`,
+    gl: `Practica ${count ? `${count} ` : ""}preguntas de ${subject.name} de ${subject.exams.length} "exames" anteriores con respostas modelo e autocorrección. ${subject.courseCode}, ${subject.university}.`,
   };
   const title = appendBrand(titleStem[lang], tr.seo.siteName);
   const description = descriptionByLang[lang];
@@ -240,9 +240,9 @@ export function buildTopicMeta(
     gl: `${topic.label}: preguntas de ${subject.name}`,
   };
   const descriptionByLang: Record<Lang, string> = {
-    en: `Practice ${count ? `${count} ` : ""}${topic.label} questions from past ${subject.name} exams with model answers and self-grading. ${subject.courseCode}, ${subject.university}.`,
-    es: `Practica ${count ? `${count} ` : ""}preguntas de ${topic.label} de exámenes anteriores de ${subject.name}, con respuestas modelo y autocorrección. ${subject.courseCode}, ${subject.university}.`,
-    gl: `Practica ${count ? `${count} ` : ""}preguntas de ${topic.label} de exames anteriores de ${subject.name}, con respostas modelo e autocorrección. ${subject.courseCode}, ${subject.university}.`,
+    en: `Practice ${count ? `${count} ` : ""}${topic.label} questions from past ${subject.name} "exams" with model answers and self-grading. ${subject.courseCode}, ${subject.university}.`,
+    es: `Practica ${count ? `${count} ` : ""}preguntas de ${topic.label} de "exámenes" anteriores de ${subject.name}, con respuestas modelo y autocorrección. ${subject.courseCode}, ${subject.university}.`,
+    gl: `Practica ${count ? `${count} ` : ""}preguntas de ${topic.label} de "exames" anteriores de ${subject.name}, con respostas modelo e autocorrección. ${subject.courseCode}, ${subject.university}.`,
   };
   const title = appendBrand(titleStem[lang], tr.seo.siteName);
   const description = descriptionByLang[lang];

--- a/src/seo/meta.ts
+++ b/src/seo/meta.ts
@@ -3,6 +3,7 @@ import { en } from "../i18n/en";
 import { es } from "../i18n/es";
 import { gl } from "../i18n/gl";
 import type { Lang } from "../i18n/context";
+import { hasAuthorizedExamContent } from "../lib/content-policy";
 
 export const BASE_URL = "https://pe.pablopl.dev";
 export const LANGS = ["en", "es", "gl"] as const;
@@ -141,14 +142,14 @@ function makePageMeta(
 export function buildHomeMeta(lang: Lang): PageMetaData {
   const tr = t(lang);
   const titleByLang: Record<Lang, string> = {
-    en: "Practice University Exams",
-    es: "Practica exámenes universitarios",
-    gl: "Practica exames universitarios",
+    en: "Practice University Questions",
+    es: "Practica preguntas universitarias",
+    gl: "Practica preguntas universitarias",
   };
   const descriptionByLang: Record<Lang, string> = {
-    en: "Practice past university exams by topic or simulate full exams with model answers, self-grading, and multiple-choice, text, and matching questions.",
-    es: "Practica exámenes universitarios anteriores por tema o simula exámenes completos con respuestas modelo, autocorrección y preguntas tipo test o desarrollo.",
-    gl: "Practica exames universitarios anteriores por tema ou simula exames completos con respostas modelo, autocorrección e preguntas tipo test ou desenvolvemento.",
+    en: "Practice university questions by topic or timed sets with model answers, self-grading, and multiple-choice, text, and matching questions.",
+    es: "Practica preguntas universitarias por tema o en modo cronometrado con respuestas modelo, autocorrección y preguntas tipo test o desarrollo.",
+    gl: "Practica preguntas universitarias por tema ou en modo cronometrado con respostas modelo, autocorrección e preguntas tipo test ou desenvolvemento.",
   };
   const title = appendBrand(titleByLang[lang], tr.seo.siteName);
   const description = descriptionByLang[lang];
@@ -179,19 +180,32 @@ export function buildSubjectMeta(
 ): PageMetaData {
   const tr = t(lang);
   const pathWithoutLang = `/${subject.id}`;
-  const titleStem: Record<Lang, string> = {
-    en: `${subject.name}: past "exams" and solved questions`,
-    es: `${subject.name}: "exámenes" y preguntas resueltas`,
-    gl: `${subject.name}: "exames" e preguntas resoltas`,
-  };
   const availableExamCount = subject.exams.filter(
     (exam) => !exam.deleteRights,
   ).length;
+  const hasAuthorizedExams = hasAuthorizedExamContent(subject);
+  const titleStem: Record<Lang, string> = {
+    en: hasAuthorizedExams
+      ? `${subject.name}: exams and solved questions`
+      : `${subject.name}: compilations and solved questions`,
+    es: hasAuthorizedExams
+      ? `${subject.name}: exámenes y preguntas resueltas`
+      : `${subject.name}: recopilatorios y preguntas resueltas`,
+    gl: hasAuthorizedExams
+      ? `${subject.name}: exames e preguntas resoltas`
+      : `${subject.name}: recompilacións e preguntas resoltas`,
+  };
   const count = stats.questionCount;
   const descriptionByLang: Record<Lang, string> = {
-    en: `Practice ${count ? `${count} ` : ""}${subject.name} questions from ${availableExamCount} past "exams" with model answers and self-grading. ${subject.courseCode}, ${subject.university}.`,
-    es: `Practica ${count ? `${count} ` : ""}preguntas de ${subject.name} de ${availableExamCount} "exámenes" anteriores con respuestas modelo y autocorrección. ${subject.courseCode}, ${subject.university}.`,
-    gl: `Practica ${count ? `${count} ` : ""}preguntas de ${subject.name} de ${availableExamCount} "exames" anteriores con respostas modelo e autocorrección. ${subject.courseCode}, ${subject.university}.`,
+    en: hasAuthorizedExams
+      ? `Practice ${count ? `${count} ` : ""}${subject.name} questions from ${availableExamCount} exams with model answers and self-grading. ${subject.courseCode}, ${subject.university}.`
+      : `Practice ${count ? `${count} ` : ""}${subject.name} questions from ${availableExamCount} compilations with model answers and self-grading. ${subject.courseCode}, ${subject.university}.`,
+    es: hasAuthorizedExams
+      ? `Practica ${count ? `${count} ` : ""}preguntas de ${subject.name} de ${availableExamCount} exámenes con respuestas modelo y autocorrección. ${subject.courseCode}, ${subject.university}.`
+      : `Practica ${count ? `${count} ` : ""}preguntas de ${subject.name} de ${availableExamCount} recopilatorios de práctica con respuestas modelo y autocorrección. ${subject.courseCode}, ${subject.university}.`,
+    gl: hasAuthorizedExams
+      ? `Practica ${count ? `${count} ` : ""}preguntas de ${subject.name} de ${availableExamCount} exames con respostas modelo e autocorrección. ${subject.courseCode}, ${subject.university}.`
+      : `Practica ${count ? `${count} ` : ""}preguntas de ${subject.name} de ${availableExamCount} recompilacións de práctica con respostas modelo e autocorrección. ${subject.courseCode}, ${subject.university}.`,
   };
   const title = appendBrand(titleStem[lang], tr.seo.siteName);
   const description = descriptionByLang[lang];
@@ -237,15 +251,22 @@ export function buildTopicMeta(
   const tr = t(lang);
   const pathWithoutLang = `/${subject.id}/practice/${topic.key}`;
   const count = stats.topicQuestionCounts?.[topic.key];
+  const hasAuthorizedExams = hasAuthorizedExamContent(subject);
   const titleStem: Record<Lang, string> = {
-    en: `${topic.label}: ${subject.name} exam questions`,
+    en: `${topic.label}: ${subject.name} ${hasAuthorizedExams ? "exam" : "practice"} questions`,
     es: `${topic.label}: preguntas de ${subject.name}`,
     gl: `${topic.label}: preguntas de ${subject.name}`,
   };
   const descriptionByLang: Record<Lang, string> = {
-    en: `Practice ${count ? `${count} ` : ""}${topic.label} questions from past ${subject.name} "exams" with model answers and self-grading. ${subject.courseCode}, ${subject.university}.`,
-    es: `Practica ${count ? `${count} ` : ""}preguntas de ${topic.label} de "exámenes" anteriores de ${subject.name}, con respuestas modelo y autocorrección. ${subject.courseCode}, ${subject.university}.`,
-    gl: `Practica ${count ? `${count} ` : ""}preguntas de ${topic.label} de "exames" anteriores de ${subject.name}, con respostas modelo e autocorrección. ${subject.courseCode}, ${subject.university}.`,
+    en: hasAuthorizedExams
+      ? `Practice ${count ? `${count} ` : ""}${topic.label} questions from ${subject.name} exams with model answers and self-grading. ${subject.courseCode}, ${subject.university}.`
+      : `Practice ${count ? `${count} ` : ""}${topic.label} questions from ${subject.name} compilations with model answers and self-grading. ${subject.courseCode}, ${subject.university}.`,
+    es: hasAuthorizedExams
+      ? `Practica ${count ? `${count} ` : ""}preguntas de ${topic.label} de exámenes de ${subject.name}, con respuestas modelo y autocorrección. ${subject.courseCode}, ${subject.university}.`
+      : `Practica ${count ? `${count} ` : ""}preguntas de ${topic.label} de recopilatorios de ${subject.name}, con respuestas modelo y autocorrección. ${subject.courseCode}, ${subject.university}.`,
+    gl: hasAuthorizedExams
+      ? `Practica ${count ? `${count} ` : ""}preguntas de ${topic.label} de exames de ${subject.name}, con respostas modelo e autocorrección. ${subject.courseCode}, ${subject.university}.`
+      : `Practica ${count ? `${count} ` : ""}preguntas de ${topic.label} de recompilacións de ${subject.name}, con respostas modelo e autocorrección. ${subject.courseCode}, ${subject.university}.`,
   };
   const title = appendBrand(titleStem[lang], tr.seo.siteName);
   const description = descriptionByLang[lang];
@@ -291,15 +312,22 @@ export function buildExamMeta(
   const tr = t(lang);
   const pathWithoutLang = `/${subject.id}/exam/${exam.year}`;
   const count = stats.examQuestionCounts?.[exam.year];
+  const hasAuthorizedExams = hasAuthorizedExamContent(subject);
   const titleStem: Record<Lang, string> = {
-    en: `${exam.title} ${subject.name}: exam simulator`,
-    es: `${exam.title} de ${subject.name}: simulador`,
-    gl: `${exam.title} de ${subject.name}: simulador`,
+    en: `${exam.title} ${subject.name}: ${hasAuthorizedExams ? "exam simulator" : "timed practice"}`,
+    es: `${exam.title} de ${subject.name}: ${hasAuthorizedExams ? "simulador" : "práctica cronometrada"}`,
+    gl: `${exam.title} de ${subject.name}: ${hasAuthorizedExams ? "simulador" : "práctica cronometrada"}`,
   };
   const descriptionByLang: Record<Lang, string> = {
-    en: `Simulate the ${exam.title} ${subject.name} exam${count ? ` with ${count} questions` : ""}. ${exam.totalPoints} points, ${exam.durationMinutes} minutes, model answers and self-grading.`,
-    es: `Simula el examen ${exam.title} de ${subject.name}${count ? ` con ${count} preguntas` : ""}. ${exam.totalPoints} puntos, ${exam.durationMinutes} minutos, respuestas modelo y autocorrección.`,
-    gl: `Simula o exame ${exam.title} de ${subject.name}${count ? ` con ${count} preguntas` : ""}. ${exam.totalPoints} puntos, ${exam.durationMinutes} minutos, respostas modelo e autocorrección.`,
+    en: hasAuthorizedExams
+      ? `Simulate the ${exam.title} ${subject.name} exam${count ? ` with ${count} questions` : ""}. ${exam.totalPoints} points, ${exam.durationMinutes} minutes, model answers and self-grading.`
+      : `Practice the ${exam.title} ${subject.name} timed set${count ? ` with ${count} questions` : ""}. ${exam.totalPoints} points, ${exam.durationMinutes} minutes, model answers and self-grading.`,
+    es: hasAuthorizedExams
+      ? `Simula el examen ${exam.title} de ${subject.name}${count ? ` con ${count} preguntas` : ""}. ${exam.totalPoints} puntos, ${exam.durationMinutes} minutos, respuestas modelo y autocorrección.`
+      : `Practica el recopilatorio cronometrado ${exam.title} de ${subject.name}${count ? ` con ${count} preguntas` : ""}. ${exam.totalPoints} puntos, ${exam.durationMinutes} minutos, respuestas modelo y autocorrección.`,
+    gl: hasAuthorizedExams
+      ? `Simula o exame ${exam.title} de ${subject.name}${count ? ` con ${count} preguntas` : ""}. ${exam.totalPoints} puntos, ${exam.durationMinutes} minutos, respostas modelo e autocorrección.`
+      : `Practica a recompilación cronometrada ${exam.title} de ${subject.name}${count ? ` con ${count} preguntas` : ""}. ${exam.totalPoints} puntos, ${exam.durationMinutes} minutos, respostas modelo e autocorrección.`,
   };
   const title = appendBrand(titleStem[lang], tr.seo.siteName);
   const description = descriptionByLang[lang];

--- a/src/seo/pageMetaMap.generated.ts
+++ b/src/seo/pageMetaMap.generated.ts
@@ -6,8 +6,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/",
-    "title": "Practice University Exams | Pásame Exámenes",
-    "description": "Practice past university exams by topic or simulate full exams with model answers, self-grading, and multiple-choice, text, and matching questions.",
+    "title": "Practice University Questions | Pásame Exámenes",
+    "description": "Practice university questions by topic or timed sets with model answers, self-grading, and multiple-choice, text, and matching questions.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en",
     "ogImage": "https://pe.pablopl.dev/og.jpg",
@@ -31,15 +31,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebSite\",\"name\":\"Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/en\",\"inLanguage\":\"en\",\"description\":\"Practice past university exams by topic or simulate full exams with model answers, self-grading, and multiple-choice, text, and matching questions.\"},{\"@type\":\"WebPage\",\"name\":\"Practice University Exams | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/en\",\"inLanguage\":\"en\",\"description\":\"Practice past university exams by topic or simulate full exams with model answers, self-grading, and multiple-choice, text, and matching questions.\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebSite\",\"name\":\"Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/en\",\"inLanguage\":\"en\",\"description\":\"Practice university questions by topic or timed sets with model answers, self-grading, and multiple-choice, text, and matching questions.\"},{\"@type\":\"WebPage\",\"name\":\"Practice University Questions | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/en\",\"inLanguage\":\"en\",\"description\":\"Practice university questions by topic or timed sets with model answers, self-grading, and multiple-choice, text, and matching questions.\"}]}"
   },
   {
     "url": "seo/en/bede.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/bede",
-    "title": "Bases de Datos: past \"exams\" and solved questions",
-    "description": "Practice 98 Bases de Datos questions from 1 past \"exams\" with model answers and self-grading. 202315, Universidade da Coruña.",
+    "title": "Bases de Datos: compilations and solved questions",
+    "description": "Practice 98 Bases de Datos questions from 1 compilations with model answers and self-grading. 202315, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/bede",
     "ogImage": "https://pe.pablopl.dev/og/bede.png",
@@ -63,15 +63,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/bede"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Bases de Datos: past \\\"exams\\\" and solved questions\",\"url\":\"https://pe.pablopl.dev/en/bede\",\"inLanguage\":\"en\",\"description\":\"Practice 98 Bases de Datos questions from 1 past \\\"exams\\\" with model answers and self-grading. 202315, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/en/bede\"}],\"url\":\"https://pe.pablopl.dev/en/bede\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Bases de Datos: compilations and solved questions\",\"url\":\"https://pe.pablopl.dev/en/bede\",\"inLanguage\":\"en\",\"description\":\"Practice 98 Bases de Datos questions from 1 compilations with model answers and self-grading. 202315, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/en/bede\"}],\"url\":\"https://pe.pablopl.dev/en/bede\"}]}"
   },
   {
     "url": "seo/en/bede/practice/recuperacion-concurrencia.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/bede/practice/recuperacion-concurrencia",
-    "title": "Recuperación y Concurrencia: Bases de Datos exam questions",
-    "description": "Practice 48 Recuperación y Concurrencia questions from past Bases de Datos \"exams\" with model answers and self-grading. 202315, Universidade da Coruña.",
+    "title": "Recuperación y Concurrencia: Bases de Datos practice questions",
+    "description": "Practice 48 Recuperación y Concurrencia questions from Bases de Datos compilations with model answers and self-grading. 202315, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/bede/practice/recuperacion-concurrencia",
     "ogImage": "https://pe.pablopl.dev/og/bede.png",
@@ -95,15 +95,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/bede/practice/recuperacion-concurrencia"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Recuperación y Concurrencia: Bases de Datos exam questions\",\"url\":\"https://pe.pablopl.dev/en/bede/practice/recuperacion-concurrencia\",\"inLanguage\":\"en\",\"description\":\"Practice 48 Recuperación y Concurrencia questions from past Bases de Datos \\\"exams\\\" with model answers and self-grading. 202315, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Recuperación y Concurrencia\"},{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/en/bede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Recuperación y Concurrencia\",\"item\":\"https://pe.pablopl.dev/en/bede/practice/recuperacion-concurrencia\"}],\"url\":\"https://pe.pablopl.dev/en/bede/practice/recuperacion-concurrencia\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Recuperación y Concurrencia: Bases de Datos practice questions\",\"url\":\"https://pe.pablopl.dev/en/bede/practice/recuperacion-concurrencia\",\"inLanguage\":\"en\",\"description\":\"Practice 48 Recuperación y Concurrencia questions from Bases de Datos compilations with model answers and self-grading. 202315, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Recuperación y Concurrencia\"},{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/en/bede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Recuperación y Concurrencia\",\"item\":\"https://pe.pablopl.dev/en/bede/practice/recuperacion-concurrencia\"}],\"url\":\"https://pe.pablopl.dev/en/bede/practice/recuperacion-concurrencia\"}]}"
   },
   {
     "url": "seo/en/bede/practice/ficheros.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/bede/practice/ficheros",
-    "title": "Ficheros: Bases de Datos exam questions | Pásame Exámenes",
-    "description": "Practice 50 Ficheros questions from past Bases de Datos \"exams\" with model answers and self-grading. 202315, Universidade da Coruña.",
+    "title": "Ficheros: Bases de Datos practice questions | Pásame Exámenes",
+    "description": "Practice 50 Ficheros questions from Bases de Datos compilations with model answers and self-grading. 202315, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/bede/practice/ficheros",
     "ogImage": "https://pe.pablopl.dev/og/bede.png",
@@ -127,15 +127,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/bede/practice/ficheros"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Ficheros: Bases de Datos exam questions | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/en/bede/practice/ficheros\",\"inLanguage\":\"en\",\"description\":\"Practice 50 Ficheros questions from past Bases de Datos \\\"exams\\\" with model answers and self-grading. 202315, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Ficheros\"},{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/en/bede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Ficheros\",\"item\":\"https://pe.pablopl.dev/en/bede/practice/ficheros\"}],\"url\":\"https://pe.pablopl.dev/en/bede/practice/ficheros\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Ficheros: Bases de Datos practice questions | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/en/bede/practice/ficheros\",\"inLanguage\":\"en\",\"description\":\"Practice 50 Ficheros questions from Bases de Datos compilations with model answers and self-grading. 202315, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Ficheros\"},{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/en/bede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Ficheros\",\"item\":\"https://pe.pablopl.dev/en/bede/practice/ficheros\"}],\"url\":\"https://pe.pablopl.dev/en/bede/practice/ficheros\"}]}"
   },
   {
     "url": "seo/en/bede/exam/daypo-preguntas.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/bede/exam/daypo-preguntas",
-    "title": "Daypo Preguntas Bases de Datos: exam simulator",
-    "description": "Simulate the Daypo Preguntas Bases de Datos exam with 98 questions. 98 points, 120 minutes, model answers and self-grading.",
+    "title": "Daypo Preguntas Bases de Datos: timed practice",
+    "description": "Practice the Daypo Preguntas Bases de Datos timed set with 98 questions. 98 points, 120 minutes, model answers and self-grading.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/bede/exam/daypo-preguntas",
     "ogImage": "https://pe.pablopl.dev/og/bede.png",
@@ -159,15 +159,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/bede/exam/daypo-preguntas"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Preguntas Bases de Datos: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/bede/exam/daypo-preguntas\",\"inLanguage\":\"en\",\"description\":\"Simulate the Daypo Preguntas Bases de Datos exam with 98 questions. 98 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/en/bede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Preguntas\",\"item\":\"https://pe.pablopl.dev/en/bede/exam/daypo-preguntas\"}],\"url\":\"https://pe.pablopl.dev/en/bede/exam/daypo-preguntas\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Preguntas Bases de Datos: timed practice\",\"url\":\"https://pe.pablopl.dev/en/bede/exam/daypo-preguntas\",\"inLanguage\":\"en\",\"description\":\"Practice the Daypo Preguntas Bases de Datos timed set with 98 questions. 98 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/en/bede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Preguntas\",\"item\":\"https://pe.pablopl.dev/en/bede/exam/daypo-preguntas\"}],\"url\":\"https://pe.pablopl.dev/en/bede/exam/daypo-preguntas\"}]}"
   },
   {
     "url": "seo/en/cepe.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/cepe",
-    "title": "Concorrencia e Paralelismo: past \"exams\" and solved questions",
-    "description": "Practice 76 Concorrencia e Paralelismo questions from 16 past \"exams\" with model answers and self-grading. 202320, Universidade da Coruña.",
+    "title": "Concorrencia e Paralelismo: exams and solved questions",
+    "description": "Practice 76 Concorrencia e Paralelismo questions from 16 exams with model answers and self-grading. 202320, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/cepe",
     "ogImage": "https://pe.pablopl.dev/og/cepe.png",
@@ -191,7 +191,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/cepe"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Concorrencia e Paralelismo: past \\\"exams\\\" and solved questions\",\"url\":\"https://pe.pablopl.dev/en/cepe\",\"inLanguage\":\"en\",\"description\":\"Practice 76 Concorrencia e Paralelismo questions from 16 past \\\"exams\\\" with model answers and self-grading. 202320, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/en/cepe\"}],\"url\":\"https://pe.pablopl.dev/en/cepe\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Concorrencia e Paralelismo: exams and solved questions\",\"url\":\"https://pe.pablopl.dev/en/cepe\",\"inLanguage\":\"en\",\"description\":\"Practice 76 Concorrencia e Paralelismo questions from 16 exams with model answers and self-grading. 202320, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/en/cepe\"}],\"url\":\"https://pe.pablopl.dev/en/cepe\"}]}"
   },
   {
     "url": "seo/en/cepe/practice/concurrencia-mutex.html",
@@ -199,7 +199,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/cepe/practice/concurrencia-mutex",
     "title": "Mutex y Condiciones: Concorrencia e Paralelismo exam questions",
-    "description": "Practice 32 Mutex y Condiciones questions from past Concorrencia e Paralelismo \"exams\" with model answers and self-grading. 202320, Universidade da Coruña.",
+    "description": "Practice 32 Mutex y Condiciones questions from Concorrencia e Paralelismo exams with model answers and self-grading. 202320, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/cepe/practice/concurrencia-mutex",
     "ogImage": "https://pe.pablopl.dev/og/cepe.png",
@@ -223,7 +223,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/cepe/practice/concurrencia-mutex"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Mutex y Condiciones: Concorrencia e Paralelismo exam questions\",\"url\":\"https://pe.pablopl.dev/en/cepe/practice/concurrencia-mutex\",\"inLanguage\":\"en\",\"description\":\"Practice 32 Mutex y Condiciones questions from past Concorrencia e Paralelismo \\\"exams\\\" with model answers and self-grading. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Mutex y Condiciones\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/en/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Mutex y Condiciones\",\"item\":\"https://pe.pablopl.dev/en/cepe/practice/concurrencia-mutex\"}],\"url\":\"https://pe.pablopl.dev/en/cepe/practice/concurrencia-mutex\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Mutex y Condiciones: Concorrencia e Paralelismo exam questions\",\"url\":\"https://pe.pablopl.dev/en/cepe/practice/concurrencia-mutex\",\"inLanguage\":\"en\",\"description\":\"Practice 32 Mutex y Condiciones questions from Concorrencia e Paralelismo exams with model answers and self-grading. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Mutex y Condiciones\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/en/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Mutex y Condiciones\",\"item\":\"https://pe.pablopl.dev/en/cepe/practice/concurrencia-mutex\"}],\"url\":\"https://pe.pablopl.dev/en/cepe/practice/concurrencia-mutex\"}]}"
   },
   {
     "url": "seo/en/cepe/practice/concurrencia-erlang.html",
@@ -231,7 +231,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/cepe/practice/concurrencia-erlang",
     "title": "Erlang: Concorrencia e Paralelismo exam questions",
-    "description": "Practice 12 Erlang questions from past Concorrencia e Paralelismo \"exams\" with model answers and self-grading. 202320, Universidade da Coruña.",
+    "description": "Practice 12 Erlang questions from Concorrencia e Paralelismo exams with model answers and self-grading. 202320, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/cepe/practice/concurrencia-erlang",
     "ogImage": "https://pe.pablopl.dev/og/cepe.png",
@@ -255,7 +255,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/cepe/practice/concurrencia-erlang"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Erlang: Concorrencia e Paralelismo exam questions\",\"url\":\"https://pe.pablopl.dev/en/cepe/practice/concurrencia-erlang\",\"inLanguage\":\"en\",\"description\":\"Practice 12 Erlang questions from past Concorrencia e Paralelismo \\\"exams\\\" with model answers and self-grading. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Erlang\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/en/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Erlang\",\"item\":\"https://pe.pablopl.dev/en/cepe/practice/concurrencia-erlang\"}],\"url\":\"https://pe.pablopl.dev/en/cepe/practice/concurrencia-erlang\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Erlang: Concorrencia e Paralelismo exam questions\",\"url\":\"https://pe.pablopl.dev/en/cepe/practice/concurrencia-erlang\",\"inLanguage\":\"en\",\"description\":\"Practice 12 Erlang questions from Concorrencia e Paralelismo exams with model answers and self-grading. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Erlang\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/en/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Erlang\",\"item\":\"https://pe.pablopl.dev/en/cepe/practice/concurrencia-erlang\"}],\"url\":\"https://pe.pablopl.dev/en/cepe/practice/concurrencia-erlang\"}]}"
   },
   {
     "url": "seo/en/cepe/practice/paralelismo-teoria.html",
@@ -263,7 +263,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/cepe/practice/paralelismo-teoria",
     "title": "Preguntas Teóricas: Concorrencia e Paralelismo exam questions",
-    "description": "Practice 19 Preguntas Teóricas questions from past Concorrencia e Paralelismo \"exams\" with model answers and self-grading. 202320, Universidade da Coruña.",
+    "description": "Practice 19 Preguntas Teóricas questions from Concorrencia e Paralelismo exams with model answers and self-grading. 202320, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/cepe/practice/paralelismo-teoria",
     "ogImage": "https://pe.pablopl.dev/og/cepe.png",
@@ -287,7 +287,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/cepe/practice/paralelismo-teoria"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Preguntas Teóricas: Concorrencia e Paralelismo exam questions\",\"url\":\"https://pe.pablopl.dev/en/cepe/practice/paralelismo-teoria\",\"inLanguage\":\"en\",\"description\":\"Practice 19 Preguntas Teóricas questions from past Concorrencia e Paralelismo \\\"exams\\\" with model answers and self-grading. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Preguntas Teóricas\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/en/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Preguntas Teóricas\",\"item\":\"https://pe.pablopl.dev/en/cepe/practice/paralelismo-teoria\"}],\"url\":\"https://pe.pablopl.dev/en/cepe/practice/paralelismo-teoria\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Preguntas Teóricas: Concorrencia e Paralelismo exam questions\",\"url\":\"https://pe.pablopl.dev/en/cepe/practice/paralelismo-teoria\",\"inLanguage\":\"en\",\"description\":\"Practice 19 Preguntas Teóricas questions from Concorrencia e Paralelismo exams with model answers and self-grading. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Preguntas Teóricas\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/en/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Preguntas Teóricas\",\"item\":\"https://pe.pablopl.dev/en/cepe/practice/paralelismo-teoria\"}],\"url\":\"https://pe.pablopl.dev/en/cepe/practice/paralelismo-teoria\"}]}"
   },
   {
     "url": "seo/en/cepe/practice/paralelismo-mpi.html",
@@ -295,7 +295,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/cepe/practice/paralelismo-mpi",
     "title": "Ejercicios de MPI: Concorrencia e Paralelismo exam questions",
-    "description": "Practice 13 Ejercicios de MPI questions from past Concorrencia e Paralelismo \"exams\" with model answers and self-grading. 202320, Universidade da Coruña.",
+    "description": "Practice 13 Ejercicios de MPI questions from Concorrencia e Paralelismo exams with model answers and self-grading. 202320, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/cepe/practice/paralelismo-mpi",
     "ogImage": "https://pe.pablopl.dev/og/cepe.png",
@@ -319,7 +319,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/cepe/practice/paralelismo-mpi"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Ejercicios de MPI: Concorrencia e Paralelismo exam questions\",\"url\":\"https://pe.pablopl.dev/en/cepe/practice/paralelismo-mpi\",\"inLanguage\":\"en\",\"description\":\"Practice 13 Ejercicios de MPI questions from past Concorrencia e Paralelismo \\\"exams\\\" with model answers and self-grading. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Ejercicios de MPI\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/en/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Ejercicios de MPI\",\"item\":\"https://pe.pablopl.dev/en/cepe/practice/paralelismo-mpi\"}],\"url\":\"https://pe.pablopl.dev/en/cepe/practice/paralelismo-mpi\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Ejercicios de MPI: Concorrencia e Paralelismo exam questions\",\"url\":\"https://pe.pablopl.dev/en/cepe/practice/paralelismo-mpi\",\"inLanguage\":\"en\",\"description\":\"Practice 13 Ejercicios de MPI questions from Concorrencia e Paralelismo exams with model answers and self-grading. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Ejercicios de MPI\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/en/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Ejercicios de MPI\",\"item\":\"https://pe.pablopl.dev/en/cepe/practice/paralelismo-mpi\"}],\"url\":\"https://pe.pablopl.dev/en/cepe/practice/paralelismo-mpi\"}]}"
   },
   {
     "url": "seo/en/cepe/exam/2018-06.html",
@@ -838,8 +838,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/deese",
-    "title": "Deseño de Software: past \"exams\" and solved questions",
-    "description": "Practice 55 Deseño de Software questions from 2 past \"exams\" with model answers and self-grading. 202317, Universidade da Coruña.",
+    "title": "Deseño de Software: compilations and solved questions",
+    "description": "Practice 55 Deseño de Software questions from 2 compilations with model answers and self-grading. 202317, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/deese",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -863,15 +863,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Deseño de Software: past \\\"exams\\\" and solved questions\",\"url\":\"https://pe.pablopl.dev/en/deese\",\"inLanguage\":\"en\",\"description\":\"Practice 55 Deseño de Software questions from 2 past \\\"exams\\\" with model answers and self-grading. 202317, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/en/deese\"}],\"url\":\"https://pe.pablopl.dev/en/deese\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Deseño de Software: compilations and solved questions\",\"url\":\"https://pe.pablopl.dev/en/deese\",\"inLanguage\":\"en\",\"description\":\"Practice 55 Deseño de Software questions from 2 compilations with model answers and self-grading. 202317, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/en/deese\"}],\"url\":\"https://pe.pablopl.dev/en/deese\"}]}"
   },
   {
     "url": "seo/en/deese/practice/intro-y-objetos.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/deese/practice/intro-y-objetos",
-    "title": "Introducción y Elementos Básicos de la OO: Deseño de Software exam questions",
-    "description": "Practice 12 Introducción y Elementos Básicos de la OO questions from past Deseño de Software \"exams\" with model answers and self-grading. 202317, Universidade da Coruña.",
+    "title": "Introducción y Elementos Básicos de la OO: Deseño de Software practice questions",
+    "description": "Practice 12 Introducción y Elementos Básicos de la OO questions from Deseño de Software compilations with model answers and self-grading. 202317, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/deese/practice/intro-y-objetos",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -895,15 +895,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/practice/intro-y-objetos"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Introducción y Elementos Básicos de la OO: Deseño de Software exam questions\",\"url\":\"https://pe.pablopl.dev/en/deese/practice/intro-y-objetos\",\"inLanguage\":\"en\",\"description\":\"Practice 12 Introducción y Elementos Básicos de la OO questions from past Deseño de Software \\\"exams\\\" with model answers and self-grading. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Introducción y Elementos Básicos de la OO\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/en/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Introducción y Elementos Básicos de la OO\",\"item\":\"https://pe.pablopl.dev/en/deese/practice/intro-y-objetos\"}],\"url\":\"https://pe.pablopl.dev/en/deese/practice/intro-y-objetos\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Introducción y Elementos Básicos de la OO: Deseño de Software practice questions\",\"url\":\"https://pe.pablopl.dev/en/deese/practice/intro-y-objetos\",\"inLanguage\":\"en\",\"description\":\"Practice 12 Introducción y Elementos Básicos de la OO questions from Deseño de Software compilations with model answers and self-grading. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Introducción y Elementos Básicos de la OO\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/en/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Introducción y Elementos Básicos de la OO\",\"item\":\"https://pe.pablopl.dev/en/deese/practice/intro-y-objetos\"}],\"url\":\"https://pe.pablopl.dev/en/deese/practice/intro-y-objetos\"}]}"
   },
   {
     "url": "seo/en/deese/practice/propiedades-oo.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/deese/practice/propiedades-oo",
-    "title": "Propiedades Básicas de la OO: Deseño de Software exam questions",
-    "description": "Practice 11 Propiedades Básicas de la OO questions from past Deseño de Software \"exams\" with model answers and self-grading. 202317, Universidade da Coruña.",
+    "title": "Propiedades Básicas de la OO: Deseño de Software practice questions",
+    "description": "Practice 11 Propiedades Básicas de la OO questions from Deseño de Software compilations with model answers and self-grading. 202317, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/deese/practice/propiedades-oo",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -927,15 +927,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/practice/propiedades-oo"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Propiedades Básicas de la OO: Deseño de Software exam questions\",\"url\":\"https://pe.pablopl.dev/en/deese/practice/propiedades-oo\",\"inLanguage\":\"en\",\"description\":\"Practice 11 Propiedades Básicas de la OO questions from past Deseño de Software \\\"exams\\\" with model answers and self-grading. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Propiedades Básicas de la OO\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/en/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Propiedades Básicas de la OO\",\"item\":\"https://pe.pablopl.dev/en/deese/practice/propiedades-oo\"}],\"url\":\"https://pe.pablopl.dev/en/deese/practice/propiedades-oo\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Propiedades Básicas de la OO: Deseño de Software practice questions\",\"url\":\"https://pe.pablopl.dev/en/deese/practice/propiedades-oo\",\"inLanguage\":\"en\",\"description\":\"Practice 11 Propiedades Básicas de la OO questions from Deseño de Software compilations with model answers and self-grading. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Propiedades Básicas de la OO\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/en/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Propiedades Básicas de la OO\",\"item\":\"https://pe.pablopl.dev/en/deese/practice/propiedades-oo\"}],\"url\":\"https://pe.pablopl.dev/en/deese/practice/propiedades-oo\"}]}"
   },
   {
     "url": "seo/en/deese/practice/uml.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/deese/practice/uml",
-    "title": "UML: Deseño de Software exam questions | Pásame Exámenes",
-    "description": "Practice 10 UML questions from past Deseño de Software \"exams\" with model answers and self-grading. 202317, Universidade da Coruña.",
+    "title": "UML: Deseño de Software practice questions | Pásame Exámenes",
+    "description": "Practice 10 UML questions from Deseño de Software compilations with model answers and self-grading. 202317, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/deese/practice/uml",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -959,15 +959,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/practice/uml"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"UML: Deseño de Software exam questions | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/en/deese/practice/uml\",\"inLanguage\":\"en\",\"description\":\"Practice 10 UML questions from past Deseño de Software \\\"exams\\\" with model answers and self-grading. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"UML\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/en/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"UML\",\"item\":\"https://pe.pablopl.dev/en/deese/practice/uml\"}],\"url\":\"https://pe.pablopl.dev/en/deese/practice/uml\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"UML: Deseño de Software practice questions | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/en/deese/practice/uml\",\"inLanguage\":\"en\",\"description\":\"Practice 10 UML questions from Deseño de Software compilations with model answers and self-grading. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"UML\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/en/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"UML\",\"item\":\"https://pe.pablopl.dev/en/deese/practice/uml\"}],\"url\":\"https://pe.pablopl.dev/en/deese/practice/uml\"}]}"
   },
   {
     "url": "seo/en/deese/practice/principios-diseno.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/deese/practice/principios-diseno",
-    "title": "Principios de Diseño: Deseño de Software exam questions",
-    "description": "Practice 12 Principios de Diseño questions from past Deseño de Software \"exams\" with model answers and self-grading. 202317, Universidade da Coruña.",
+    "title": "Principios de Diseño: Deseño de Software practice questions",
+    "description": "Practice 12 Principios de Diseño questions from Deseño de Software compilations with model answers and self-grading. 202317, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/deese/practice/principios-diseno",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -991,15 +991,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/practice/principios-diseno"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Principios de Diseño: Deseño de Software exam questions\",\"url\":\"https://pe.pablopl.dev/en/deese/practice/principios-diseno\",\"inLanguage\":\"en\",\"description\":\"Practice 12 Principios de Diseño questions from past Deseño de Software \\\"exams\\\" with model answers and self-grading. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Principios de Diseño\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/en/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Principios de Diseño\",\"item\":\"https://pe.pablopl.dev/en/deese/practice/principios-diseno\"}],\"url\":\"https://pe.pablopl.dev/en/deese/practice/principios-diseno\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Principios de Diseño: Deseño de Software practice questions\",\"url\":\"https://pe.pablopl.dev/en/deese/practice/principios-diseno\",\"inLanguage\":\"en\",\"description\":\"Practice 12 Principios de Diseño questions from Deseño de Software compilations with model answers and self-grading. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Principios de Diseño\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/en/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Principios de Diseño\",\"item\":\"https://pe.pablopl.dev/en/deese/practice/principios-diseno\"}],\"url\":\"https://pe.pablopl.dev/en/deese/practice/principios-diseno\"}]}"
   },
   {
     "url": "seo/en/deese/practice/patrones-diseno.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/deese/practice/patrones-diseno",
-    "title": "Patrones de Diseño: Deseño de Software exam questions",
-    "description": "Practice 10 Patrones de Diseño questions from past Deseño de Software \"exams\" with model answers and self-grading. 202317, Universidade da Coruña.",
+    "title": "Patrones de Diseño: Deseño de Software practice questions",
+    "description": "Practice 10 Patrones de Diseño questions from Deseño de Software compilations with model answers and self-grading. 202317, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/deese/practice/patrones-diseno",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -1023,15 +1023,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/practice/patrones-diseno"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Patrones de Diseño: Deseño de Software exam questions\",\"url\":\"https://pe.pablopl.dev/en/deese/practice/patrones-diseno\",\"inLanguage\":\"en\",\"description\":\"Practice 10 Patrones de Diseño questions from past Deseño de Software \\\"exams\\\" with model answers and self-grading. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Patrones de Diseño\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/en/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Patrones de Diseño\",\"item\":\"https://pe.pablopl.dev/en/deese/practice/patrones-diseno\"}],\"url\":\"https://pe.pablopl.dev/en/deese/practice/patrones-diseno\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Patrones de Diseño: Deseño de Software practice questions\",\"url\":\"https://pe.pablopl.dev/en/deese/practice/patrones-diseno\",\"inLanguage\":\"en\",\"description\":\"Practice 10 Patrones de Diseño questions from Deseño de Software compilations with model answers and self-grading. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Patrones de Diseño\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/en/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Patrones de Diseño\",\"item\":\"https://pe.pablopl.dev/en/deese/practice/patrones-diseno\"}],\"url\":\"https://pe.pablopl.dev/en/deese/practice/patrones-diseno\"}]}"
   },
   {
     "url": "seo/en/deese/exam/2020-01.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/deese/exam/2020-01",
-    "title": "Posibles preguntas Enero 2020 Deseño de Software: exam simulator",
-    "description": "Simulate the Posibles preguntas Enero 2020 Deseño de Software exam with 30 questions. 30 points, 150 minutes, model answers and self-grading.",
+    "title": "Posibles preguntas Enero 2020 Deseño de Software: timed practice",
+    "description": "Practice the Posibles preguntas Enero 2020 Deseño de Software timed set with 30 questions. 30 points, 150 minutes, model answers and self-grading.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/deese/exam/2020-01",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -1055,15 +1055,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/exam/2020-01"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Enero 2020 Deseño de Software: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/deese/exam/2020-01\",\"inLanguage\":\"en\",\"description\":\"Simulate the Posibles preguntas Enero 2020 Deseño de Software exam with 30 questions. 30 points, 150 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/en/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Enero 2020\",\"item\":\"https://pe.pablopl.dev/en/deese/exam/2020-01\"}],\"url\":\"https://pe.pablopl.dev/en/deese/exam/2020-01\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Enero 2020 Deseño de Software: timed practice\",\"url\":\"https://pe.pablopl.dev/en/deese/exam/2020-01\",\"inLanguage\":\"en\",\"description\":\"Practice the Posibles preguntas Enero 2020 Deseño de Software timed set with 30 questions. 30 points, 150 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/en/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Enero 2020\",\"item\":\"https://pe.pablopl.dev/en/deese/exam/2020-01\"}],\"url\":\"https://pe.pablopl.dev/en/deese/exam/2020-01\"}]}"
   },
   {
     "url": "seo/en/deese/exam/2022-01.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/deese/exam/2022-01",
-    "title": "Posibles preguntas Enero 2022 Deseño de Software: exam simulator",
-    "description": "Simulate the Posibles preguntas Enero 2022 Deseño de Software exam with 25 questions. 25 points, 150 minutes, model answers and self-grading.",
+    "title": "Posibles preguntas Enero 2022 Deseño de Software: timed practice",
+    "description": "Practice the Posibles preguntas Enero 2022 Deseño de Software timed set with 25 questions. 25 points, 150 minutes, model answers and self-grading.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/deese/exam/2022-01",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -1087,15 +1087,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/exam/2022-01"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Enero 2022 Deseño de Software: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/deese/exam/2022-01\",\"inLanguage\":\"en\",\"description\":\"Simulate the Posibles preguntas Enero 2022 Deseño de Software exam with 25 questions. 25 points, 150 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/en/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Enero 2022\",\"item\":\"https://pe.pablopl.dev/en/deese/exam/2022-01\"}],\"url\":\"https://pe.pablopl.dev/en/deese/exam/2022-01\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Enero 2022 Deseño de Software: timed practice\",\"url\":\"https://pe.pablopl.dev/en/deese/exam/2022-01\",\"inLanguage\":\"en\",\"description\":\"Practice the Posibles preguntas Enero 2022 Deseño de Software timed set with 25 questions. 25 points, 150 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/en/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Enero 2022\",\"item\":\"https://pe.pablopl.dev/en/deese/exam/2022-01\"}],\"url\":\"https://pe.pablopl.dev/en/deese/exam/2022-01\"}]}"
   },
   {
     "url": "seo/en/ece.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/ece",
-    "title": "Estrutura de Computadores: past \"exams\" and solved questions",
-    "description": "Practice 51 Estrutura de Computadores questions from 11 past \"exams\" with model answers and self-grading. 202314, Universidade da Coruña.",
+    "title": "Estrutura de Computadores: exams and solved questions",
+    "description": "Practice 51 Estrutura de Computadores questions from 11 exams with model answers and self-grading. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/ece",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -1119,7 +1119,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Estrutura de Computadores: past \\\"exams\\\" and solved questions\",\"url\":\"https://pe.pablopl.dev/en/ece\",\"inLanguage\":\"en\",\"description\":\"Practice 51 Estrutura de Computadores questions from 11 past \\\"exams\\\" with model answers and self-grading. 202314, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/en/ece\"}],\"url\":\"https://pe.pablopl.dev/en/ece\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Estrutura de Computadores: exams and solved questions\",\"url\":\"https://pe.pablopl.dev/en/ece\",\"inLanguage\":\"en\",\"description\":\"Practice 51 Estrutura de Computadores questions from 11 exams with model answers and self-grading. 202314, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/en/ece\"}],\"url\":\"https://pe.pablopl.dev/en/ece\"}]}"
   },
   {
     "url": "seo/en/ece/practice/rendimiento.html",
@@ -1127,7 +1127,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/ece/practice/rendimiento",
     "title": "Rendimiento: Estrutura de Computadores exam questions",
-    "description": "Practice 7 Rendimiento questions from past Estrutura de Computadores \"exams\" with model answers and self-grading. 202314, Universidade da Coruña.",
+    "description": "Practice 7 Rendimiento questions from Estrutura de Computadores exams with model answers and self-grading. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/ece/practice/rendimiento",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -1151,7 +1151,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece/practice/rendimiento"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Rendimiento: Estrutura de Computadores exam questions\",\"url\":\"https://pe.pablopl.dev/en/ece/practice/rendimiento\",\"inLanguage\":\"en\",\"description\":\"Practice 7 Rendimiento questions from past Estrutura de Computadores \\\"exams\\\" with model answers and self-grading. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Rendimiento\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/en/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Rendimiento\",\"item\":\"https://pe.pablopl.dev/en/ece/practice/rendimiento\"}],\"url\":\"https://pe.pablopl.dev/en/ece/practice/rendimiento\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Rendimiento: Estrutura de Computadores exam questions\",\"url\":\"https://pe.pablopl.dev/en/ece/practice/rendimiento\",\"inLanguage\":\"en\",\"description\":\"Practice 7 Rendimiento questions from Estrutura de Computadores exams with model answers and self-grading. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Rendimiento\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/en/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Rendimiento\",\"item\":\"https://pe.pablopl.dev/en/ece/practice/rendimiento\"}],\"url\":\"https://pe.pablopl.dev/en/ece/practice/rendimiento\"}]}"
   },
   {
     "url": "seo/en/ece/practice/segmentacion.html",
@@ -1159,7 +1159,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/ece/practice/segmentacion",
     "title": "Segmentación: Estrutura de Computadores exam questions",
-    "description": "Practice 7 Segmentación questions from past Estrutura de Computadores \"exams\" with model answers and self-grading. 202314, Universidade da Coruña.",
+    "description": "Practice 7 Segmentación questions from Estrutura de Computadores exams with model answers and self-grading. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/ece/practice/segmentacion",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -1183,7 +1183,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece/practice/segmentacion"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Segmentación: Estrutura de Computadores exam questions\",\"url\":\"https://pe.pablopl.dev/en/ece/practice/segmentacion\",\"inLanguage\":\"en\",\"description\":\"Practice 7 Segmentación questions from past Estrutura de Computadores \\\"exams\\\" with model answers and self-grading. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Segmentación\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/en/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Segmentación\",\"item\":\"https://pe.pablopl.dev/en/ece/practice/segmentacion\"}],\"url\":\"https://pe.pablopl.dev/en/ece/practice/segmentacion\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Segmentación: Estrutura de Computadores exam questions\",\"url\":\"https://pe.pablopl.dev/en/ece/practice/segmentacion\",\"inLanguage\":\"en\",\"description\":\"Practice 7 Segmentación questions from Estrutura de Computadores exams with model answers and self-grading. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Segmentación\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/en/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Segmentación\",\"item\":\"https://pe.pablopl.dev/en/ece/practice/segmentacion\"}],\"url\":\"https://pe.pablopl.dev/en/ece/practice/segmentacion\"}]}"
   },
   {
     "url": "seo/en/ece/practice/cache.html",
@@ -1191,7 +1191,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/ece/practice/cache",
     "title": "Memoria caché: Estrutura de Computadores exam questions",
-    "description": "Practice 7 Memoria caché questions from past Estrutura de Computadores \"exams\" with model answers and self-grading. 202314, Universidade da Coruña.",
+    "description": "Practice 7 Memoria caché questions from Estrutura de Computadores exams with model answers and self-grading. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/ece/practice/cache",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -1215,7 +1215,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece/practice/cache"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Memoria caché: Estrutura de Computadores exam questions\",\"url\":\"https://pe.pablopl.dev/en/ece/practice/cache\",\"inLanguage\":\"en\",\"description\":\"Practice 7 Memoria caché questions from past Estrutura de Computadores \\\"exams\\\" with model answers and self-grading. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Memoria caché\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/en/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Memoria caché\",\"item\":\"https://pe.pablopl.dev/en/ece/practice/cache\"}],\"url\":\"https://pe.pablopl.dev/en/ece/practice/cache\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Memoria caché: Estrutura de Computadores exam questions\",\"url\":\"https://pe.pablopl.dev/en/ece/practice/cache\",\"inLanguage\":\"en\",\"description\":\"Practice 7 Memoria caché questions from Estrutura de Computadores exams with model answers and self-grading. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Memoria caché\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/en/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Memoria caché\",\"item\":\"https://pe.pablopl.dev/en/ece/practice/cache\"}],\"url\":\"https://pe.pablopl.dev/en/ece/practice/cache\"}]}"
   },
   {
     "url": "seo/en/ece/practice/memoria-virtual.html",
@@ -1223,7 +1223,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/ece/practice/memoria-virtual",
     "title": "Memoria virtual: Estrutura de Computadores exam questions",
-    "description": "Practice 11 Memoria virtual questions from past Estrutura de Computadores \"exams\" with model answers and self-grading. 202314, Universidade da Coruña.",
+    "description": "Practice 11 Memoria virtual questions from Estrutura de Computadores exams with model answers and self-grading. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/ece/practice/memoria-virtual",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -1247,7 +1247,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece/practice/memoria-virtual"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Memoria virtual: Estrutura de Computadores exam questions\",\"url\":\"https://pe.pablopl.dev/en/ece/practice/memoria-virtual\",\"inLanguage\":\"en\",\"description\":\"Practice 11 Memoria virtual questions from past Estrutura de Computadores \\\"exams\\\" with model answers and self-grading. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Memoria virtual\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/en/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Memoria virtual\",\"item\":\"https://pe.pablopl.dev/en/ece/practice/memoria-virtual\"}],\"url\":\"https://pe.pablopl.dev/en/ece/practice/memoria-virtual\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Memoria virtual: Estrutura de Computadores exam questions\",\"url\":\"https://pe.pablopl.dev/en/ece/practice/memoria-virtual\",\"inLanguage\":\"en\",\"description\":\"Practice 11 Memoria virtual questions from Estrutura de Computadores exams with model answers and self-grading. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Memoria virtual\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/en/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Memoria virtual\",\"item\":\"https://pe.pablopl.dev/en/ece/practice/memoria-virtual\"}],\"url\":\"https://pe.pablopl.dev/en/ece/practice/memoria-virtual\"}]}"
   },
   {
     "url": "seo/en/ece/practice/buses.html",
@@ -1255,7 +1255,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/ece/practice/buses",
     "title": "Buses y E/S: Estrutura de Computadores exam questions",
-    "description": "Practice 11 Buses y E/S questions from past Estrutura de Computadores \"exams\" with model answers and self-grading. 202314, Universidade da Coruña.",
+    "description": "Practice 11 Buses y E/S questions from Estrutura de Computadores exams with model answers and self-grading. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/ece/practice/buses",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -1279,7 +1279,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece/practice/buses"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Buses y E/S: Estrutura de Computadores exam questions\",\"url\":\"https://pe.pablopl.dev/en/ece/practice/buses\",\"inLanguage\":\"en\",\"description\":\"Practice 11 Buses y E/S questions from past Estrutura de Computadores \\\"exams\\\" with model answers and self-grading. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Buses y E/S\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/en/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Buses y E/S\",\"item\":\"https://pe.pablopl.dev/en/ece/practice/buses\"}],\"url\":\"https://pe.pablopl.dev/en/ece/practice/buses\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Buses y E/S: Estrutura de Computadores exam questions\",\"url\":\"https://pe.pablopl.dev/en/ece/practice/buses\",\"inLanguage\":\"en\",\"description\":\"Practice 11 Buses y E/S questions from Estrutura de Computadores exams with model answers and self-grading. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Buses y E/S\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/en/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Buses y E/S\",\"item\":\"https://pe.pablopl.dev/en/ece/practice/buses\"}],\"url\":\"https://pe.pablopl.dev/en/ece/practice/buses\"}]}"
   },
   {
     "url": "seo/en/ece/practice/raid.html",
@@ -1287,7 +1287,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/ece/practice/raid",
     "title": "RAID y almacenamiento: Estrutura de Computadores exam questions",
-    "description": "Practice 8 RAID y almacenamiento questions from past Estrutura de Computadores \"exams\" with model answers and self-grading. 202314, Universidade da Coruña.",
+    "description": "Practice 8 RAID y almacenamiento questions from Estrutura de Computadores exams with model answers and self-grading. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/ece/practice/raid",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -1311,7 +1311,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece/practice/raid"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"RAID y almacenamiento: Estrutura de Computadores exam questions\",\"url\":\"https://pe.pablopl.dev/en/ece/practice/raid\",\"inLanguage\":\"en\",\"description\":\"Practice 8 RAID y almacenamiento questions from past Estrutura de Computadores \\\"exams\\\" with model answers and self-grading. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"RAID y almacenamiento\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/en/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"RAID y almacenamiento\",\"item\":\"https://pe.pablopl.dev/en/ece/practice/raid\"}],\"url\":\"https://pe.pablopl.dev/en/ece/practice/raid\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"RAID y almacenamiento: Estrutura de Computadores exam questions\",\"url\":\"https://pe.pablopl.dev/en/ece/practice/raid\",\"inLanguage\":\"en\",\"description\":\"Practice 8 RAID y almacenamiento questions from Estrutura de Computadores exams with model answers and self-grading. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"RAID y almacenamiento\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/en/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"RAID y almacenamiento\",\"item\":\"https://pe.pablopl.dev/en/ece/practice/raid\"}],\"url\":\"https://pe.pablopl.dev/en/ece/practice/raid\"}]}"
   },
   {
     "url": "seo/en/ece/exam/2021-01.html",
@@ -1670,8 +1670,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/emeele",
-    "title": "Introduction to Machine Learning: past \"exams\" and solved questions",
-    "description": "Practice 47 Introduction to Machine Learning questions from 2 past \"exams\" with model answers and self-grading. 2DV516, Linnaeus University.",
+    "title": "Introduction to Machine Learning: exams and solved questions",
+    "description": "Practice 47 Introduction to Machine Learning questions from 2 exams with model answers and self-grading. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/emeele",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -1695,7 +1695,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Introduction to Machine Learning: past \\\"exams\\\" and solved questions\",\"url\":\"https://pe.pablopl.dev/en/emeele\",\"inLanguage\":\"en\",\"description\":\"Practice 47 Introduction to Machine Learning questions from 2 past \\\"exams\\\" with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Linnaeus University\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"}],\"url\":\"https://pe.pablopl.dev/en/emeele\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Introduction to Machine Learning: exams and solved questions\",\"url\":\"https://pe.pablopl.dev/en/emeele\",\"inLanguage\":\"en\",\"description\":\"Practice 47 Introduction to Machine Learning questions from 2 exams with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Linnaeus University\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"}],\"url\":\"https://pe.pablopl.dev/en/emeele\"}]}"
   },
   {
     "url": "seo/en/emeele/practice/kNN.html",
@@ -1703,7 +1703,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/emeele/practice/kNN",
     "title": "k-Nearest Neighbors: Introduction to Machine Learning exam questions",
-    "description": "Practice 6 k-Nearest Neighbors questions from past Introduction to Machine Learning \"exams\" with model answers and self-grading. 2DV516, Linnaeus University.",
+    "description": "Practice 6 k-Nearest Neighbors questions from Introduction to Machine Learning exams with model answers and self-grading. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/emeele/practice/kNN",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -1727,7 +1727,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/kNN"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"k-Nearest Neighbors: Introduction to Machine Learning exam questions\",\"url\":\"https://pe.pablopl.dev/en/emeele/practice/kNN\",\"inLanguage\":\"en\",\"description\":\"Practice 6 k-Nearest Neighbors questions from past Introduction to Machine Learning \\\"exams\\\" with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"k-Nearest Neighbors\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"k-Nearest Neighbors\",\"item\":\"https://pe.pablopl.dev/en/emeele/practice/kNN\"}],\"url\":\"https://pe.pablopl.dev/en/emeele/practice/kNN\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"k-Nearest Neighbors: Introduction to Machine Learning exam questions\",\"url\":\"https://pe.pablopl.dev/en/emeele/practice/kNN\",\"inLanguage\":\"en\",\"description\":\"Practice 6 k-Nearest Neighbors questions from Introduction to Machine Learning exams with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"k-Nearest Neighbors\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"k-Nearest Neighbors\",\"item\":\"https://pe.pablopl.dev/en/emeele/practice/kNN\"}],\"url\":\"https://pe.pablopl.dev/en/emeele/practice/kNN\"}]}"
   },
   {
     "url": "seo/en/emeele/practice/Bias-Variance.html",
@@ -1735,7 +1735,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/emeele/practice/Bias-Variance",
     "title": "Bias-Variance Tradeoff: Introduction to Machine Learning exam questions",
-    "description": "Practice 5 Bias-Variance Tradeoff questions from past Introduction to Machine Learning \"exams\" with model answers and self-grading. 2DV516, Linnaeus University.",
+    "description": "Practice 5 Bias-Variance Tradeoff questions from Introduction to Machine Learning exams with model answers and self-grading. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/emeele/practice/Bias-Variance",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -1759,7 +1759,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Bias-Variance"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Bias-Variance Tradeoff: Introduction to Machine Learning exam questions\",\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Bias-Variance\",\"inLanguage\":\"en\",\"description\":\"Practice 5 Bias-Variance Tradeoff questions from past Introduction to Machine Learning \\\"exams\\\" with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Bias-Variance Tradeoff\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Bias-Variance Tradeoff\",\"item\":\"https://pe.pablopl.dev/en/emeele/practice/Bias-Variance\"}],\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Bias-Variance\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Bias-Variance Tradeoff: Introduction to Machine Learning exam questions\",\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Bias-Variance\",\"inLanguage\":\"en\",\"description\":\"Practice 5 Bias-Variance Tradeoff questions from Introduction to Machine Learning exams with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Bias-Variance Tradeoff\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Bias-Variance Tradeoff\",\"item\":\"https://pe.pablopl.dev/en/emeele/practice/Bias-Variance\"}],\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Bias-Variance\"}]}"
   },
   {
     "url": "seo/en/emeele/practice/Linear%20%26%20Logistic%20Regression.html",
@@ -1767,7 +1767,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/emeele/practice/Linear & Logistic Regression",
     "title": "Linear & Logistic Regression: Introduction to Machine Learning exam questions",
-    "description": "Practice 5 Linear & Logistic Regression questions from past Introduction to Machine Learning \"exams\" with model answers and self-grading. 2DV516, Linnaeus University.",
+    "description": "Practice 5 Linear & Logistic Regression questions from Introduction to Machine Learning exams with model answers and self-grading. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/emeele/practice/Linear%20%26%20Logistic%20Regression",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -1791,7 +1791,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Linear%20%26%20Logistic%20Regression"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Linear & Logistic Regression: Introduction to Machine Learning exam questions\",\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Linear%20%26%20Logistic%20Regression\",\"inLanguage\":\"en\",\"description\":\"Practice 5 Linear & Logistic Regression questions from past Introduction to Machine Learning \\\"exams\\\" with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Linear & Logistic Regression\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Linear & Logistic Regression\",\"item\":\"https://pe.pablopl.dev/en/emeele/practice/Linear%20%26%20Logistic%20Regression\"}],\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Linear%20%26%20Logistic%20Regression\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Linear & Logistic Regression: Introduction to Machine Learning exam questions\",\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Linear%20%26%20Logistic%20Regression\",\"inLanguage\":\"en\",\"description\":\"Practice 5 Linear & Logistic Regression questions from Introduction to Machine Learning exams with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Linear & Logistic Regression\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Linear & Logistic Regression\",\"item\":\"https://pe.pablopl.dev/en/emeele/practice/Linear%20%26%20Logistic%20Regression\"}],\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Linear%20%26%20Logistic%20Regression\"}]}"
   },
   {
     "url": "seo/en/emeele/practice/Model%20Selection%20%26%20Regularization.html",
@@ -1799,7 +1799,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/emeele/practice/Model Selection & Regularization",
     "title": "Model Selection & Regularization: Introduction to Machine Learning exam questions",
-    "description": "Practice 5 Model Selection & Regularization questions from past Introduction to Machine Learning \"exams\" with model answers and self-grading. 2DV516, Linnaeus University.",
+    "description": "Practice 5 Model Selection & Regularization questions from Introduction to Machine Learning exams with model answers and self-grading. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/emeele/practice/Model%20Selection%20%26%20Regularization",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -1823,7 +1823,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Model%20Selection%20%26%20Regularization"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Model Selection & Regularization: Introduction to Machine Learning exam questions\",\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Model%20Selection%20%26%20Regularization\",\"inLanguage\":\"en\",\"description\":\"Practice 5 Model Selection & Regularization questions from past Introduction to Machine Learning \\\"exams\\\" with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Model Selection & Regularization\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Model Selection & Regularization\",\"item\":\"https://pe.pablopl.dev/en/emeele/practice/Model%20Selection%20%26%20Regularization\"}],\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Model%20Selection%20%26%20Regularization\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Model Selection & Regularization: Introduction to Machine Learning exam questions\",\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Model%20Selection%20%26%20Regularization\",\"inLanguage\":\"en\",\"description\":\"Practice 5 Model Selection & Regularization questions from Introduction to Machine Learning exams with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Model Selection & Regularization\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Model Selection & Regularization\",\"item\":\"https://pe.pablopl.dev/en/emeele/practice/Model%20Selection%20%26%20Regularization\"}],\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Model%20Selection%20%26%20Regularization\"}]}"
   },
   {
     "url": "seo/en/emeele/practice/Neural%20Networks.html",
@@ -1831,7 +1831,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/emeele/practice/Neural Networks",
     "title": "Neural Networks: Introduction to Machine Learning exam questions",
-    "description": "Practice 6 Neural Networks questions from past Introduction to Machine Learning \"exams\" with model answers and self-grading. 2DV516, Linnaeus University.",
+    "description": "Practice 6 Neural Networks questions from Introduction to Machine Learning exams with model answers and self-grading. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/emeele/practice/Neural%20Networks",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -1855,7 +1855,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Neural%20Networks"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Neural Networks: Introduction to Machine Learning exam questions\",\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Neural%20Networks\",\"inLanguage\":\"en\",\"description\":\"Practice 6 Neural Networks questions from past Introduction to Machine Learning \\\"exams\\\" with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Neural Networks\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Neural Networks\",\"item\":\"https://pe.pablopl.dev/en/emeele/practice/Neural%20Networks\"}],\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Neural%20Networks\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Neural Networks: Introduction to Machine Learning exam questions\",\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Neural%20Networks\",\"inLanguage\":\"en\",\"description\":\"Practice 6 Neural Networks questions from Introduction to Machine Learning exams with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Neural Networks\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Neural Networks\",\"item\":\"https://pe.pablopl.dev/en/emeele/practice/Neural%20Networks\"}],\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Neural%20Networks\"}]}"
   },
   {
     "url": "seo/en/emeele/practice/Decision%20Trees%20%26%20Ensembles.html",
@@ -1863,7 +1863,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/emeele/practice/Decision Trees & Ensembles",
     "title": "Decision Trees & Ensembles: Introduction to Machine Learning exam questions",
-    "description": "Practice 4 Decision Trees & Ensembles questions from past Introduction to Machine Learning \"exams\" with model answers and self-grading. 2DV516, Linnaeus University.",
+    "description": "Practice 4 Decision Trees & Ensembles questions from Introduction to Machine Learning exams with model answers and self-grading. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/emeele/practice/Decision%20Trees%20%26%20Ensembles",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -1887,7 +1887,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Decision%20Trees%20%26%20Ensembles"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Decision Trees & Ensembles: Introduction to Machine Learning exam questions\",\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Decision%20Trees%20%26%20Ensembles\",\"inLanguage\":\"en\",\"description\":\"Practice 4 Decision Trees & Ensembles questions from past Introduction to Machine Learning \\\"exams\\\" with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Decision Trees & Ensembles\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Decision Trees & Ensembles\",\"item\":\"https://pe.pablopl.dev/en/emeele/practice/Decision%20Trees%20%26%20Ensembles\"}],\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Decision%20Trees%20%26%20Ensembles\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Decision Trees & Ensembles: Introduction to Machine Learning exam questions\",\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Decision%20Trees%20%26%20Ensembles\",\"inLanguage\":\"en\",\"description\":\"Practice 4 Decision Trees & Ensembles questions from Introduction to Machine Learning exams with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Decision Trees & Ensembles\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Decision Trees & Ensembles\",\"item\":\"https://pe.pablopl.dev/en/emeele/practice/Decision%20Trees%20%26%20Ensembles\"}],\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Decision%20Trees%20%26%20Ensembles\"}]}"
   },
   {
     "url": "seo/en/emeele/practice/Support%20Vector%20Machines.html",
@@ -1895,7 +1895,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/emeele/practice/Support Vector Machines",
     "title": "Support Vector Machines: Introduction to Machine Learning exam questions",
-    "description": "Practice 6 Support Vector Machines questions from past Introduction to Machine Learning \"exams\" with model answers and self-grading. 2DV516, Linnaeus University.",
+    "description": "Practice 6 Support Vector Machines questions from Introduction to Machine Learning exams with model answers and self-grading. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/emeele/practice/Support%20Vector%20Machines",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -1919,7 +1919,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Support%20Vector%20Machines"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Support Vector Machines: Introduction to Machine Learning exam questions\",\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Support%20Vector%20Machines\",\"inLanguage\":\"en\",\"description\":\"Practice 6 Support Vector Machines questions from past Introduction to Machine Learning \\\"exams\\\" with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Support Vector Machines\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Support Vector Machines\",\"item\":\"https://pe.pablopl.dev/en/emeele/practice/Support%20Vector%20Machines\"}],\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Support%20Vector%20Machines\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Support Vector Machines: Introduction to Machine Learning exam questions\",\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Support%20Vector%20Machines\",\"inLanguage\":\"en\",\"description\":\"Practice 6 Support Vector Machines questions from Introduction to Machine Learning exams with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Support Vector Machines\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Support Vector Machines\",\"item\":\"https://pe.pablopl.dev/en/emeele/practice/Support%20Vector%20Machines\"}],\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Support%20Vector%20Machines\"}]}"
   },
   {
     "url": "seo/en/emeele/practice/Clustering.html",
@@ -1927,7 +1927,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/emeele/practice/Clustering",
     "title": "Clustering: Introduction to Machine Learning exam questions",
-    "description": "Practice 6 Clustering questions from past Introduction to Machine Learning \"exams\" with model answers and self-grading. 2DV516, Linnaeus University.",
+    "description": "Practice 6 Clustering questions from Introduction to Machine Learning exams with model answers and self-grading. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/emeele/practice/Clustering",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -1951,7 +1951,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Clustering"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Clustering: Introduction to Machine Learning exam questions\",\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Clustering\",\"inLanguage\":\"en\",\"description\":\"Practice 6 Clustering questions from past Introduction to Machine Learning \\\"exams\\\" with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Clustering\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Clustering\",\"item\":\"https://pe.pablopl.dev/en/emeele/practice/Clustering\"}],\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Clustering\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Clustering: Introduction to Machine Learning exam questions\",\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Clustering\",\"inLanguage\":\"en\",\"description\":\"Practice 6 Clustering questions from Introduction to Machine Learning exams with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Clustering\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Clustering\",\"item\":\"https://pe.pablopl.dev/en/emeele/practice/Clustering\"}],\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Clustering\"}]}"
   },
   {
     "url": "seo/en/emeele/practice/Dimensionality%20Reduction.html",
@@ -1959,7 +1959,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/emeele/practice/Dimensionality Reduction",
     "title": "Dimensionality Reduction: Introduction to Machine Learning exam questions",
-    "description": "Practice 4 Dimensionality Reduction questions from past Introduction to Machine Learning \"exams\" with model answers and self-grading. 2DV516, Linnaeus University.",
+    "description": "Practice 4 Dimensionality Reduction questions from Introduction to Machine Learning exams with model answers and self-grading. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/emeele/practice/Dimensionality%20Reduction",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -1983,7 +1983,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Dimensionality%20Reduction"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Dimensionality Reduction: Introduction to Machine Learning exam questions\",\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Dimensionality%20Reduction\",\"inLanguage\":\"en\",\"description\":\"Practice 4 Dimensionality Reduction questions from past Introduction to Machine Learning \\\"exams\\\" with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Dimensionality Reduction\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Dimensionality Reduction\",\"item\":\"https://pe.pablopl.dev/en/emeele/practice/Dimensionality%20Reduction\"}],\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Dimensionality%20Reduction\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Dimensionality Reduction: Introduction to Machine Learning exam questions\",\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Dimensionality%20Reduction\",\"inLanguage\":\"en\",\"description\":\"Practice 4 Dimensionality Reduction questions from Introduction to Machine Learning exams with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Dimensionality Reduction\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Dimensionality Reduction\",\"item\":\"https://pe.pablopl.dev/en/emeele/practice/Dimensionality%20Reduction\"}],\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Dimensionality%20Reduction\"}]}"
   },
   {
     "url": "seo/en/emeele/exam/2024.html",
@@ -2054,8 +2054,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/equisi",
-    "title": "Xestión de Infraestruturas: past \"exams\" and solved questions",
-    "description": "Practice 381 Xestión de Infraestruturas questions from 4 past \"exams\" with model answers and self-grading. 200190, Universidade da Coruña.",
+    "title": "Xestión de Infraestruturas: compilations and solved questions",
+    "description": "Practice 381 Xestión de Infraestruturas questions from 4 compilations with model answers and self-grading. 200190, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/equisi",
     "ogImage": "https://pe.pablopl.dev/og/equisi.png",
@@ -2079,15 +2079,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equisi"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Xestión de Infraestruturas: past \\\"exams\\\" and solved questions\",\"url\":\"https://pe.pablopl.dev/en/equisi\",\"inLanguage\":\"en\",\"description\":\"Practice 381 Xestión de Infraestruturas questions from 4 past \\\"exams\\\" with model answers and self-grading. 200190, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/en/equisi\"}],\"url\":\"https://pe.pablopl.dev/en/equisi\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Xestión de Infraestruturas: compilations and solved questions\",\"url\":\"https://pe.pablopl.dev/en/equisi\",\"inLanguage\":\"en\",\"description\":\"Practice 381 Xestión de Infraestruturas questions from 4 compilations with model answers and self-grading. 200190, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/en/equisi\"}],\"url\":\"https://pe.pablopl.dev/en/equisi\"}]}"
   },
   {
     "url": "seo/en/equisi/practice/modulo-i.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/equisi/practice/modulo-i",
-    "title": "Módulo I: Sinais e Comunicacións: Xestión de Infraestruturas exam questions",
-    "description": "Practice 130 Módulo I: Sinais e Comunicacións questions from past Xestión de Infraestruturas \"exams\" with model answers and self-grading. 200190, Universidade da Coruña.",
+    "title": "Módulo I: Sinais e Comunicacións: Xestión de Infraestruturas practice questions",
+    "description": "Practice 130 Módulo I: Sinais e Comunicacións questions from Xestión de Infraestruturas compilations with model answers and self-grading. 200190, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/equisi/practice/modulo-i",
     "ogImage": "https://pe.pablopl.dev/og/equisi.png",
@@ -2111,15 +2111,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equisi/practice/modulo-i"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Módulo I: Sinais e Comunicacións: Xestión de Infraestruturas exam questions\",\"url\":\"https://pe.pablopl.dev/en/equisi/practice/modulo-i\",\"inLanguage\":\"en\",\"description\":\"Practice 130 Módulo I: Sinais e Comunicacións questions from past Xestión de Infraestruturas \\\"exams\\\" with model answers and self-grading. 200190, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Módulo I: Sinais e Comunicacións\"},{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/en/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Módulo I: Sinais e Comunicacións\",\"item\":\"https://pe.pablopl.dev/en/equisi/practice/modulo-i\"}],\"url\":\"https://pe.pablopl.dev/en/equisi/practice/modulo-i\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Módulo I: Sinais e Comunicacións: Xestión de Infraestruturas practice questions\",\"url\":\"https://pe.pablopl.dev/en/equisi/practice/modulo-i\",\"inLanguage\":\"en\",\"description\":\"Practice 130 Módulo I: Sinais e Comunicacións questions from Xestión de Infraestruturas compilations with model answers and self-grading. 200190, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Módulo I: Sinais e Comunicacións\"},{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/en/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Módulo I: Sinais e Comunicacións\",\"item\":\"https://pe.pablopl.dev/en/equisi/practice/modulo-i\"}],\"url\":\"https://pe.pablopl.dev/en/equisi/practice/modulo-i\"}]}"
   },
   {
     "url": "seo/en/equisi/practice/modulo-ii.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/equisi/practice/modulo-ii",
-    "title": "Módulo II: Infraestruturas TI: Xestión de Infraestruturas exam questions",
-    "description": "Practice 251 Módulo II: Infraestruturas TI questions from past Xestión de Infraestruturas \"exams\" with model answers and self-grading. 200190, Universidade da Coruña.",
+    "title": "Módulo II: Infraestruturas TI: Xestión de Infraestruturas practice questions",
+    "description": "Practice 251 Módulo II: Infraestruturas TI questions from Xestión de Infraestruturas compilations with model answers and self-grading. 200190, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/equisi/practice/modulo-ii",
     "ogImage": "https://pe.pablopl.dev/og/equisi.png",
@@ -2143,15 +2143,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equisi/practice/modulo-ii"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Módulo II: Infraestruturas TI: Xestión de Infraestruturas exam questions\",\"url\":\"https://pe.pablopl.dev/en/equisi/practice/modulo-ii\",\"inLanguage\":\"en\",\"description\":\"Practice 251 Módulo II: Infraestruturas TI questions from past Xestión de Infraestruturas \\\"exams\\\" with model answers and self-grading. 200190, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Módulo II: Infraestruturas TI\"},{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/en/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Módulo II: Infraestruturas TI\",\"item\":\"https://pe.pablopl.dev/en/equisi/practice/modulo-ii\"}],\"url\":\"https://pe.pablopl.dev/en/equisi/practice/modulo-ii\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Módulo II: Infraestruturas TI: Xestión de Infraestruturas practice questions\",\"url\":\"https://pe.pablopl.dev/en/equisi/practice/modulo-ii\",\"inLanguage\":\"en\",\"description\":\"Practice 251 Módulo II: Infraestruturas TI questions from Xestión de Infraestruturas compilations with model answers and self-grading. 200190, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Módulo II: Infraestruturas TI\"},{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/en/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Módulo II: Infraestruturas TI\",\"item\":\"https://pe.pablopl.dev/en/equisi/practice/modulo-ii\"}],\"url\":\"https://pe.pablopl.dev/en/equisi/practice/modulo-ii\"}]}"
   },
   {
     "url": "seo/en/equisi/exam/2024-07.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/equisi/exam/2024-07",
-    "title": "Posibles preguntas Xullo 2024 Xestión de Infraestruturas: exam simulator",
-    "description": "Simulate the Posibles preguntas Xullo 2024 Xestión de Infraestruturas exam with 20 questions. 10 points, 45 minutes, model answers and self-grading.",
+    "title": "Posibles preguntas Xullo 2024 Xestión de Infraestruturas: timed practice",
+    "description": "Practice the Posibles preguntas Xullo 2024 Xestión de Infraestruturas timed set with 20 questions. 10 points, 45 minutes, model answers and self-grading.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/equisi/exam/2024-07",
     "ogImage": "https://pe.pablopl.dev/og/equisi.png",
@@ -2175,15 +2175,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equisi/exam/2024-07"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Xullo 2024 Xestión de Infraestruturas: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/equisi/exam/2024-07\",\"inLanguage\":\"en\",\"description\":\"Simulate the Posibles preguntas Xullo 2024 Xestión de Infraestruturas exam with 20 questions. 10 points, 45 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/en/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Xullo 2024\",\"item\":\"https://pe.pablopl.dev/en/equisi/exam/2024-07\"}],\"url\":\"https://pe.pablopl.dev/en/equisi/exam/2024-07\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Xullo 2024 Xestión de Infraestruturas: timed practice\",\"url\":\"https://pe.pablopl.dev/en/equisi/exam/2024-07\",\"inLanguage\":\"en\",\"description\":\"Practice the Posibles preguntas Xullo 2024 Xestión de Infraestruturas timed set with 20 questions. 10 points, 45 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/en/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Xullo 2024\",\"item\":\"https://pe.pablopl.dev/en/equisi/exam/2024-07\"}],\"url\":\"https://pe.pablopl.dev/en/equisi/exam/2024-07\"}]}"
   },
   {
     "url": "seo/en/equisi/exam/daypo-modulo-i.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/equisi/exam/daypo-modulo-i",
-    "title": "Daypo Módulo I Xestión de Infraestruturas: exam simulator",
-    "description": "Simulate the Daypo Módulo I Xestión de Infraestruturas exam with 130 questions. 130 points, 120 minutes, model answers and self-grading.",
+    "title": "Daypo Módulo I Xestión de Infraestruturas: timed practice",
+    "description": "Practice the Daypo Módulo I Xestión de Infraestruturas timed set with 130 questions. 130 points, 120 minutes, model answers and self-grading.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/equisi/exam/daypo-modulo-i",
     "ogImage": "https://pe.pablopl.dev/og/equisi.png",
@@ -2207,15 +2207,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equisi/exam/daypo-modulo-i"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Módulo I Xestión de Infraestruturas: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/equisi/exam/daypo-modulo-i\",\"inLanguage\":\"en\",\"description\":\"Simulate the Daypo Módulo I Xestión de Infraestruturas exam with 130 questions. 130 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/en/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Módulo I\",\"item\":\"https://pe.pablopl.dev/en/equisi/exam/daypo-modulo-i\"}],\"url\":\"https://pe.pablopl.dev/en/equisi/exam/daypo-modulo-i\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Módulo I Xestión de Infraestruturas: timed practice\",\"url\":\"https://pe.pablopl.dev/en/equisi/exam/daypo-modulo-i\",\"inLanguage\":\"en\",\"description\":\"Practice the Daypo Módulo I Xestión de Infraestruturas timed set with 130 questions. 130 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/en/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Módulo I\",\"item\":\"https://pe.pablopl.dev/en/equisi/exam/daypo-modulo-i\"}],\"url\":\"https://pe.pablopl.dev/en/equisi/exam/daypo-modulo-i\"}]}"
   },
   {
     "url": "seo/en/equisi/exam/daypo-modulo-ii.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/equisi/exam/daypo-modulo-ii",
-    "title": "Daypo Módulo II Xestión de Infraestruturas: exam simulator",
-    "description": "Simulate the Daypo Módulo II Xestión de Infraestruturas exam with 109 questions. 109 points, 120 minutes, model answers and self-grading.",
+    "title": "Daypo Módulo II Xestión de Infraestruturas: timed practice",
+    "description": "Practice the Daypo Módulo II Xestión de Infraestruturas timed set with 109 questions. 109 points, 120 minutes, model answers and self-grading.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/equisi/exam/daypo-modulo-ii",
     "ogImage": "https://pe.pablopl.dev/og/equisi.png",
@@ -2239,15 +2239,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equisi/exam/daypo-modulo-ii"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Módulo II Xestión de Infraestruturas: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/equisi/exam/daypo-modulo-ii\",\"inLanguage\":\"en\",\"description\":\"Simulate the Daypo Módulo II Xestión de Infraestruturas exam with 109 questions. 109 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/en/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Módulo II\",\"item\":\"https://pe.pablopl.dev/en/equisi/exam/daypo-modulo-ii\"}],\"url\":\"https://pe.pablopl.dev/en/equisi/exam/daypo-modulo-ii\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Módulo II Xestión de Infraestruturas: timed practice\",\"url\":\"https://pe.pablopl.dev/en/equisi/exam/daypo-modulo-ii\",\"inLanguage\":\"en\",\"description\":\"Practice the Daypo Módulo II Xestión de Infraestruturas timed set with 109 questions. 109 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/en/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Módulo II\",\"item\":\"https://pe.pablopl.dev/en/equisi/exam/daypo-modulo-ii\"}],\"url\":\"https://pe.pablopl.dev/en/equisi/exam/daypo-modulo-ii\"}]}"
   },
   {
     "url": "seo/en/equisi/exam/megarecopilacion.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/equisi/exam/megarecopilacion",
-    "title": "Megarecopilación Test XI Xestión de Infraestruturas: exam simulator",
-    "description": "Simulate the Megarecopilación Test XI Xestión de Infraestruturas exam with 122 questions. 122 points, 90 minutes, model answers and self-grading.",
+    "title": "Megarecopilación Test XI Xestión de Infraestruturas: timed practice",
+    "description": "Practice the Megarecopilación Test XI Xestión de Infraestruturas timed set with 122 questions. 122 points, 90 minutes, model answers and self-grading.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/equisi/exam/megarecopilacion",
     "ogImage": "https://pe.pablopl.dev/og/equisi.png",
@@ -2271,15 +2271,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equisi/exam/megarecopilacion"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Megarecopilación Test XI Xestión de Infraestruturas: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/equisi/exam/megarecopilacion\",\"inLanguage\":\"en\",\"description\":\"Simulate the Megarecopilación Test XI Xestión de Infraestruturas exam with 122 questions. 122 points, 90 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/en/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Megarecopilación Test XI\",\"item\":\"https://pe.pablopl.dev/en/equisi/exam/megarecopilacion\"}],\"url\":\"https://pe.pablopl.dev/en/equisi/exam/megarecopilacion\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Megarecopilación Test XI Xestión de Infraestruturas: timed practice\",\"url\":\"https://pe.pablopl.dev/en/equisi/exam/megarecopilacion\",\"inLanguage\":\"en\",\"description\":\"Practice the Megarecopilación Test XI Xestión de Infraestruturas timed set with 122 questions. 122 points, 90 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/en/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Megarecopilación Test XI\",\"item\":\"https://pe.pablopl.dev/en/equisi/exam/megarecopilacion\"}],\"url\":\"https://pe.pablopl.dev/en/equisi/exam/megarecopilacion\"}]}"
   },
   {
     "url": "seo/en/equispe.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/equispe",
-    "title": "Xestión de Proxectos: past \"exams\" and solved questions",
-    "description": "Practice 175 Xestión de Proxectos questions from 5 past \"exams\" with model answers and self-grading. 202323, Universidade da Coruña.",
+    "title": "Xestión de Proxectos: compilations and solved questions",
+    "description": "Practice 175 Xestión de Proxectos questions from 5 compilations with model answers and self-grading. 202323, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/equispe",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -2303,15 +2303,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Xestión de Proxectos: past \\\"exams\\\" and solved questions\",\"url\":\"https://pe.pablopl.dev/en/equispe\",\"inLanguage\":\"en\",\"description\":\"Practice 175 Xestión de Proxectos questions from 5 past \\\"exams\\\" with model answers and self-grading. 202323, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/en/equispe\"}],\"url\":\"https://pe.pablopl.dev/en/equispe\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Xestión de Proxectos: compilations and solved questions\",\"url\":\"https://pe.pablopl.dev/en/equispe\",\"inLanguage\":\"en\",\"description\":\"Practice 175 Xestión de Proxectos questions from 5 compilations with model answers and self-grading. 202323, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/en/equispe\"}],\"url\":\"https://pe.pablopl.dev/en/equispe\"}]}"
   },
   {
     "url": "seo/en/equispe/practice/teoria.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/equispe/practice/teoria",
-    "title": "Teoría: Xestión de Proxectos exam questions | Pásame Exámenes",
-    "description": "Practice 107 Teoría questions from past Xestión de Proxectos \"exams\" with model answers and self-grading. 202323, Universidade da Coruña.",
+    "title": "Teoría: Xestión de Proxectos practice questions",
+    "description": "Practice 107 Teoría questions from Xestión de Proxectos compilations with model answers and self-grading. 202323, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/equispe/practice/teoria",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -2335,15 +2335,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe/practice/teoria"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Teoría: Xestión de Proxectos exam questions | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/en/equispe/practice/teoria\",\"inLanguage\":\"en\",\"description\":\"Practice 107 Teoría questions from past Xestión de Proxectos \\\"exams\\\" with model answers and self-grading. 202323, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Teoría\"},{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/en/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Teoría\",\"item\":\"https://pe.pablopl.dev/en/equispe/practice/teoria\"}],\"url\":\"https://pe.pablopl.dev/en/equispe/practice/teoria\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Teoría: Xestión de Proxectos practice questions\",\"url\":\"https://pe.pablopl.dev/en/equispe/practice/teoria\",\"inLanguage\":\"en\",\"description\":\"Practice 107 Teoría questions from Xestión de Proxectos compilations with model answers and self-grading. 202323, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Teoría\"},{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/en/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Teoría\",\"item\":\"https://pe.pablopl.dev/en/equispe/practice/teoria\"}],\"url\":\"https://pe.pablopl.dev/en/equispe/practice/teoria\"}]}"
   },
   {
     "url": "seo/en/equispe/practice/practica.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/equispe/practice/practica",
-    "title": "Práctica: Xestión de Proxectos exam questions",
-    "description": "Practice 68 Práctica questions from past Xestión de Proxectos \"exams\" with model answers and self-grading. 202323, Universidade da Coruña.",
+    "title": "Práctica: Xestión de Proxectos practice questions",
+    "description": "Practice 68 Práctica questions from Xestión de Proxectos compilations with model answers and self-grading. 202323, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/equispe/practice/practica",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -2367,15 +2367,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe/practice/practica"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Práctica: Xestión de Proxectos exam questions\",\"url\":\"https://pe.pablopl.dev/en/equispe/practice/practica\",\"inLanguage\":\"en\",\"description\":\"Practice 68 Práctica questions from past Xestión de Proxectos \\\"exams\\\" with model answers and self-grading. 202323, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Práctica\"},{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/en/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Práctica\",\"item\":\"https://pe.pablopl.dev/en/equispe/practice/practica\"}],\"url\":\"https://pe.pablopl.dev/en/equispe/practice/practica\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Práctica: Xestión de Proxectos practice questions\",\"url\":\"https://pe.pablopl.dev/en/equispe/practice/practica\",\"inLanguage\":\"en\",\"description\":\"Practice 68 Práctica questions from Xestión de Proxectos compilations with model answers and self-grading. 202323, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Práctica\"},{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/en/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Práctica\",\"item\":\"https://pe.pablopl.dev/en/equispe/practice/practica\"}],\"url\":\"https://pe.pablopl.dev/en/equispe/practice/practica\"}]}"
   },
   {
     "url": "seo/en/equispe/exam/2024-01.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/equispe/exam/2024-01",
-    "title": "Posibles preguntas Xaneiro 2024 Xestión de Proxectos: exam simulator",
-    "description": "Simulate the Posibles preguntas Xaneiro 2024 Xestión de Proxectos exam with 7 questions. 10 points, 120 minutes, model answers and self-grading.",
+    "title": "Posibles preguntas Xaneiro 2024 Xestión de Proxectos: timed practice",
+    "description": "Practice the Posibles preguntas Xaneiro 2024 Xestión de Proxectos timed set with 7 questions. 10 points, 120 minutes, model answers and self-grading.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/equispe/exam/2024-01",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -2399,15 +2399,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe/exam/2024-01"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Xaneiro 2024 Xestión de Proxectos: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/equispe/exam/2024-01\",\"inLanguage\":\"en\",\"description\":\"Simulate the Posibles preguntas Xaneiro 2024 Xestión de Proxectos exam with 7 questions. 10 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/en/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Xaneiro 2024\",\"item\":\"https://pe.pablopl.dev/en/equispe/exam/2024-01\"}],\"url\":\"https://pe.pablopl.dev/en/equispe/exam/2024-01\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Xaneiro 2024 Xestión de Proxectos: timed practice\",\"url\":\"https://pe.pablopl.dev/en/equispe/exam/2024-01\",\"inLanguage\":\"en\",\"description\":\"Practice the Posibles preguntas Xaneiro 2024 Xestión de Proxectos timed set with 7 questions. 10 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/en/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Xaneiro 2024\",\"item\":\"https://pe.pablopl.dev/en/equispe/exam/2024-01\"}],\"url\":\"https://pe.pablopl.dev/en/equispe/exam/2024-01\"}]}"
   },
   {
     "url": "seo/en/equispe/exam/2026-01.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/equispe/exam/2026-01",
-    "title": "Posibles preguntas Xaneiro 2026 Xestión de Proxectos: exam simulator",
-    "description": "Simulate the Posibles preguntas Xaneiro 2026 Xestión de Proxectos exam with 13 questions. 25 points, 180 minutes, model answers and self-grading.",
+    "title": "Posibles preguntas Xaneiro 2026 Xestión de Proxectos: timed practice",
+    "description": "Practice the Posibles preguntas Xaneiro 2026 Xestión de Proxectos timed set with 13 questions. 25 points, 180 minutes, model answers and self-grading.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/equispe/exam/2026-01",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -2431,15 +2431,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe/exam/2026-01"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Xaneiro 2026 Xestión de Proxectos: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/equispe/exam/2026-01\",\"inLanguage\":\"en\",\"description\":\"Simulate the Posibles preguntas Xaneiro 2026 Xestión de Proxectos exam with 13 questions. 25 points, 180 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/en/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Xaneiro 2026\",\"item\":\"https://pe.pablopl.dev/en/equispe/exam/2026-01\"}],\"url\":\"https://pe.pablopl.dev/en/equispe/exam/2026-01\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Xaneiro 2026 Xestión de Proxectos: timed practice\",\"url\":\"https://pe.pablopl.dev/en/equispe/exam/2026-01\",\"inLanguage\":\"en\",\"description\":\"Practice the Posibles preguntas Xaneiro 2026 Xestión de Proxectos timed set with 13 questions. 25 points, 180 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/en/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Xaneiro 2026\",\"item\":\"https://pe.pablopl.dev/en/equispe/exam/2026-01\"}],\"url\":\"https://pe.pablopl.dev/en/equispe/exam/2026-01\"}]}"
   },
   {
     "url": "seo/en/equispe/exam/daypo-tipo-udc.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/equispe/exam/daypo-tipo-udc",
-    "title": "Daypo Tipo UDC Xestión de Proxectos: exam simulator",
-    "description": "Simulate the Daypo Tipo UDC Xestión de Proxectos exam with 63 questions. 63 points, 90 minutes, model answers and self-grading.",
+    "title": "Daypo Tipo UDC Xestión de Proxectos: timed practice",
+    "description": "Practice the Daypo Tipo UDC Xestión de Proxectos timed set with 63 questions. 63 points, 90 minutes, model answers and self-grading.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/equispe/exam/daypo-tipo-udc",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -2463,15 +2463,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe/exam/daypo-tipo-udc"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Tipo UDC Xestión de Proxectos: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/equispe/exam/daypo-tipo-udc\",\"inLanguage\":\"en\",\"description\":\"Simulate the Daypo Tipo UDC Xestión de Proxectos exam with 63 questions. 63 points, 90 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/en/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Tipo UDC\",\"item\":\"https://pe.pablopl.dev/en/equispe/exam/daypo-tipo-udc\"}],\"url\":\"https://pe.pablopl.dev/en/equispe/exam/daypo-tipo-udc\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Tipo UDC Xestión de Proxectos: timed practice\",\"url\":\"https://pe.pablopl.dev/en/equispe/exam/daypo-tipo-udc\",\"inLanguage\":\"en\",\"description\":\"Practice the Daypo Tipo UDC Xestión de Proxectos timed set with 63 questions. 63 points, 90 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/en/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Tipo UDC\",\"item\":\"https://pe.pablopl.dev/en/equispe/exam/daypo-tipo-udc\"}],\"url\":\"https://pe.pablopl.dev/en/equispe/exam/daypo-tipo-udc\"}]}"
   },
   {
     "url": "seo/en/equispe/exam/daypo-teoria.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/equispe/exam/daypo-teoria",
-    "title": "Daypo Teoría Xestión de Proxectos: exam simulator",
-    "description": "Simulate the Daypo Teoría Xestión de Proxectos exam with 34 questions. 34 points, 60 minutes, model answers and self-grading.",
+    "title": "Daypo Teoría Xestión de Proxectos: timed practice",
+    "description": "Practice the Daypo Teoría Xestión de Proxectos timed set with 34 questions. 34 points, 60 minutes, model answers and self-grading.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/equispe/exam/daypo-teoria",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -2495,15 +2495,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe/exam/daypo-teoria"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Teoría Xestión de Proxectos: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/equispe/exam/daypo-teoria\",\"inLanguage\":\"en\",\"description\":\"Simulate the Daypo Teoría Xestión de Proxectos exam with 34 questions. 34 points, 60 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/en/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Teoría\",\"item\":\"https://pe.pablopl.dev/en/equispe/exam/daypo-teoria\"}],\"url\":\"https://pe.pablopl.dev/en/equispe/exam/daypo-teoria\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Teoría Xestión de Proxectos: timed practice\",\"url\":\"https://pe.pablopl.dev/en/equispe/exam/daypo-teoria\",\"inLanguage\":\"en\",\"description\":\"Practice the Daypo Teoría Xestión de Proxectos timed set with 34 questions. 34 points, 60 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/en/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Teoría\",\"item\":\"https://pe.pablopl.dev/en/equispe/exam/daypo-teoria\"}],\"url\":\"https://pe.pablopl.dev/en/equispe/exam/daypo-teoria\"}]}"
   },
   {
     "url": "seo/en/equispe/exam/daypo-practica.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/equispe/exam/daypo-practica",
-    "title": "Daypo Práctica Xestión de Proxectos: exam simulator",
-    "description": "Simulate the Daypo Práctica Xestión de Proxectos exam with 58 questions. 58 points, 90 minutes, model answers and self-grading.",
+    "title": "Daypo Práctica Xestión de Proxectos: timed practice",
+    "description": "Practice the Daypo Práctica Xestión de Proxectos timed set with 58 questions. 58 points, 90 minutes, model answers and self-grading.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/equispe/exam/daypo-practica",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -2527,15 +2527,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe/exam/daypo-practica"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Práctica Xestión de Proxectos: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/equispe/exam/daypo-practica\",\"inLanguage\":\"en\",\"description\":\"Simulate the Daypo Práctica Xestión de Proxectos exam with 58 questions. 58 points, 90 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/en/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Práctica\",\"item\":\"https://pe.pablopl.dev/en/equispe/exam/daypo-practica\"}],\"url\":\"https://pe.pablopl.dev/en/equispe/exam/daypo-practica\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Práctica Xestión de Proxectos: timed practice\",\"url\":\"https://pe.pablopl.dev/en/equispe/exam/daypo-practica\",\"inLanguage\":\"en\",\"description\":\"Practice the Daypo Práctica Xestión de Proxectos timed set with 58 questions. 58 points, 90 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/en/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Práctica\",\"item\":\"https://pe.pablopl.dev/en/equispe/exam/daypo-practica\"}],\"url\":\"https://pe.pablopl.dev/en/equispe/exam/daypo-practica\"}]}"
   },
   {
     "url": "seo/en/esei.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/esei",
-    "title": "Sistemas Intelixentes: past \"exams\" and solved questions",
-    "description": "Practice 234 Sistemas Intelixentes questions from 5 past \"exams\" with model answers and self-grading. 202322, Universidade da Coruña.",
+    "title": "Sistemas Intelixentes: compilations and solved questions",
+    "description": "Practice 234 Sistemas Intelixentes questions from 5 compilations with model answers and self-grading. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/esei",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -2559,15 +2559,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Sistemas Intelixentes: past \\\"exams\\\" and solved questions\",\"url\":\"https://pe.pablopl.dev/en/esei\",\"inLanguage\":\"en\",\"description\":\"Practice 234 Sistemas Intelixentes questions from 5 past \\\"exams\\\" with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"}],\"url\":\"https://pe.pablopl.dev/en/esei\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Sistemas Intelixentes: compilations and solved questions\",\"url\":\"https://pe.pablopl.dev/en/esei\",\"inLanguage\":\"en\",\"description\":\"Practice 234 Sistemas Intelixentes questions from 5 compilations with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"}],\"url\":\"https://pe.pablopl.dev/en/esei\"}]}"
   },
   {
     "url": "seo/en/esei/practice/t1.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/esei/practice/t1",
-    "title": "Tema 1: Introducción: Sistemas Intelixentes exam questions",
-    "description": "Practice 4 Tema 1: Introducción questions from past Sistemas Intelixentes \"exams\" with model answers and self-grading. 202322, Universidade da Coruña.",
+    "title": "Tema 1: Introducción: Sistemas Intelixentes practice questions",
+    "description": "Practice 4 Tema 1: Introducción questions from Sistemas Intelixentes compilations with model answers and self-grading. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/esei/practice/t1",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -2591,15 +2591,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t1"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 1: Introducción: Sistemas Intelixentes exam questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t1\",\"inLanguage\":\"en\",\"description\":\"Practice 4 Tema 1: Introducción questions from past Sistemas Intelixentes \\\"exams\\\" with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 1: Introducción\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 1: Introducción\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t1\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t1\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 1: Introducción: Sistemas Intelixentes practice questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t1\",\"inLanguage\":\"en\",\"description\":\"Practice 4 Tema 1: Introducción questions from Sistemas Intelixentes compilations with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 1: Introducción\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 1: Introducción\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t1\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t1\"}]}"
   },
   {
     "url": "seo/en/esei/practice/t2.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/esei/practice/t2",
-    "title": "Tema 2: Búsqueda: Sistemas Intelixentes exam questions",
-    "description": "Practice 24 Tema 2: Búsqueda questions from past Sistemas Intelixentes \"exams\" with model answers and self-grading. 202322, Universidade da Coruña.",
+    "title": "Tema 2: Búsqueda: Sistemas Intelixentes practice questions",
+    "description": "Practice 24 Tema 2: Búsqueda questions from Sistemas Intelixentes compilations with model answers and self-grading. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/esei/practice/t2",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -2623,15 +2623,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t2"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 2: Búsqueda: Sistemas Intelixentes exam questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t2\",\"inLanguage\":\"en\",\"description\":\"Practice 24 Tema 2: Búsqueda questions from past Sistemas Intelixentes \\\"exams\\\" with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 2: Búsqueda\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 2: Búsqueda\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t2\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t2\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 2: Búsqueda: Sistemas Intelixentes practice questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t2\",\"inLanguage\":\"en\",\"description\":\"Practice 24 Tema 2: Búsqueda questions from Sistemas Intelixentes compilations with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 2: Búsqueda\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 2: Búsqueda\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t2\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t2\"}]}"
   },
   {
     "url": "seo/en/esei/practice/t3.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/esei/practice/t3",
-    "title": "Tema 3: Representación: Sistemas Intelixentes exam questions",
-    "description": "Practice 17 Tema 3: Representación questions from past Sistemas Intelixentes \"exams\" with model answers and self-grading. 202322, Universidade da Coruña.",
+    "title": "Tema 3: Representación: Sistemas Intelixentes practice questions",
+    "description": "Practice 17 Tema 3: Representación questions from Sistemas Intelixentes compilations with model answers and self-grading. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/esei/practice/t3",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -2655,15 +2655,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t3"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 3: Representación: Sistemas Intelixentes exam questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t3\",\"inLanguage\":\"en\",\"description\":\"Practice 17 Tema 3: Representación questions from past Sistemas Intelixentes \\\"exams\\\" with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 3: Representación\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 3: Representación\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t3\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t3\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 3: Representación: Sistemas Intelixentes practice questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t3\",\"inLanguage\":\"en\",\"description\":\"Practice 17 Tema 3: Representación questions from Sistemas Intelixentes compilations with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 3: Representación\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 3: Representación\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t3\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t3\"}]}"
   },
   {
     "url": "seo/en/esei/practice/t4.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/esei/practice/t4",
-    "title": "Tema 4: Razonamiento: Sistemas Intelixentes exam questions",
-    "description": "Practice 12 Tema 4: Razonamiento questions from past Sistemas Intelixentes \"exams\" with model answers and self-grading. 202322, Universidade da Coruña.",
+    "title": "Tema 4: Razonamiento: Sistemas Intelixentes practice questions",
+    "description": "Practice 12 Tema 4: Razonamiento questions from Sistemas Intelixentes compilations with model answers and self-grading. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/esei/practice/t4",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -2687,15 +2687,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t4"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 4: Razonamiento: Sistemas Intelixentes exam questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t4\",\"inLanguage\":\"en\",\"description\":\"Practice 12 Tema 4: Razonamiento questions from past Sistemas Intelixentes \\\"exams\\\" with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 4: Razonamiento\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 4: Razonamiento\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t4\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t4\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 4: Razonamiento: Sistemas Intelixentes practice questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t4\",\"inLanguage\":\"en\",\"description\":\"Practice 12 Tema 4: Razonamiento questions from Sistemas Intelixentes compilations with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 4: Razonamiento\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 4: Razonamiento\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t4\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t4\"}]}"
   },
   {
     "url": "seo/en/esei/practice/t5.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/esei/practice/t5",
-    "title": "Tema 5: Planificación: Sistemas Intelixentes exam questions",
-    "description": "Practice 2 Tema 5: Planificación questions from past Sistemas Intelixentes \"exams\" with model answers and self-grading. 202322, Universidade da Coruña.",
+    "title": "Tema 5: Planificación: Sistemas Intelixentes practice questions",
+    "description": "Practice 2 Tema 5: Planificación questions from Sistemas Intelixentes compilations with model answers and self-grading. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/esei/practice/t5",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -2719,15 +2719,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t5"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 5: Planificación: Sistemas Intelixentes exam questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t5\",\"inLanguage\":\"en\",\"description\":\"Practice 2 Tema 5: Planificación questions from past Sistemas Intelixentes \\\"exams\\\" with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 5: Planificación\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 5: Planificación\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t5\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t5\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 5: Planificación: Sistemas Intelixentes practice questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t5\",\"inLanguage\":\"en\",\"description\":\"Practice 2 Tema 5: Planificación questions from Sistemas Intelixentes compilations with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 5: Planificación\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 5: Planificación\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t5\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t5\"}]}"
   },
   {
     "url": "seo/en/esei/practice/t6.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/esei/practice/t6",
-    "title": "Tema 6: Introducción a los sistemas subsimbólicos: Sistemas Intelixentes exam questions",
-    "description": "Practice 18 Tema 6: Introducción a los sistemas subsimbólicos questions from past Sistemas Intelixentes \"exams\" with model answers and self-grading. 202322, Universidade da Coruña.",
+    "title": "Tema 6: Introducción a los sistemas subsimbólicos: Sistemas Intelixentes practice questions",
+    "description": "Practice 18 Tema 6: Introducción a los sistemas subsimbólicos questions from Sistemas Intelixentes compilations with model answers and self-grading. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/esei/practice/t6",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -2751,15 +2751,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t6"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 6: Introducción a los sistemas subsimbólicos: Sistemas Intelixentes exam questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t6\",\"inLanguage\":\"en\",\"description\":\"Practice 18 Tema 6: Introducción a los sistemas subsimbólicos questions from past Sistemas Intelixentes \\\"exams\\\" with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 6: Introducción a los sistemas subsimbólicos\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 6: Introducción a los sistemas subsimbólicos\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t6\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t6\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 6: Introducción a los sistemas subsimbólicos: Sistemas Intelixentes practice questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t6\",\"inLanguage\":\"en\",\"description\":\"Practice 18 Tema 6: Introducción a los sistemas subsimbólicos questions from Sistemas Intelixentes compilations with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 6: Introducción a los sistemas subsimbólicos\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 6: Introducción a los sistemas subsimbólicos\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t6\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t6\"}]}"
   },
   {
     "url": "seo/en/esei/practice/t7.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/esei/practice/t7",
-    "title": "Tema 7: Redes Neuronales Artificiales: modelos y características: Sistemas Intelixentes exam questions",
-    "description": "Practice 40 Tema 7: Redes Neuronales Artificiales: modelos y características questions from past Sistemas Intelixentes \"exams\" with model answers and self-grading. 202322, Universidade da Coruña.",
+    "title": "Tema 7: Redes Neuronales Artificiales: modelos y características: Sistemas Intelixentes practice questions",
+    "description": "Practice 40 Tema 7: Redes Neuronales Artificiales: modelos y características questions from Sistemas Intelixentes compilations with model answers and self-grading. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/esei/practice/t7",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -2783,15 +2783,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t7"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 7: Redes Neuronales Artificiales: modelos y características: Sistemas Intelixentes exam questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t7\",\"inLanguage\":\"en\",\"description\":\"Practice 40 Tema 7: Redes Neuronales Artificiales: modelos y características questions from past Sistemas Intelixentes \\\"exams\\\" with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 7: Redes Neuronales Artificiales: modelos y características\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 7: Redes Neuronales Artificiales: modelos y características\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t7\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t7\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 7: Redes Neuronales Artificiales: modelos y características: Sistemas Intelixentes practice questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t7\",\"inLanguage\":\"en\",\"description\":\"Practice 40 Tema 7: Redes Neuronales Artificiales: modelos y características questions from Sistemas Intelixentes compilations with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 7: Redes Neuronales Artificiales: modelos y características\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 7: Redes Neuronales Artificiales: modelos y características\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t7\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t7\"}]}"
   },
   {
     "url": "seo/en/esei/practice/t8.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/esei/practice/t8",
-    "title": "Tema 8: Entrenamiento de Redes Neuronales Artificiales: Sistemas Intelixentes exam questions",
-    "description": "Practice 20 Tema 8: Entrenamiento de Redes Neuronales Artificiales questions from past Sistemas Intelixentes \"exams\" with model answers and self-grading. 202322, Universidade da Coruña.",
+    "title": "Tema 8: Entrenamiento de Redes Neuronales Artificiales: Sistemas Intelixentes practice questions",
+    "description": "Practice 20 Tema 8: Entrenamiento de Redes Neuronales Artificiales questions from Sistemas Intelixentes compilations with model answers and self-grading. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/esei/practice/t8",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -2815,15 +2815,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t8"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 8: Entrenamiento de Redes Neuronales Artificiales: Sistemas Intelixentes exam questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t8\",\"inLanguage\":\"en\",\"description\":\"Practice 20 Tema 8: Entrenamiento de Redes Neuronales Artificiales questions from past Sistemas Intelixentes \\\"exams\\\" with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 8: Entrenamiento de Redes Neuronales Artificiales\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 8: Entrenamiento de Redes Neuronales Artificiales\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t8\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t8\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 8: Entrenamiento de Redes Neuronales Artificiales: Sistemas Intelixentes practice questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t8\",\"inLanguage\":\"en\",\"description\":\"Practice 20 Tema 8: Entrenamiento de Redes Neuronales Artificiales questions from Sistemas Intelixentes compilations with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 8: Entrenamiento de Redes Neuronales Artificiales\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 8: Entrenamiento de Redes Neuronales Artificiales\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t8\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t8\"}]}"
   },
   {
     "url": "seo/en/esei/practice/t9.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/esei/practice/t9",
-    "title": "Tema 9: Sistemas autoorganizativos: Sistemas Intelixentes exam questions",
-    "description": "Practice 59 Tema 9: Sistemas autoorganizativos questions from past Sistemas Intelixentes \"exams\" with model answers and self-grading. 202322, Universidade da Coruña.",
+    "title": "Tema 9: Sistemas autoorganizativos: Sistemas Intelixentes practice questions",
+    "description": "Practice 59 Tema 9: Sistemas autoorganizativos questions from Sistemas Intelixentes compilations with model answers and self-grading. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/esei/practice/t9",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -2847,15 +2847,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t9"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 9: Sistemas autoorganizativos: Sistemas Intelixentes exam questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t9\",\"inLanguage\":\"en\",\"description\":\"Practice 59 Tema 9: Sistemas autoorganizativos questions from past Sistemas Intelixentes \\\"exams\\\" with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 9: Sistemas autoorganizativos\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 9: Sistemas autoorganizativos\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t9\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t9\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 9: Sistemas autoorganizativos: Sistemas Intelixentes practice questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t9\",\"inLanguage\":\"en\",\"description\":\"Practice 59 Tema 9: Sistemas autoorganizativos questions from Sistemas Intelixentes compilations with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 9: Sistemas autoorganizativos\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 9: Sistemas autoorganizativos\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t9\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t9\"}]}"
   },
   {
     "url": "seo/en/esei/practice/t10.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/esei/practice/t10",
-    "title": "Tema 10: Computación Evolutiva: Sistemas Intelixentes exam questions",
-    "description": "Practice 38 Tema 10: Computación Evolutiva questions from past Sistemas Intelixentes \"exams\" with model answers and self-grading. 202322, Universidade da Coruña.",
+    "title": "Tema 10: Computación Evolutiva: Sistemas Intelixentes practice questions",
+    "description": "Practice 38 Tema 10: Computación Evolutiva questions from Sistemas Intelixentes compilations with model answers and self-grading. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/esei/practice/t10",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -2879,15 +2879,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t10"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 10: Computación Evolutiva: Sistemas Intelixentes exam questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t10\",\"inLanguage\":\"en\",\"description\":\"Practice 38 Tema 10: Computación Evolutiva questions from past Sistemas Intelixentes \\\"exams\\\" with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 10: Computación Evolutiva\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 10: Computación Evolutiva\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t10\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t10\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 10: Computación Evolutiva: Sistemas Intelixentes practice questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t10\",\"inLanguage\":\"en\",\"description\":\"Practice 38 Tema 10: Computación Evolutiva questions from Sistemas Intelixentes compilations with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 10: Computación Evolutiva\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 10: Computación Evolutiva\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t10\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t10\"}]}"
   },
   {
     "url": "seo/en/esei/exam/2023.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/esei/exam/2023",
-    "title": "Posibles preguntas 2023 Sistemas Intelixentes: exam simulator",
-    "description": "Simulate the Posibles preguntas 2023 Sistemas Intelixentes exam with 45 questions. 45 points, 120 minutes, model answers and self-grading.",
+    "title": "Posibles preguntas 2023 Sistemas Intelixentes: timed practice",
+    "description": "Practice the Posibles preguntas 2023 Sistemas Intelixentes timed set with 45 questions. 45 points, 120 minutes, model answers and self-grading.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/esei/exam/2023",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -2911,15 +2911,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/exam/2023"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas 2023 Sistemas Intelixentes: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/esei/exam/2023\",\"inLanguage\":\"en\",\"description\":\"Simulate the Posibles preguntas 2023 Sistemas Intelixentes exam with 45 questions. 45 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas 2023\",\"item\":\"https://pe.pablopl.dev/en/esei/exam/2023\"}],\"url\":\"https://pe.pablopl.dev/en/esei/exam/2023\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas 2023 Sistemas Intelixentes: timed practice\",\"url\":\"https://pe.pablopl.dev/en/esei/exam/2023\",\"inLanguage\":\"en\",\"description\":\"Practice the Posibles preguntas 2023 Sistemas Intelixentes timed set with 45 questions. 45 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas 2023\",\"item\":\"https://pe.pablopl.dev/en/esei/exam/2023\"}],\"url\":\"https://pe.pablopl.dev/en/esei/exam/2023\"}]}"
   },
   {
     "url": "seo/en/esei/exam/2024.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/esei/exam/2024",
-    "title": "Posibles preguntas 2024 Sistemas Intelixentes: exam simulator",
-    "description": "Simulate the Posibles preguntas 2024 Sistemas Intelixentes exam with 44 questions. 44 points, 120 minutes, model answers and self-grading.",
+    "title": "Posibles preguntas 2024 Sistemas Intelixentes: timed practice",
+    "description": "Practice the Posibles preguntas 2024 Sistemas Intelixentes timed set with 44 questions. 44 points, 120 minutes, model answers and self-grading.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/esei/exam/2024",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -2943,15 +2943,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/exam/2024"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas 2024 Sistemas Intelixentes: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/esei/exam/2024\",\"inLanguage\":\"en\",\"description\":\"Simulate the Posibles preguntas 2024 Sistemas Intelixentes exam with 44 questions. 44 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas 2024\",\"item\":\"https://pe.pablopl.dev/en/esei/exam/2024\"}],\"url\":\"https://pe.pablopl.dev/en/esei/exam/2024\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas 2024 Sistemas Intelixentes: timed practice\",\"url\":\"https://pe.pablopl.dev/en/esei/exam/2024\",\"inLanguage\":\"en\",\"description\":\"Practice the Posibles preguntas 2024 Sistemas Intelixentes timed set with 44 questions. 44 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas 2024\",\"item\":\"https://pe.pablopl.dev/en/esei/exam/2024\"}],\"url\":\"https://pe.pablopl.dev/en/esei/exam/2024\"}]}"
   },
   {
     "url": "seo/en/esei/exam/2025-05.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/esei/exam/2025-05",
-    "title": "Posibles preguntas Mayo 2025 Sistemas Intelixentes: exam simulator",
-    "description": "Simulate the Posibles preguntas Mayo 2025 Sistemas Intelixentes exam with 42 questions. 42 points, 120 minutes, model answers and self-grading.",
+    "title": "Posibles preguntas Mayo 2025 Sistemas Intelixentes: timed practice",
+    "description": "Practice the Posibles preguntas Mayo 2025 Sistemas Intelixentes timed set with 42 questions. 42 points, 120 minutes, model answers and self-grading.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/esei/exam/2025-05",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -2975,15 +2975,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/exam/2025-05"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Mayo 2025 Sistemas Intelixentes: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/esei/exam/2025-05\",\"inLanguage\":\"en\",\"description\":\"Simulate the Posibles preguntas Mayo 2025 Sistemas Intelixentes exam with 42 questions. 42 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Mayo 2025\",\"item\":\"https://pe.pablopl.dev/en/esei/exam/2025-05\"}],\"url\":\"https://pe.pablopl.dev/en/esei/exam/2025-05\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Mayo 2025 Sistemas Intelixentes: timed practice\",\"url\":\"https://pe.pablopl.dev/en/esei/exam/2025-05\",\"inLanguage\":\"en\",\"description\":\"Practice the Posibles preguntas Mayo 2025 Sistemas Intelixentes timed set with 42 questions. 42 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Mayo 2025\",\"item\":\"https://pe.pablopl.dev/en/esei/exam/2025-05\"}],\"url\":\"https://pe.pablopl.dev/en/esei/exam/2025-05\"}]}"
   },
   {
     "url": "seo/en/esei/exam/2025-07.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/esei/exam/2025-07",
-    "title": "Posibles preguntas Julio 2025 Sistemas Intelixentes: exam simulator",
-    "description": "Simulate the Posibles preguntas Julio 2025 Sistemas Intelixentes exam with 47 questions. 47 points, 120 minutes, model answers and self-grading.",
+    "title": "Posibles preguntas Julio 2025 Sistemas Intelixentes: timed practice",
+    "description": "Practice the Posibles preguntas Julio 2025 Sistemas Intelixentes timed set with 47 questions. 47 points, 120 minutes, model answers and self-grading.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/esei/exam/2025-07",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -3007,15 +3007,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/exam/2025-07"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Julio 2025 Sistemas Intelixentes: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/esei/exam/2025-07\",\"inLanguage\":\"en\",\"description\":\"Simulate the Posibles preguntas Julio 2025 Sistemas Intelixentes exam with 47 questions. 47 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Julio 2025\",\"item\":\"https://pe.pablopl.dev/en/esei/exam/2025-07\"}],\"url\":\"https://pe.pablopl.dev/en/esei/exam/2025-07\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Julio 2025 Sistemas Intelixentes: timed practice\",\"url\":\"https://pe.pablopl.dev/en/esei/exam/2025-07\",\"inLanguage\":\"en\",\"description\":\"Practice the Posibles preguntas Julio 2025 Sistemas Intelixentes timed set with 47 questions. 47 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Julio 2025\",\"item\":\"https://pe.pablopl.dev/en/esei/exam/2025-07\"}],\"url\":\"https://pe.pablopl.dev/en/esei/exam/2025-07\"}]}"
   },
   {
     "url": "seo/en/esei/exam/2026-06.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/esei/exam/2026-06",
-    "title": "Posibles preguntas Junio 2026 Sistemas Intelixentes: exam simulator",
-    "description": "Simulate the Posibles preguntas Junio 2026 Sistemas Intelixentes exam with 56 questions. 56 points, 120 minutes, model answers and self-grading.",
+    "title": "Posibles preguntas Junio 2026 Sistemas Intelixentes: timed practice",
+    "description": "Practice the Posibles preguntas Junio 2026 Sistemas Intelixentes timed set with 56 questions. 56 points, 120 minutes, model answers and self-grading.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/esei/exam/2026-06",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -3039,15 +3039,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/exam/2026-06"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Junio 2026 Sistemas Intelixentes: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/esei/exam/2026-06\",\"inLanguage\":\"en\",\"description\":\"Simulate the Posibles preguntas Junio 2026 Sistemas Intelixentes exam with 56 questions. 56 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Junio 2026\",\"item\":\"https://pe.pablopl.dev/en/esei/exam/2026-06\"}],\"url\":\"https://pe.pablopl.dev/en/esei/exam/2026-06\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Junio 2026 Sistemas Intelixentes: timed practice\",\"url\":\"https://pe.pablopl.dev/en/esei/exam/2026-06\",\"inLanguage\":\"en\",\"description\":\"Practice the Posibles preguntas Junio 2026 Sistemas Intelixentes timed set with 56 questions. 56 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Junio 2026\",\"item\":\"https://pe.pablopl.dev/en/esei/exam/2026-06\"}],\"url\":\"https://pe.pablopl.dev/en/esei/exam/2026-06\"}]}"
   },
   {
     "url": "seo/en/eseo.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/eseo",
-    "title": "Sistemas Operativos: past \"exams\" and solved questions",
-    "description": "Practice 119 Sistemas Operativos questions from 9 past \"exams\" with model answers and self-grading. 202318, Universidade da Coruña.",
+    "title": "Sistemas Operativos: exams and solved questions",
+    "description": "Practice 119 Sistemas Operativos questions from 9 exams with model answers and self-grading. 202318, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/eseo",
     "ogImage": "https://pe.pablopl.dev/og/eseo.png",
@@ -3071,7 +3071,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/eseo"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Sistemas Operativos: past \\\"exams\\\" and solved questions\",\"url\":\"https://pe.pablopl.dev/en/eseo\",\"inLanguage\":\"en\",\"description\":\"Practice 119 Sistemas Operativos questions from 9 past \\\"exams\\\" with model answers and self-grading. 202318, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/en/eseo\"}],\"url\":\"https://pe.pablopl.dev/en/eseo\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Sistemas Operativos: exams and solved questions\",\"url\":\"https://pe.pablopl.dev/en/eseo\",\"inLanguage\":\"en\",\"description\":\"Practice 119 Sistemas Operativos questions from 9 exams with model answers and self-grading. 202318, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/en/eseo\"}],\"url\":\"https://pe.pablopl.dev/en/eseo\"}]}"
   },
   {
     "url": "seo/en/eseo/practice/sistema-ficheros.html",
@@ -3079,7 +3079,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/eseo/practice/sistema-ficheros",
     "title": "Sistema de Ficheros: Sistemas Operativos exam questions",
-    "description": "Practice 36 Sistema de Ficheros questions from past Sistemas Operativos \"exams\" with model answers and self-grading. 202318, Universidade da Coruña.",
+    "description": "Practice 36 Sistema de Ficheros questions from Sistemas Operativos exams with model answers and self-grading. 202318, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/eseo/practice/sistema-ficheros",
     "ogImage": "https://pe.pablopl.dev/og/eseo.png",
@@ -3103,7 +3103,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/eseo/practice/sistema-ficheros"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Sistema de Ficheros: Sistemas Operativos exam questions\",\"url\":\"https://pe.pablopl.dev/en/eseo/practice/sistema-ficheros\",\"inLanguage\":\"en\",\"description\":\"Practice 36 Sistema de Ficheros questions from past Sistemas Operativos \\\"exams\\\" with model answers and self-grading. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Sistema de Ficheros\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/en/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Sistema de Ficheros\",\"item\":\"https://pe.pablopl.dev/en/eseo/practice/sistema-ficheros\"}],\"url\":\"https://pe.pablopl.dev/en/eseo/practice/sistema-ficheros\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Sistema de Ficheros: Sistemas Operativos exam questions\",\"url\":\"https://pe.pablopl.dev/en/eseo/practice/sistema-ficheros\",\"inLanguage\":\"en\",\"description\":\"Practice 36 Sistema de Ficheros questions from Sistemas Operativos exams with model answers and self-grading. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Sistema de Ficheros\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/en/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Sistema de Ficheros\",\"item\":\"https://pe.pablopl.dev/en/eseo/practice/sistema-ficheros\"}],\"url\":\"https://pe.pablopl.dev/en/eseo/practice/sistema-ficheros\"}]}"
   },
   {
     "url": "seo/en/eseo/practice/memoria.html",
@@ -3111,7 +3111,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/eseo/practice/memoria",
     "title": "Gestión de Memoria: Sistemas Operativos exam questions",
-    "description": "Practice 25 Gestión de Memoria questions from past Sistemas Operativos \"exams\" with model answers and self-grading. 202318, Universidade da Coruña.",
+    "description": "Practice 25 Gestión de Memoria questions from Sistemas Operativos exams with model answers and self-grading. 202318, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/eseo/practice/memoria",
     "ogImage": "https://pe.pablopl.dev/og/eseo.png",
@@ -3135,7 +3135,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/eseo/practice/memoria"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Gestión de Memoria: Sistemas Operativos exam questions\",\"url\":\"https://pe.pablopl.dev/en/eseo/practice/memoria\",\"inLanguage\":\"en\",\"description\":\"Practice 25 Gestión de Memoria questions from past Sistemas Operativos \\\"exams\\\" with model answers and self-grading. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Gestión de Memoria\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/en/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Gestión de Memoria\",\"item\":\"https://pe.pablopl.dev/en/eseo/practice/memoria\"}],\"url\":\"https://pe.pablopl.dev/en/eseo/practice/memoria\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Gestión de Memoria: Sistemas Operativos exam questions\",\"url\":\"https://pe.pablopl.dev/en/eseo/practice/memoria\",\"inLanguage\":\"en\",\"description\":\"Practice 25 Gestión de Memoria questions from Sistemas Operativos exams with model answers and self-grading. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Gestión de Memoria\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/en/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Gestión de Memoria\",\"item\":\"https://pe.pablopl.dev/en/eseo/practice/memoria\"}],\"url\":\"https://pe.pablopl.dev/en/eseo/practice/memoria\"}]}"
   },
   {
     "url": "seo/en/eseo/practice/procesos.html",
@@ -3143,7 +3143,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/eseo/practice/procesos",
     "title": "Procesos e Hilos: Sistemas Operativos exam questions",
-    "description": "Practice 30 Procesos e Hilos questions from past Sistemas Operativos \"exams\" with model answers and self-grading. 202318, Universidade da Coruña.",
+    "description": "Practice 30 Procesos e Hilos questions from Sistemas Operativos exams with model answers and self-grading. 202318, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/eseo/practice/procesos",
     "ogImage": "https://pe.pablopl.dev/og/eseo.png",
@@ -3167,7 +3167,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/eseo/practice/procesos"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Procesos e Hilos: Sistemas Operativos exam questions\",\"url\":\"https://pe.pablopl.dev/en/eseo/practice/procesos\",\"inLanguage\":\"en\",\"description\":\"Practice 30 Procesos e Hilos questions from past Sistemas Operativos \\\"exams\\\" with model answers and self-grading. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Procesos e Hilos\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/en/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Procesos e Hilos\",\"item\":\"https://pe.pablopl.dev/en/eseo/practice/procesos\"}],\"url\":\"https://pe.pablopl.dev/en/eseo/practice/procesos\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Procesos e Hilos: Sistemas Operativos exam questions\",\"url\":\"https://pe.pablopl.dev/en/eseo/practice/procesos\",\"inLanguage\":\"en\",\"description\":\"Practice 30 Procesos e Hilos questions from Sistemas Operativos exams with model answers and self-grading. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Procesos e Hilos\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/en/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Procesos e Hilos\",\"item\":\"https://pe.pablopl.dev/en/eseo/practice/procesos\"}],\"url\":\"https://pe.pablopl.dev/en/eseo/practice/procesos\"}]}"
   },
   {
     "url": "seo/en/eseo/practice/entrada-salida.html",
@@ -3175,7 +3175,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/eseo/practice/entrada-salida",
     "title": "Entrada/Salida: Sistemas Operativos exam questions",
-    "description": "Practice 28 Entrada/Salida questions from past Sistemas Operativos \"exams\" with model answers and self-grading. 202318, Universidade da Coruña.",
+    "description": "Practice 28 Entrada/Salida questions from Sistemas Operativos exams with model answers and self-grading. 202318, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/eseo/practice/entrada-salida",
     "ogImage": "https://pe.pablopl.dev/og/eseo.png",
@@ -3199,7 +3199,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/eseo/practice/entrada-salida"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Entrada/Salida: Sistemas Operativos exam questions\",\"url\":\"https://pe.pablopl.dev/en/eseo/practice/entrada-salida\",\"inLanguage\":\"en\",\"description\":\"Practice 28 Entrada/Salida questions from past Sistemas Operativos \\\"exams\\\" with model answers and self-grading. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Entrada/Salida\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/en/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Entrada/Salida\",\"item\":\"https://pe.pablopl.dev/en/eseo/practice/entrada-salida\"}],\"url\":\"https://pe.pablopl.dev/en/eseo/practice/entrada-salida\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Entrada/Salida: Sistemas Operativos exam questions\",\"url\":\"https://pe.pablopl.dev/en/eseo/practice/entrada-salida\",\"inLanguage\":\"en\",\"description\":\"Practice 28 Entrada/Salida questions from Sistemas Operativos exams with model answers and self-grading. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Entrada/Salida\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/en/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Entrada/Salida\",\"item\":\"https://pe.pablopl.dev/en/eseo/practice/entrada-salida\"}],\"url\":\"https://pe.pablopl.dev/en/eseo/practice/entrada-salida\"}]}"
   },
   {
     "url": "seo/en/eseo/exam/2020-01.html",
@@ -3494,8 +3494,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/iesede",
-    "title": "Internet y Sistemas Distribuidos: past \"exams\" and solved questions",
-    "description": "Practice 18 Internet y Sistemas Distribuidos questions from 1 past \"exams\" with model answers and self-grading. 200188, Universidade da Coruña.",
+    "title": "Internet y Sistemas Distribuidos: compilations and solved questions",
+    "description": "Practice 18 Internet y Sistemas Distribuidos questions from 1 compilations with model answers and self-grading. 200188, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/iesede",
     "ogImage": "https://pe.pablopl.dev/og/iesede.png",
@@ -3519,15 +3519,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/iesede"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Internet y Sistemas Distribuidos: past \\\"exams\\\" and solved questions\",\"url\":\"https://pe.pablopl.dev/en/iesede\",\"inLanguage\":\"en\",\"description\":\"Practice 18 Internet y Sistemas Distribuidos questions from 1 past \\\"exams\\\" with model answers and self-grading. 200188, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Internet y Sistemas Distribuidos\",\"courseCode\":\"200188\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Internet y Sistemas Distribuidos\",\"item\":\"https://pe.pablopl.dev/en/iesede\"}],\"url\":\"https://pe.pablopl.dev/en/iesede\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Internet y Sistemas Distribuidos: compilations and solved questions\",\"url\":\"https://pe.pablopl.dev/en/iesede\",\"inLanguage\":\"en\",\"description\":\"Practice 18 Internet y Sistemas Distribuidos questions from 1 compilations with model answers and self-grading. 200188, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Internet y Sistemas Distribuidos\",\"courseCode\":\"200188\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Internet y Sistemas Distribuidos\",\"item\":\"https://pe.pablopl.dev/en/iesede\"}],\"url\":\"https://pe.pablopl.dev/en/iesede\"}]}"
   },
   {
     "url": "seo/en/iesede/practice/general.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/iesede/practice/general",
-    "title": "General: Internet y Sistemas Distribuidos exam questions",
-    "description": "Practice 18 General questions from past Internet y Sistemas Distribuidos \"exams\" with model answers and self-grading. 200188, Universidade da Coruña.",
+    "title": "General: Internet y Sistemas Distribuidos practice questions",
+    "description": "Practice 18 General questions from Internet y Sistemas Distribuidos compilations with model answers and self-grading. 200188, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/iesede/practice/general",
     "ogImage": "https://pe.pablopl.dev/og/iesede.png",
@@ -3551,15 +3551,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/iesede/practice/general"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"General: Internet y Sistemas Distribuidos exam questions\",\"url\":\"https://pe.pablopl.dev/en/iesede/practice/general\",\"inLanguage\":\"en\",\"description\":\"Practice 18 General questions from past Internet y Sistemas Distribuidos \\\"exams\\\" with model answers and self-grading. 200188, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"General\"},{\"@type\":\"Course\",\"name\":\"Internet y Sistemas Distribuidos\",\"courseCode\":\"200188\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Internet y Sistemas Distribuidos\",\"item\":\"https://pe.pablopl.dev/en/iesede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"General\",\"item\":\"https://pe.pablopl.dev/en/iesede/practice/general\"}],\"url\":\"https://pe.pablopl.dev/en/iesede/practice/general\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"General: Internet y Sistemas Distribuidos practice questions\",\"url\":\"https://pe.pablopl.dev/en/iesede/practice/general\",\"inLanguage\":\"en\",\"description\":\"Practice 18 General questions from Internet y Sistemas Distribuidos compilations with model answers and self-grading. 200188, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"General\"},{\"@type\":\"Course\",\"name\":\"Internet y Sistemas Distribuidos\",\"courseCode\":\"200188\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Internet y Sistemas Distribuidos\",\"item\":\"https://pe.pablopl.dev/en/iesede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"General\",\"item\":\"https://pe.pablopl.dev/en/iesede/practice/general\"}],\"url\":\"https://pe.pablopl.dev/en/iesede/practice/general\"}]}"
   },
   {
     "url": "seo/en/iesede/exam/examen_recopilatorio.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/iesede/exam/examen_recopilatorio",
-    "title": "Recopilación Internet y Sistemas Distribuidos: exam simulator",
-    "description": "Simulate the Recopilación Internet y Sistemas Distribuidos exam with 18 questions. 18 points, 120 minutes, model answers and self-grading.",
+    "title": "Recopilación Internet y Sistemas Distribuidos: timed practice",
+    "description": "Practice the Recopilación Internet y Sistemas Distribuidos timed set with 18 questions. 18 points, 120 minutes, model answers and self-grading.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/iesede/exam/examen_recopilatorio",
     "ogImage": "https://pe.pablopl.dev/og/iesede.png",
@@ -3583,15 +3583,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/iesede/exam/examen_recopilatorio"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Recopilación Internet y Sistemas Distribuidos: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/iesede/exam/examen_recopilatorio\",\"inLanguage\":\"en\",\"description\":\"Simulate the Recopilación Internet y Sistemas Distribuidos exam with 18 questions. 18 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Internet y Sistemas Distribuidos\",\"courseCode\":\"200188\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Internet y Sistemas Distribuidos\",\"item\":\"https://pe.pablopl.dev/en/iesede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Recopilación\",\"item\":\"https://pe.pablopl.dev/en/iesede/exam/examen_recopilatorio\"}],\"url\":\"https://pe.pablopl.dev/en/iesede/exam/examen_recopilatorio\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Recopilación Internet y Sistemas Distribuidos: timed practice\",\"url\":\"https://pe.pablopl.dev/en/iesede/exam/examen_recopilatorio\",\"inLanguage\":\"en\",\"description\":\"Practice the Recopilación Internet y Sistemas Distribuidos timed set with 18 questions. 18 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Internet y Sistemas Distribuidos\",\"courseCode\":\"200188\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Internet y Sistemas Distribuidos\",\"item\":\"https://pe.pablopl.dev/en/iesede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Recopilación\",\"item\":\"https://pe.pablopl.dev/en/iesede/exam/examen_recopilatorio\"}],\"url\":\"https://pe.pablopl.dev/en/iesede/exam/examen_recopilatorio\"}]}"
   },
   {
     "url": "seo/en/peese.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/peese",
-    "title": "Proceso Software: past \"exams\" and solved questions",
-    "description": "Practice 17 Proceso Software questions from 1 past \"exams\" with model answers and self-grading. 202321, Universidade da Coruña.",
+    "title": "Proceso Software: compilations and solved questions",
+    "description": "Practice 17 Proceso Software questions from 1 compilations with model answers and self-grading. 202321, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/peese",
     "ogImage": "https://pe.pablopl.dev/og/peese.png",
@@ -3615,15 +3615,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/peese"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Proceso Software: past \\\"exams\\\" and solved questions\",\"url\":\"https://pe.pablopl.dev/en/peese\",\"inLanguage\":\"en\",\"description\":\"Practice 17 Proceso Software questions from 1 past \\\"exams\\\" with model answers and self-grading. 202321, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Proceso Software\",\"courseCode\":\"202321\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Proceso Software\",\"item\":\"https://pe.pablopl.dev/en/peese\"}],\"url\":\"https://pe.pablopl.dev/en/peese\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Proceso Software: compilations and solved questions\",\"url\":\"https://pe.pablopl.dev/en/peese\",\"inLanguage\":\"en\",\"description\":\"Practice 17 Proceso Software questions from 1 compilations with model answers and self-grading. 202321, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Proceso Software\",\"courseCode\":\"202321\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Proceso Software\",\"item\":\"https://pe.pablopl.dev/en/peese\"}],\"url\":\"https://pe.pablopl.dev/en/peese\"}]}"
   },
   {
     "url": "seo/en/peese/practice/teoria.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/peese/practice/teoria",
-    "title": "Teoría: Proceso Software exam questions | Pásame Exámenes",
-    "description": "Practice 17 Teoría questions from past Proceso Software \"exams\" with model answers and self-grading. 202321, Universidade da Coruña.",
+    "title": "Teoría: Proceso Software practice questions | Pásame Exámenes",
+    "description": "Practice 17 Teoría questions from Proceso Software compilations with model answers and self-grading. 202321, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/peese/practice/teoria",
     "ogImage": "https://pe.pablopl.dev/og/peese.png",
@@ -3647,15 +3647,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/peese/practice/teoria"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Teoría: Proceso Software exam questions | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/en/peese/practice/teoria\",\"inLanguage\":\"en\",\"description\":\"Practice 17 Teoría questions from past Proceso Software \\\"exams\\\" with model answers and self-grading. 202321, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Teoría\"},{\"@type\":\"Course\",\"name\":\"Proceso Software\",\"courseCode\":\"202321\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Proceso Software\",\"item\":\"https://pe.pablopl.dev/en/peese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Teoría\",\"item\":\"https://pe.pablopl.dev/en/peese/practice/teoria\"}],\"url\":\"https://pe.pablopl.dev/en/peese/practice/teoria\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Teoría: Proceso Software practice questions | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/en/peese/practice/teoria\",\"inLanguage\":\"en\",\"description\":\"Practice 17 Teoría questions from Proceso Software compilations with model answers and self-grading. 202321, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Teoría\"},{\"@type\":\"Course\",\"name\":\"Proceso Software\",\"courseCode\":\"202321\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Proceso Software\",\"item\":\"https://pe.pablopl.dev/en/peese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Teoría\",\"item\":\"https://pe.pablopl.dev/en/peese/practice/teoria\"}],\"url\":\"https://pe.pablopl.dev/en/peese/practice/teoria\"}]}"
   },
   {
     "url": "seo/en/peese/exam/2026-05.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/peese/exam/2026-05",
-    "title": "Posibles preguntas Mayo 2026 Proceso Software: exam simulator",
-    "description": "Simulate the Posibles preguntas Mayo 2026 Proceso Software exam with 17 questions. 8.5 points, 120 minutes, model answers and self-grading.",
+    "title": "Posibles preguntas Mayo 2026 Proceso Software: timed practice",
+    "description": "Practice the Posibles preguntas Mayo 2026 Proceso Software timed set with 17 questions. 8.5 points, 120 minutes, model answers and self-grading.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/peese/exam/2026-05",
     "ogImage": "https://pe.pablopl.dev/og/peese.png",
@@ -3679,15 +3679,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/peese/exam/2026-05"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Mayo 2026 Proceso Software: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/peese/exam/2026-05\",\"inLanguage\":\"en\",\"description\":\"Simulate the Posibles preguntas Mayo 2026 Proceso Software exam with 17 questions. 8.5 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Proceso Software\",\"courseCode\":\"202321\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Proceso Software\",\"item\":\"https://pe.pablopl.dev/en/peese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Mayo 2026\",\"item\":\"https://pe.pablopl.dev/en/peese/exam/2026-05\"}],\"url\":\"https://pe.pablopl.dev/en/peese/exam/2026-05\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Mayo 2026 Proceso Software: timed practice\",\"url\":\"https://pe.pablopl.dev/en/peese/exam/2026-05\",\"inLanguage\":\"en\",\"description\":\"Practice the Posibles preguntas Mayo 2026 Proceso Software timed set with 17 questions. 8.5 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Proceso Software\",\"courseCode\":\"202321\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Proceso Software\",\"item\":\"https://pe.pablopl.dev/en/peese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Mayo 2026\",\"item\":\"https://pe.pablopl.dev/en/peese/exam/2026-05\"}],\"url\":\"https://pe.pablopl.dev/en/peese/exam/2026-05\"}]}"
   },
   {
     "url": "seo/en/pei.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/pei",
-    "title": "Programación Integrativa: past \"exams\" and solved questions",
-    "description": "Practice 54 Programación Integrativa questions from 1 past \"exams\" with model answers and self-grading. 200214, Universidade da Coruña.",
+    "title": "Programación Integrativa: compilations and solved questions",
+    "description": "Practice 54 Programación Integrativa questions from 1 compilations with model answers and self-grading. 200214, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/pei",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -3711,15 +3711,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Programación Integrativa: past \\\"exams\\\" and solved questions\",\"url\":\"https://pe.pablopl.dev/en/pei\",\"inLanguage\":\"en\",\"description\":\"Practice 54 Programación Integrativa questions from 1 past \\\"exams\\\" with model answers and self-grading. 200214, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/en/pei\"}],\"url\":\"https://pe.pablopl.dev/en/pei\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Programación Integrativa: compilations and solved questions\",\"url\":\"https://pe.pablopl.dev/en/pei\",\"inLanguage\":\"en\",\"description\":\"Practice 54 Programación Integrativa questions from 1 compilations with model answers and self-grading. 200214, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/en/pei\"}],\"url\":\"https://pe.pablopl.dev/en/pei\"}]}"
   },
   {
     "url": "seo/en/pei/practice/pandas.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/pei/practice/pandas",
-    "title": "Pandas y Datos Estructurados: Programación Integrativa exam questions",
-    "description": "Practice 8 Pandas y Datos Estructurados questions from past Programación Integrativa \"exams\" with model answers and self-grading. 200214, Universidade da Coruña.",
+    "title": "Pandas y Datos Estructurados: Programación Integrativa practice questions",
+    "description": "Practice 8 Pandas y Datos Estructurados questions from Programación Integrativa compilations with model answers and self-grading. 200214, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/pei/practice/pandas",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -3743,15 +3743,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei/practice/pandas"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Pandas y Datos Estructurados: Programación Integrativa exam questions\",\"url\":\"https://pe.pablopl.dev/en/pei/practice/pandas\",\"inLanguage\":\"en\",\"description\":\"Practice 8 Pandas y Datos Estructurados questions from past Programación Integrativa \\\"exams\\\" with model answers and self-grading. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Pandas y Datos Estructurados\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/en/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Pandas y Datos Estructurados\",\"item\":\"https://pe.pablopl.dev/en/pei/practice/pandas\"}],\"url\":\"https://pe.pablopl.dev/en/pei/practice/pandas\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Pandas y Datos Estructurados: Programación Integrativa practice questions\",\"url\":\"https://pe.pablopl.dev/en/pei/practice/pandas\",\"inLanguage\":\"en\",\"description\":\"Practice 8 Pandas y Datos Estructurados questions from Programación Integrativa compilations with model answers and self-grading. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Pandas y Datos Estructurados\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/en/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Pandas y Datos Estructurados\",\"item\":\"https://pe.pablopl.dev/en/pei/practice/pandas\"}],\"url\":\"https://pe.pablopl.dev/en/pei/practice/pandas\"}]}"
   },
   {
     "url": "seo/en/pei/practice/poo.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/pei/practice/poo",
-    "title": "POO en Python: Programación Integrativa exam questions",
-    "description": "Practice 8 POO en Python questions from past Programación Integrativa \"exams\" with model answers and self-grading. 200214, Universidade da Coruña.",
+    "title": "POO en Python: Programación Integrativa practice questions",
+    "description": "Practice 8 POO en Python questions from Programación Integrativa compilations with model answers and self-grading. 200214, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/pei/practice/poo",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -3775,15 +3775,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei/practice/poo"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"POO en Python: Programación Integrativa exam questions\",\"url\":\"https://pe.pablopl.dev/en/pei/practice/poo\",\"inLanguage\":\"en\",\"description\":\"Practice 8 POO en Python questions from past Programación Integrativa \\\"exams\\\" with model answers and self-grading. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"POO en Python\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/en/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"POO en Python\",\"item\":\"https://pe.pablopl.dev/en/pei/practice/poo\"}],\"url\":\"https://pe.pablopl.dev/en/pei/practice/poo\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"POO en Python: Programación Integrativa practice questions\",\"url\":\"https://pe.pablopl.dev/en/pei/practice/poo\",\"inLanguage\":\"en\",\"description\":\"Practice 8 POO en Python questions from Programación Integrativa compilations with model answers and self-grading. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"POO en Python\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/en/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"POO en Python\",\"item\":\"https://pe.pablopl.dev/en/pei/practice/poo\"}],\"url\":\"https://pe.pablopl.dev/en/pei/practice/poo\"}]}"
   },
   {
     "url": "seo/en/pei/practice/scripting.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/pei/practice/scripting",
-    "title": "Scripting y Regex: Programación Integrativa exam questions",
-    "description": "Practice 15 Scripting y Regex questions from past Programación Integrativa \"exams\" with model answers and self-grading. 200214, Universidade da Coruña.",
+    "title": "Scripting y Regex: Programación Integrativa practice questions",
+    "description": "Practice 15 Scripting y Regex questions from Programación Integrativa compilations with model answers and self-grading. 200214, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/pei/practice/scripting",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -3807,15 +3807,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei/practice/scripting"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Scripting y Regex: Programación Integrativa exam questions\",\"url\":\"https://pe.pablopl.dev/en/pei/practice/scripting\",\"inLanguage\":\"en\",\"description\":\"Practice 15 Scripting y Regex questions from past Programación Integrativa \\\"exams\\\" with model answers and self-grading. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Scripting y Regex\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/en/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Scripting y Regex\",\"item\":\"https://pe.pablopl.dev/en/pei/practice/scripting\"}],\"url\":\"https://pe.pablopl.dev/en/pei/practice/scripting\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Scripting y Regex: Programación Integrativa practice questions\",\"url\":\"https://pe.pablopl.dev/en/pei/practice/scripting\",\"inLanguage\":\"en\",\"description\":\"Practice 15 Scripting y Regex questions from Programación Integrativa compilations with model answers and self-grading. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Scripting y Regex\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/en/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Scripting y Regex\",\"item\":\"https://pe.pablopl.dev/en/pei/practice/scripting\"}],\"url\":\"https://pe.pablopl.dev/en/pei/practice/scripting\"}]}"
   },
   {
     "url": "seo/en/pei/practice/django-apis.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/pei/practice/django-apis",
-    "title": "Django, APIs e Integración: Programación Integrativa exam questions",
-    "description": "Practice 14 Django, APIs e Integración questions from past Programación Integrativa \"exams\" with model answers and self-grading. 200214, Universidade da Coruña.",
+    "title": "Django, APIs e Integración: Programación Integrativa practice questions",
+    "description": "Practice 14 Django, APIs e Integración questions from Programación Integrativa compilations with model answers and self-grading. 200214, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/pei/practice/django-apis",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -3839,15 +3839,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei/practice/django-apis"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Django, APIs e Integración: Programación Integrativa exam questions\",\"url\":\"https://pe.pablopl.dev/en/pei/practice/django-apis\",\"inLanguage\":\"en\",\"description\":\"Practice 14 Django, APIs e Integración questions from past Programación Integrativa \\\"exams\\\" with model answers and self-grading. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Django, APIs e Integración\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/en/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Django, APIs e Integración\",\"item\":\"https://pe.pablopl.dev/en/pei/practice/django-apis\"}],\"url\":\"https://pe.pablopl.dev/en/pei/practice/django-apis\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Django, APIs e Integración: Programación Integrativa practice questions\",\"url\":\"https://pe.pablopl.dev/en/pei/practice/django-apis\",\"inLanguage\":\"en\",\"description\":\"Practice 14 Django, APIs e Integración questions from Programación Integrativa compilations with model answers and self-grading. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Django, APIs e Integración\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/en/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Django, APIs e Integración\",\"item\":\"https://pe.pablopl.dev/en/pei/practice/django-apis\"}],\"url\":\"https://pe.pablopl.dev/en/pei/practice/django-apis\"}]}"
   },
   {
     "url": "seo/en/pei/practice/conceptos.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/pei/practice/conceptos",
-    "title": "Conceptos y Test: Programación Integrativa exam questions",
-    "description": "Practice 9 Conceptos y Test questions from past Programación Integrativa \"exams\" with model answers and self-grading. 200214, Universidade da Coruña.",
+    "title": "Conceptos y Test: Programación Integrativa practice questions",
+    "description": "Practice 9 Conceptos y Test questions from Programación Integrativa compilations with model answers and self-grading. 200214, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/pei/practice/conceptos",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -3871,15 +3871,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei/practice/conceptos"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Conceptos y Test: Programación Integrativa exam questions\",\"url\":\"https://pe.pablopl.dev/en/pei/practice/conceptos\",\"inLanguage\":\"en\",\"description\":\"Practice 9 Conceptos y Test questions from past Programación Integrativa \\\"exams\\\" with model answers and self-grading. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Conceptos y Test\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/en/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Conceptos y Test\",\"item\":\"https://pe.pablopl.dev/en/pei/practice/conceptos\"}],\"url\":\"https://pe.pablopl.dev/en/pei/practice/conceptos\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Conceptos y Test: Programación Integrativa practice questions\",\"url\":\"https://pe.pablopl.dev/en/pei/practice/conceptos\",\"inLanguage\":\"en\",\"description\":\"Practice 9 Conceptos y Test questions from Programación Integrativa compilations with model answers and self-grading. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Conceptos y Test\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/en/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Conceptos y Test\",\"item\":\"https://pe.pablopl.dev/en/pei/practice/conceptos\"}],\"url\":\"https://pe.pablopl.dev/en/pei/practice/conceptos\"}]}"
   },
   {
     "url": "seo/en/pei/exam/recopilacion.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/pei/exam/recopilacion",
-    "title": "Recopilación Programación Integrativa: exam simulator",
-    "description": "Simulate the Recopilación Programación Integrativa exam with 54 questions. 30 points, 120 minutes, model answers and self-grading.",
+    "title": "Recopilación Programación Integrativa: timed practice",
+    "description": "Practice the Recopilación Programación Integrativa timed set with 54 questions. 30 points, 120 minutes, model answers and self-grading.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/pei/exam/recopilacion",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -3903,15 +3903,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei/exam/recopilacion"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Recopilación Programación Integrativa: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/pei/exam/recopilacion\",\"inLanguage\":\"en\",\"description\":\"Simulate the Recopilación Programación Integrativa exam with 54 questions. 30 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/en/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Recopilación\",\"item\":\"https://pe.pablopl.dev/en/pei/exam/recopilacion\"}],\"url\":\"https://pe.pablopl.dev/en/pei/exam/recopilacion\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Recopilación Programación Integrativa: timed practice\",\"url\":\"https://pe.pablopl.dev/en/pei/exam/recopilacion\",\"inLanguage\":\"en\",\"description\":\"Practice the Recopilación Programación Integrativa timed set with 54 questions. 30 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/en/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Recopilación\",\"item\":\"https://pe.pablopl.dev/en/pei/exam/recopilacion\"}],\"url\":\"https://pe.pablopl.dev/en/pei/exam/recopilacion\"}]}"
   },
   {
     "url": "seo/en/redes.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/redes",
-    "title": "Redes: past \"exams\" and solved questions | Pásame Exámenes",
-    "description": "Practice 460 Redes questions from 3 past \"exams\" with model answers and self-grading. 202319, Universidade da Coruña.",
+    "title": "Redes: compilations and solved questions | Pásame Exámenes",
+    "description": "Practice 460 Redes questions from 3 compilations with model answers and self-grading. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/redes",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -3935,15 +3935,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Redes: past \\\"exams\\\" and solved questions | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/en/redes\",\"inLanguage\":\"en\",\"description\":\"Practice 460 Redes questions from 3 past \\\"exams\\\" with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"}],\"url\":\"https://pe.pablopl.dev/en/redes\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Redes: compilations and solved questions | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/en/redes\",\"inLanguage\":\"en\",\"description\":\"Practice 460 Redes questions from 3 compilations with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"}],\"url\":\"https://pe.pablopl.dev/en/redes\"}]}"
   },
   {
     "url": "seo/en/redes/practice/tema-1.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/redes/practice/tema-1",
-    "title": "Tema 1. Redes de ordenadores e Internet: Redes exam questions",
-    "description": "Practice 54 Tema 1. Redes de ordenadores e Internet questions from past Redes \"exams\" with model answers and self-grading. 202319, Universidade da Coruña.",
+    "title": "Tema 1. Redes de ordenadores e Internet: Redes practice questions",
+    "description": "Practice 54 Tema 1. Redes de ordenadores e Internet questions from Redes compilations with model answers and self-grading. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/redes/practice/tema-1",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -3967,15 +3967,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-1"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 1. Redes de ordenadores e Internet: Redes exam questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-1\",\"inLanguage\":\"en\",\"description\":\"Practice 54 Tema 1. Redes de ordenadores e Internet questions from past Redes \\\"exams\\\" with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 1. Redes de ordenadores e Internet\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 1. Redes de ordenadores e Internet\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-1\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-1\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 1. Redes de ordenadores e Internet: Redes practice questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-1\",\"inLanguage\":\"en\",\"description\":\"Practice 54 Tema 1. Redes de ordenadores e Internet questions from Redes compilations with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 1. Redes de ordenadores e Internet\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 1. Redes de ordenadores e Internet\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-1\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-1\"}]}"
   },
   {
     "url": "seo/en/redes/practice/tema-2.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/redes/practice/tema-2",
-    "title": "Tema 2. Introducción a TCP/IP: Redes exam questions",
-    "description": "Practice 19 Tema 2. Introducción a TCP/IP questions from past Redes \"exams\" with model answers and self-grading. 202319, Universidade da Coruña.",
+    "title": "Tema 2. Introducción a TCP/IP: Redes practice questions",
+    "description": "Practice 19 Tema 2. Introducción a TCP/IP questions from Redes compilations with model answers and self-grading. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/redes/practice/tema-2",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -3999,15 +3999,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-2"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 2. Introducción a TCP/IP: Redes exam questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-2\",\"inLanguage\":\"en\",\"description\":\"Practice 19 Tema 2. Introducción a TCP/IP questions from past Redes \\\"exams\\\" with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 2. Introducción a TCP/IP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 2. Introducción a TCP/IP\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-2\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-2\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 2. Introducción a TCP/IP: Redes practice questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-2\",\"inLanguage\":\"en\",\"description\":\"Practice 19 Tema 2. Introducción a TCP/IP questions from Redes compilations with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 2. Introducción a TCP/IP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 2. Introducción a TCP/IP\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-2\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-2\"}]}"
   },
   {
     "url": "seo/en/redes/practice/tema-3-4.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/redes/practice/tema-3-4",
-    "title": "Tema 3-4. Protocolos nivel de aplicación: Redes exam questions",
-    "description": "Practice 77 Tema 3-4. Protocolos nivel de aplicación questions from past Redes \"exams\" with model answers and self-grading. 202319, Universidade da Coruña.",
+    "title": "Tema 3-4. Protocolos nivel de aplicación: Redes practice questions",
+    "description": "Practice 77 Tema 3-4. Protocolos nivel de aplicación questions from Redes compilations with model answers and self-grading. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/redes/practice/tema-3-4",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -4031,15 +4031,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-3-4"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 3-4. Protocolos nivel de aplicación: Redes exam questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-3-4\",\"inLanguage\":\"en\",\"description\":\"Practice 77 Tema 3-4. Protocolos nivel de aplicación questions from past Redes \\\"exams\\\" with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 3-4. Protocolos nivel de aplicación\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 3-4. Protocolos nivel de aplicación\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-3-4\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-3-4\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 3-4. Protocolos nivel de aplicación: Redes practice questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-3-4\",\"inLanguage\":\"en\",\"description\":\"Practice 77 Tema 3-4. Protocolos nivel de aplicación questions from Redes compilations with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 3-4. Protocolos nivel de aplicación\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 3-4. Protocolos nivel de aplicación\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-3-4\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-3-4\"}]}"
   },
   {
     "url": "seo/en/redes/practice/tema-5.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/redes/practice/tema-5",
-    "title": "Tema 5. Protocolos de transporte UDP y TCP: Redes exam questions",
-    "description": "Practice 51 Tema 5. Protocolos de transporte UDP y TCP questions from past Redes \"exams\" with model answers and self-grading. 202319, Universidade da Coruña.",
+    "title": "Tema 5. Protocolos de transporte UDP y TCP: Redes practice questions",
+    "description": "Practice 51 Tema 5. Protocolos de transporte UDP y TCP questions from Redes compilations with model answers and self-grading. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/redes/practice/tema-5",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -4063,15 +4063,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-5"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 5. Protocolos de transporte UDP y TCP: Redes exam questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-5\",\"inLanguage\":\"en\",\"description\":\"Practice 51 Tema 5. Protocolos de transporte UDP y TCP questions from past Redes \\\"exams\\\" with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 5. Protocolos de transporte UDP y TCP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 5. Protocolos de transporte UDP y TCP\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-5\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-5\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 5. Protocolos de transporte UDP y TCP: Redes practice questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-5\",\"inLanguage\":\"en\",\"description\":\"Practice 51 Tema 5. Protocolos de transporte UDP y TCP questions from Redes compilations with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 5. Protocolos de transporte UDP y TCP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 5. Protocolos de transporte UDP y TCP\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-5\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-5\"}]}"
   },
   {
     "url": "seo/en/redes/practice/tema-6.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/redes/practice/tema-6",
-    "title": "Tema 6. Intercambio de datos TCP: Redes exam questions",
-    "description": "Practice 48 Tema 6. Intercambio de datos TCP questions from past Redes \"exams\" with model answers and self-grading. 202319, Universidade da Coruña.",
+    "title": "Tema 6. Intercambio de datos TCP: Redes practice questions",
+    "description": "Practice 48 Tema 6. Intercambio de datos TCP questions from Redes compilations with model answers and self-grading. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/redes/practice/tema-6",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -4095,15 +4095,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-6"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 6. Intercambio de datos TCP: Redes exam questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-6\",\"inLanguage\":\"en\",\"description\":\"Practice 48 Tema 6. Intercambio de datos TCP questions from past Redes \\\"exams\\\" with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 6. Intercambio de datos TCP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 6. Intercambio de datos TCP\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-6\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-6\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 6. Intercambio de datos TCP: Redes practice questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-6\",\"inLanguage\":\"en\",\"description\":\"Practice 48 Tema 6. Intercambio de datos TCP questions from Redes compilations with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 6. Intercambio de datos TCP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 6. Intercambio de datos TCP\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-6\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-6\"}]}"
   },
   {
     "url": "seo/en/redes/practice/tema-7.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/redes/practice/tema-7",
-    "title": "Tema 7. Nivel de red: protocolo IP: Redes exam questions",
-    "description": "Practice 81 Tema 7. Nivel de red: protocolo IP questions from past Redes \"exams\" with model answers and self-grading. 202319, Universidade da Coruña.",
+    "title": "Tema 7. Nivel de red: protocolo IP: Redes practice questions",
+    "description": "Practice 81 Tema 7. Nivel de red: protocolo IP questions from Redes compilations with model answers and self-grading. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/redes/practice/tema-7",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -4127,15 +4127,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-7"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 7. Nivel de red: protocolo IP: Redes exam questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-7\",\"inLanguage\":\"en\",\"description\":\"Practice 81 Tema 7. Nivel de red: protocolo IP questions from past Redes \\\"exams\\\" with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 7. Nivel de red: protocolo IP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 7. Nivel de red: protocolo IP\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-7\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-7\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 7. Nivel de red: protocolo IP: Redes practice questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-7\",\"inLanguage\":\"en\",\"description\":\"Practice 81 Tema 7. Nivel de red: protocolo IP questions from Redes compilations with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 7. Nivel de red: protocolo IP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 7. Nivel de red: protocolo IP\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-7\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-7\"}]}"
   },
   {
     "url": "seo/en/redes/practice/tema-8.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/redes/practice/tema-8",
-    "title": "Tema 8. Enrutamiento: Redes exam questions | Pásame Exámenes",
-    "description": "Practice 22 Tema 8. Enrutamiento questions from past Redes \"exams\" with model answers and self-grading. 202319, Universidade da Coruña.",
+    "title": "Tema 8. Enrutamiento: Redes practice questions",
+    "description": "Practice 22 Tema 8. Enrutamiento questions from Redes compilations with model answers and self-grading. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/redes/practice/tema-8",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -4159,15 +4159,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-8"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 8. Enrutamiento: Redes exam questions | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-8\",\"inLanguage\":\"en\",\"description\":\"Practice 22 Tema 8. Enrutamiento questions from past Redes \\\"exams\\\" with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 8. Enrutamiento\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 8. Enrutamiento\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-8\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-8\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 8. Enrutamiento: Redes practice questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-8\",\"inLanguage\":\"en\",\"description\":\"Practice 22 Tema 8. Enrutamiento questions from Redes compilations with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 8. Enrutamiento\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 8. Enrutamiento\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-8\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-8\"}]}"
   },
   {
     "url": "seo/en/redes/practice/tema-9.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/redes/practice/tema-9",
-    "title": "Tema 9. ICMP y fragmentación IP: Redes exam questions",
-    "description": "Practice 24 Tema 9. ICMP y fragmentación IP questions from past Redes \"exams\" with model answers and self-grading. 202319, Universidade da Coruña.",
+    "title": "Tema 9. ICMP y fragmentación IP: Redes practice questions",
+    "description": "Practice 24 Tema 9. ICMP y fragmentación IP questions from Redes compilations with model answers and self-grading. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/redes/practice/tema-9",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -4191,15 +4191,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-9"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 9. ICMP y fragmentación IP: Redes exam questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-9\",\"inLanguage\":\"en\",\"description\":\"Practice 24 Tema 9. ICMP y fragmentación IP questions from past Redes \\\"exams\\\" with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 9. ICMP y fragmentación IP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 9. ICMP y fragmentación IP\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-9\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-9\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 9. ICMP y fragmentación IP: Redes practice questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-9\",\"inLanguage\":\"en\",\"description\":\"Practice 24 Tema 9. ICMP y fragmentación IP questions from Redes compilations with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 9. ICMP y fragmentación IP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 9. ICMP y fragmentación IP\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-9\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-9\"}]}"
   },
   {
     "url": "seo/en/redes/practice/tema-10.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/redes/practice/tema-10",
-    "title": "Tema 10. Protocolo IPv6: Redes exam questions",
-    "description": "Practice 11 Tema 10. Protocolo IPv6 questions from past Redes \"exams\" with model answers and self-grading. 202319, Universidade da Coruña.",
+    "title": "Tema 10. Protocolo IPv6: Redes practice questions",
+    "description": "Practice 11 Tema 10. Protocolo IPv6 questions from Redes compilations with model answers and self-grading. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/redes/practice/tema-10",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -4223,15 +4223,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-10"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 10. Protocolo IPv6: Redes exam questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-10\",\"inLanguage\":\"en\",\"description\":\"Practice 11 Tema 10. Protocolo IPv6 questions from past Redes \\\"exams\\\" with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 10. Protocolo IPv6\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 10. Protocolo IPv6\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-10\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-10\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 10. Protocolo IPv6: Redes practice questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-10\",\"inLanguage\":\"en\",\"description\":\"Practice 11 Tema 10. Protocolo IPv6 questions from Redes compilations with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 10. Protocolo IPv6\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 10. Protocolo IPv6\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-10\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-10\"}]}"
   },
   {
     "url": "seo/en/redes/practice/tema-11.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/redes/practice/tema-11",
-    "title": "Tema 11. TCP/IP y nivel de enlace: Redes exam questions",
-    "description": "Practice 24 Tema 11. TCP/IP y nivel de enlace questions from past Redes \"exams\" with model answers and self-grading. 202319, Universidade da Coruña.",
+    "title": "Tema 11. TCP/IP y nivel de enlace: Redes practice questions",
+    "description": "Practice 24 Tema 11. TCP/IP y nivel de enlace questions from Redes compilations with model answers and self-grading. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/redes/practice/tema-11",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -4255,15 +4255,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-11"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 11. TCP/IP y nivel de enlace: Redes exam questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-11\",\"inLanguage\":\"en\",\"description\":\"Practice 24 Tema 11. TCP/IP y nivel de enlace questions from past Redes \\\"exams\\\" with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 11. TCP/IP y nivel de enlace\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 11. TCP/IP y nivel de enlace\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-11\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-11\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 11. TCP/IP y nivel de enlace: Redes practice questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-11\",\"inLanguage\":\"en\",\"description\":\"Practice 24 Tema 11. TCP/IP y nivel de enlace questions from Redes compilations with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 11. TCP/IP y nivel de enlace\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 11. TCP/IP y nivel de enlace\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-11\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-11\"}]}"
   },
   {
     "url": "seo/en/redes/practice/tema-12.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/redes/practice/tema-12",
-    "title": "Tema 12. Tecnologías del nivel de enlace: Redes exam questions",
-    "description": "Practice 49 Tema 12. Tecnologías del nivel de enlace questions from past Redes \"exams\" with model answers and self-grading. 202319, Universidade da Coruña.",
+    "title": "Tema 12. Tecnologías del nivel de enlace: Redes practice questions",
+    "description": "Practice 49 Tema 12. Tecnologías del nivel de enlace questions from Redes compilations with model answers and self-grading. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/redes/practice/tema-12",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -4287,15 +4287,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-12"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 12. Tecnologías del nivel de enlace: Redes exam questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-12\",\"inLanguage\":\"en\",\"description\":\"Practice 49 Tema 12. Tecnologías del nivel de enlace questions from past Redes \\\"exams\\\" with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 12. Tecnologías del nivel de enlace\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 12. Tecnologías del nivel de enlace\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-12\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-12\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 12. Tecnologías del nivel de enlace: Redes practice questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-12\",\"inLanguage\":\"en\",\"description\":\"Practice 49 Tema 12. Tecnologías del nivel de enlace questions from Redes compilations with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 12. Tecnologías del nivel de enlace\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 12. Tecnologías del nivel de enlace\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-12\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-12\"}]}"
   },
   {
     "url": "seo/en/redes/exam/daypo-recopilatorio-lara.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/redes/exam/daypo-recopilatorio-lara",
-    "title": "Daypo Recopilatorio (des. 2008) Redes: exam simulator",
-    "description": "Simulate the Daypo Recopilatorio (des. 2008) Redes exam with 125 questions. 125 points, 120 minutes, model answers and self-grading.",
+    "title": "Daypo Recopilatorio (des. 2008) Redes: timed practice",
+    "description": "Practice the Daypo Recopilatorio (des. 2008) Redes timed set with 125 questions. 125 points, 120 minutes, model answers and self-grading.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/redes/exam/daypo-recopilatorio-lara",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -4319,15 +4319,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/exam/daypo-recopilatorio-lara"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Recopilatorio (des. 2008) Redes: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/redes/exam/daypo-recopilatorio-lara\",\"inLanguage\":\"en\",\"description\":\"Simulate the Daypo Recopilatorio (des. 2008) Redes exam with 125 questions. 125 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Recopilatorio (des. 2008)\",\"item\":\"https://pe.pablopl.dev/en/redes/exam/daypo-recopilatorio-lara\"}],\"url\":\"https://pe.pablopl.dev/en/redes/exam/daypo-recopilatorio-lara\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Recopilatorio (des. 2008) Redes: timed practice\",\"url\":\"https://pe.pablopl.dev/en/redes/exam/daypo-recopilatorio-lara\",\"inLanguage\":\"en\",\"description\":\"Practice the Daypo Recopilatorio (des. 2008) Redes timed set with 125 questions. 125 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Recopilatorio (des. 2008)\",\"item\":\"https://pe.pablopl.dev/en/redes/exam/daypo-recopilatorio-lara\"}],\"url\":\"https://pe.pablopl.dev/en/redes/exam/daypo-recopilatorio-lara\"}]}"
   },
   {
     "url": "seo/en/redes/exam/daypo-recopilatorio-udc.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/redes/exam/daypo-recopilatorio-udc",
-    "title": "Daypo Recopilatorio (UDC) Redes: exam simulator",
-    "description": "Simulate the Daypo Recopilatorio (UDC) Redes exam with 298 questions. 298 points, 240 minutes, model answers and self-grading.",
+    "title": "Daypo Recopilatorio (UDC) Redes: timed practice",
+    "description": "Practice the Daypo Recopilatorio (UDC) Redes timed set with 298 questions. 298 points, 240 minutes, model answers and self-grading.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/redes/exam/daypo-recopilatorio-udc",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -4351,15 +4351,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/exam/daypo-recopilatorio-udc"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Recopilatorio (UDC) Redes: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/redes/exam/daypo-recopilatorio-udc\",\"inLanguage\":\"en\",\"description\":\"Simulate the Daypo Recopilatorio (UDC) Redes exam with 298 questions. 298 points, 240 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Recopilatorio (UDC)\",\"item\":\"https://pe.pablopl.dev/en/redes/exam/daypo-recopilatorio-udc\"}],\"url\":\"https://pe.pablopl.dev/en/redes/exam/daypo-recopilatorio-udc\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Recopilatorio (UDC) Redes: timed practice\",\"url\":\"https://pe.pablopl.dev/en/redes/exam/daypo-recopilatorio-udc\",\"inLanguage\":\"en\",\"description\":\"Practice the Daypo Recopilatorio (UDC) Redes timed set with 298 questions. 298 points, 240 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Recopilatorio (UDC)\",\"item\":\"https://pe.pablopl.dev/en/redes/exam/daypo-recopilatorio-udc\"}],\"url\":\"https://pe.pablopl.dev/en/redes/exam/daypo-recopilatorio-udc\"}]}"
   },
   {
     "url": "seo/en/redes/exam/2025-05.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/redes/exam/2025-05",
-    "title": "Posibles preguntas Mayo 2025 Redes: exam simulator",
-    "description": "Simulate the Posibles preguntas Mayo 2025 Redes exam with 37 questions. 37 points, 120 minutes, model answers and self-grading.",
+    "title": "Posibles preguntas Mayo 2025 Redes: timed practice",
+    "description": "Practice the Posibles preguntas Mayo 2025 Redes timed set with 37 questions. 37 points, 120 minutes, model answers and self-grading.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/redes/exam/2025-05",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -4383,15 +4383,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/exam/2025-05"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Mayo 2025 Redes: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/redes/exam/2025-05\",\"inLanguage\":\"en\",\"description\":\"Simulate the Posibles preguntas Mayo 2025 Redes exam with 37 questions. 37 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Mayo 2025\",\"item\":\"https://pe.pablopl.dev/en/redes/exam/2025-05\"}],\"url\":\"https://pe.pablopl.dev/en/redes/exam/2025-05\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Mayo 2025 Redes: timed practice\",\"url\":\"https://pe.pablopl.dev/en/redes/exam/2025-05\",\"inLanguage\":\"en\",\"description\":\"Practice the Posibles preguntas Mayo 2025 Redes timed set with 37 questions. 37 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Mayo 2025\",\"item\":\"https://pe.pablopl.dev/en/redes/exam/2025-05\"}],\"url\":\"https://pe.pablopl.dev/en/redes/exam/2025-05\"}]}"
   },
   {
     "url": "seo/es.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/",
-    "title": "Practica exámenes universitarios | Pásame Exámenes",
-    "description": "Practica exámenes universitarios anteriores por tema o simula exámenes completos con respuestas modelo, autocorrección y preguntas tipo test o desarrollo.",
+    "title": "Practica preguntas universitarias | Pásame Exámenes",
+    "description": "Practica preguntas universitarias por tema o en modo cronometrado con respuestas modelo, autocorrección y preguntas tipo test o desarrollo.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es",
     "ogImage": "https://pe.pablopl.dev/og.jpg",
@@ -4415,15 +4415,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebSite\",\"name\":\"Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es\",\"inLanguage\":\"es\",\"description\":\"Practica exámenes universitarios anteriores por tema o simula exámenes completos con respuestas modelo, autocorrección y preguntas tipo test o desarrollo.\"},{\"@type\":\"WebPage\",\"name\":\"Practica exámenes universitarios | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es\",\"inLanguage\":\"es\",\"description\":\"Practica exámenes universitarios anteriores por tema o simula exámenes completos con respuestas modelo, autocorrección y preguntas tipo test o desarrollo.\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebSite\",\"name\":\"Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es\",\"inLanguage\":\"es\",\"description\":\"Practica preguntas universitarias por tema o en modo cronometrado con respuestas modelo, autocorrección y preguntas tipo test o desarrollo.\"},{\"@type\":\"WebPage\",\"name\":\"Practica preguntas universitarias | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es\",\"inLanguage\":\"es\",\"description\":\"Practica preguntas universitarias por tema o en modo cronometrado con respuestas modelo, autocorrección y preguntas tipo test o desarrollo.\"}]}"
   },
   {
     "url": "seo/es/bede.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/bede",
-    "title": "Bases de Datos: \"exámenes\" y preguntas resueltas",
-    "description": "Practica 98 preguntas de Bases de Datos de 1 \"exámenes\" anteriores con respuestas modelo y autocorrección. 202315, Universidade da Coruña.",
+    "title": "Bases de Datos: recopilatorios y preguntas resueltas",
+    "description": "Practica 98 preguntas de Bases de Datos de 1 recopilatorios de práctica con respuestas modelo y autocorrección. 202315, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/bede",
     "ogImage": "https://pe.pablopl.dev/og/bede.png",
@@ -4447,7 +4447,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/bede"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Bases de Datos: \\\"exámenes\\\" y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/bede\",\"inLanguage\":\"es\",\"description\":\"Practica 98 preguntas de Bases de Datos de 1 \\\"exámenes\\\" anteriores con respuestas modelo y autocorrección. 202315, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/es/bede\"}],\"url\":\"https://pe.pablopl.dev/es/bede\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Bases de Datos: recopilatorios y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/bede\",\"inLanguage\":\"es\",\"description\":\"Practica 98 preguntas de Bases de Datos de 1 recopilatorios de práctica con respuestas modelo y autocorrección. 202315, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/es/bede\"}],\"url\":\"https://pe.pablopl.dev/es/bede\"}]}"
   },
   {
     "url": "seo/es/bede/practice/recuperacion-concurrencia.html",
@@ -4455,7 +4455,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/bede/practice/recuperacion-concurrencia",
     "title": "Recuperación y Concurrencia: preguntas de Bases de Datos",
-    "description": "Practica 48 preguntas de Recuperación y Concurrencia de \"exámenes\" anteriores de Bases de Datos, con respuestas modelo y autocorrección. 202315, Universidade da Coruña.",
+    "description": "Practica 48 preguntas de Recuperación y Concurrencia de recopilatorios de Bases de Datos, con respuestas modelo y autocorrección. 202315, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/bede/practice/recuperacion-concurrencia",
     "ogImage": "https://pe.pablopl.dev/og/bede.png",
@@ -4479,7 +4479,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/bede/practice/recuperacion-concurrencia"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Recuperación y Concurrencia: preguntas de Bases de Datos\",\"url\":\"https://pe.pablopl.dev/es/bede/practice/recuperacion-concurrencia\",\"inLanguage\":\"es\",\"description\":\"Practica 48 preguntas de Recuperación y Concurrencia de \\\"exámenes\\\" anteriores de Bases de Datos, con respuestas modelo y autocorrección. 202315, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Recuperación y Concurrencia\"},{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/es/bede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Recuperación y Concurrencia\",\"item\":\"https://pe.pablopl.dev/es/bede/practice/recuperacion-concurrencia\"}],\"url\":\"https://pe.pablopl.dev/es/bede/practice/recuperacion-concurrencia\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Recuperación y Concurrencia: preguntas de Bases de Datos\",\"url\":\"https://pe.pablopl.dev/es/bede/practice/recuperacion-concurrencia\",\"inLanguage\":\"es\",\"description\":\"Practica 48 preguntas de Recuperación y Concurrencia de recopilatorios de Bases de Datos, con respuestas modelo y autocorrección. 202315, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Recuperación y Concurrencia\"},{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/es/bede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Recuperación y Concurrencia\",\"item\":\"https://pe.pablopl.dev/es/bede/practice/recuperacion-concurrencia\"}],\"url\":\"https://pe.pablopl.dev/es/bede/practice/recuperacion-concurrencia\"}]}"
   },
   {
     "url": "seo/es/bede/practice/ficheros.html",
@@ -4487,7 +4487,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/bede/practice/ficheros",
     "title": "Ficheros: preguntas de Bases de Datos | Pásame Exámenes",
-    "description": "Practica 50 preguntas de Ficheros de \"exámenes\" anteriores de Bases de Datos, con respuestas modelo y autocorrección. 202315, Universidade da Coruña.",
+    "description": "Practica 50 preguntas de Ficheros de recopilatorios de Bases de Datos, con respuestas modelo y autocorrección. 202315, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/bede/practice/ficheros",
     "ogImage": "https://pe.pablopl.dev/og/bede.png",
@@ -4511,15 +4511,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/bede/practice/ficheros"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Ficheros: preguntas de Bases de Datos | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/bede/practice/ficheros\",\"inLanguage\":\"es\",\"description\":\"Practica 50 preguntas de Ficheros de \\\"exámenes\\\" anteriores de Bases de Datos, con respuestas modelo y autocorrección. 202315, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Ficheros\"},{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/es/bede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Ficheros\",\"item\":\"https://pe.pablopl.dev/es/bede/practice/ficheros\"}],\"url\":\"https://pe.pablopl.dev/es/bede/practice/ficheros\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Ficheros: preguntas de Bases de Datos | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/bede/practice/ficheros\",\"inLanguage\":\"es\",\"description\":\"Practica 50 preguntas de Ficheros de recopilatorios de Bases de Datos, con respuestas modelo y autocorrección. 202315, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Ficheros\"},{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/es/bede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Ficheros\",\"item\":\"https://pe.pablopl.dev/es/bede/practice/ficheros\"}],\"url\":\"https://pe.pablopl.dev/es/bede/practice/ficheros\"}]}"
   },
   {
     "url": "seo/es/bede/exam/daypo-preguntas.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/bede/exam/daypo-preguntas",
-    "title": "Daypo Preguntas de Bases de Datos: simulador | Pásame Exámenes",
-    "description": "Simula el examen Daypo Preguntas de Bases de Datos con 98 preguntas. 98 puntos, 120 minutos, respuestas modelo y autocorrección.",
+    "title": "Daypo Preguntas de Bases de Datos: práctica cronometrada",
+    "description": "Practica el recopilatorio cronometrado Daypo Preguntas de Bases de Datos con 98 preguntas. 98 puntos, 120 minutos, respuestas modelo y autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/bede/exam/daypo-preguntas",
     "ogImage": "https://pe.pablopl.dev/og/bede.png",
@@ -4543,15 +4543,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/bede/exam/daypo-preguntas"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Preguntas de Bases de Datos: simulador | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/bede/exam/daypo-preguntas\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Daypo Preguntas de Bases de Datos con 98 preguntas. 98 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/es/bede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Preguntas\",\"item\":\"https://pe.pablopl.dev/es/bede/exam/daypo-preguntas\"}],\"url\":\"https://pe.pablopl.dev/es/bede/exam/daypo-preguntas\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Preguntas de Bases de Datos: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/es/bede/exam/daypo-preguntas\",\"inLanguage\":\"es\",\"description\":\"Practica el recopilatorio cronometrado Daypo Preguntas de Bases de Datos con 98 preguntas. 98 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/es/bede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Preguntas\",\"item\":\"https://pe.pablopl.dev/es/bede/exam/daypo-preguntas\"}],\"url\":\"https://pe.pablopl.dev/es/bede/exam/daypo-preguntas\"}]}"
   },
   {
     "url": "seo/es/cepe.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/cepe",
-    "title": "Concorrencia e Paralelismo: \"exámenes\" y preguntas resueltas",
-    "description": "Practica 76 preguntas de Concorrencia e Paralelismo de 16 \"exámenes\" anteriores con respuestas modelo y autocorrección. 202320, Universidade da Coruña.",
+    "title": "Concorrencia e Paralelismo: exámenes y preguntas resueltas",
+    "description": "Practica 76 preguntas de Concorrencia e Paralelismo de 16 exámenes con respuestas modelo y autocorrección. 202320, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/cepe",
     "ogImage": "https://pe.pablopl.dev/og/cepe.png",
@@ -4575,7 +4575,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/cepe"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Concorrencia e Paralelismo: \\\"exámenes\\\" y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/cepe\",\"inLanguage\":\"es\",\"description\":\"Practica 76 preguntas de Concorrencia e Paralelismo de 16 \\\"exámenes\\\" anteriores con respuestas modelo y autocorrección. 202320, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/es/cepe\"}],\"url\":\"https://pe.pablopl.dev/es/cepe\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Concorrencia e Paralelismo: exámenes y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/cepe\",\"inLanguage\":\"es\",\"description\":\"Practica 76 preguntas de Concorrencia e Paralelismo de 16 exámenes con respuestas modelo y autocorrección. 202320, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/es/cepe\"}],\"url\":\"https://pe.pablopl.dev/es/cepe\"}]}"
   },
   {
     "url": "seo/es/cepe/practice/concurrencia-mutex.html",
@@ -4583,7 +4583,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/cepe/practice/concurrencia-mutex",
     "title": "Mutex y Condiciones: preguntas de Concorrencia e Paralelismo",
-    "description": "Practica 32 preguntas de Mutex y Condiciones de \"exámenes\" anteriores de Concorrencia e Paralelismo, con respuestas modelo y autocorrección. 202320, Universidade da Coruña.",
+    "description": "Practica 32 preguntas de Mutex y Condiciones de exámenes de Concorrencia e Paralelismo, con respuestas modelo y autocorrección. 202320, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/cepe/practice/concurrencia-mutex",
     "ogImage": "https://pe.pablopl.dev/og/cepe.png",
@@ -4607,7 +4607,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/cepe/practice/concurrencia-mutex"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Mutex y Condiciones: preguntas de Concorrencia e Paralelismo\",\"url\":\"https://pe.pablopl.dev/es/cepe/practice/concurrencia-mutex\",\"inLanguage\":\"es\",\"description\":\"Practica 32 preguntas de Mutex y Condiciones de \\\"exámenes\\\" anteriores de Concorrencia e Paralelismo, con respuestas modelo y autocorrección. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Mutex y Condiciones\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/es/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Mutex y Condiciones\",\"item\":\"https://pe.pablopl.dev/es/cepe/practice/concurrencia-mutex\"}],\"url\":\"https://pe.pablopl.dev/es/cepe/practice/concurrencia-mutex\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Mutex y Condiciones: preguntas de Concorrencia e Paralelismo\",\"url\":\"https://pe.pablopl.dev/es/cepe/practice/concurrencia-mutex\",\"inLanguage\":\"es\",\"description\":\"Practica 32 preguntas de Mutex y Condiciones de exámenes de Concorrencia e Paralelismo, con respuestas modelo y autocorrección. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Mutex y Condiciones\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/es/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Mutex y Condiciones\",\"item\":\"https://pe.pablopl.dev/es/cepe/practice/concurrencia-mutex\"}],\"url\":\"https://pe.pablopl.dev/es/cepe/practice/concurrencia-mutex\"}]}"
   },
   {
     "url": "seo/es/cepe/practice/concurrencia-erlang.html",
@@ -4615,7 +4615,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/cepe/practice/concurrencia-erlang",
     "title": "Erlang: preguntas de Concorrencia e Paralelismo",
-    "description": "Practica 12 preguntas de Erlang de \"exámenes\" anteriores de Concorrencia e Paralelismo, con respuestas modelo y autocorrección. 202320, Universidade da Coruña.",
+    "description": "Practica 12 preguntas de Erlang de exámenes de Concorrencia e Paralelismo, con respuestas modelo y autocorrección. 202320, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/cepe/practice/concurrencia-erlang",
     "ogImage": "https://pe.pablopl.dev/og/cepe.png",
@@ -4639,7 +4639,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/cepe/practice/concurrencia-erlang"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Erlang: preguntas de Concorrencia e Paralelismo\",\"url\":\"https://pe.pablopl.dev/es/cepe/practice/concurrencia-erlang\",\"inLanguage\":\"es\",\"description\":\"Practica 12 preguntas de Erlang de \\\"exámenes\\\" anteriores de Concorrencia e Paralelismo, con respuestas modelo y autocorrección. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Erlang\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/es/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Erlang\",\"item\":\"https://pe.pablopl.dev/es/cepe/practice/concurrencia-erlang\"}],\"url\":\"https://pe.pablopl.dev/es/cepe/practice/concurrencia-erlang\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Erlang: preguntas de Concorrencia e Paralelismo\",\"url\":\"https://pe.pablopl.dev/es/cepe/practice/concurrencia-erlang\",\"inLanguage\":\"es\",\"description\":\"Practica 12 preguntas de Erlang de exámenes de Concorrencia e Paralelismo, con respuestas modelo y autocorrección. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Erlang\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/es/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Erlang\",\"item\":\"https://pe.pablopl.dev/es/cepe/practice/concurrencia-erlang\"}],\"url\":\"https://pe.pablopl.dev/es/cepe/practice/concurrencia-erlang\"}]}"
   },
   {
     "url": "seo/es/cepe/practice/paralelismo-teoria.html",
@@ -4647,7 +4647,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/cepe/practice/paralelismo-teoria",
     "title": "Preguntas Teóricas: preguntas de Concorrencia e Paralelismo",
-    "description": "Practica 19 preguntas de Preguntas Teóricas de \"exámenes\" anteriores de Concorrencia e Paralelismo, con respuestas modelo y autocorrección. 202320, Universidade da Coruña.",
+    "description": "Practica 19 preguntas de Preguntas Teóricas de exámenes de Concorrencia e Paralelismo, con respuestas modelo y autocorrección. 202320, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/cepe/practice/paralelismo-teoria",
     "ogImage": "https://pe.pablopl.dev/og/cepe.png",
@@ -4671,7 +4671,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/cepe/practice/paralelismo-teoria"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Preguntas Teóricas: preguntas de Concorrencia e Paralelismo\",\"url\":\"https://pe.pablopl.dev/es/cepe/practice/paralelismo-teoria\",\"inLanguage\":\"es\",\"description\":\"Practica 19 preguntas de Preguntas Teóricas de \\\"exámenes\\\" anteriores de Concorrencia e Paralelismo, con respuestas modelo y autocorrección. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Preguntas Teóricas\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/es/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Preguntas Teóricas\",\"item\":\"https://pe.pablopl.dev/es/cepe/practice/paralelismo-teoria\"}],\"url\":\"https://pe.pablopl.dev/es/cepe/practice/paralelismo-teoria\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Preguntas Teóricas: preguntas de Concorrencia e Paralelismo\",\"url\":\"https://pe.pablopl.dev/es/cepe/practice/paralelismo-teoria\",\"inLanguage\":\"es\",\"description\":\"Practica 19 preguntas de Preguntas Teóricas de exámenes de Concorrencia e Paralelismo, con respuestas modelo y autocorrección. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Preguntas Teóricas\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/es/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Preguntas Teóricas\",\"item\":\"https://pe.pablopl.dev/es/cepe/practice/paralelismo-teoria\"}],\"url\":\"https://pe.pablopl.dev/es/cepe/practice/paralelismo-teoria\"}]}"
   },
   {
     "url": "seo/es/cepe/practice/paralelismo-mpi.html",
@@ -4679,7 +4679,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/cepe/practice/paralelismo-mpi",
     "title": "Ejercicios de MPI: preguntas de Concorrencia e Paralelismo",
-    "description": "Practica 13 preguntas de Ejercicios de MPI de \"exámenes\" anteriores de Concorrencia e Paralelismo, con respuestas modelo y autocorrección. 202320, Universidade da Coruña.",
+    "description": "Practica 13 preguntas de Ejercicios de MPI de exámenes de Concorrencia e Paralelismo, con respuestas modelo y autocorrección. 202320, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/cepe/practice/paralelismo-mpi",
     "ogImage": "https://pe.pablopl.dev/og/cepe.png",
@@ -4703,7 +4703,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/cepe/practice/paralelismo-mpi"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Ejercicios de MPI: preguntas de Concorrencia e Paralelismo\",\"url\":\"https://pe.pablopl.dev/es/cepe/practice/paralelismo-mpi\",\"inLanguage\":\"es\",\"description\":\"Practica 13 preguntas de Ejercicios de MPI de \\\"exámenes\\\" anteriores de Concorrencia e Paralelismo, con respuestas modelo y autocorrección. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Ejercicios de MPI\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/es/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Ejercicios de MPI\",\"item\":\"https://pe.pablopl.dev/es/cepe/practice/paralelismo-mpi\"}],\"url\":\"https://pe.pablopl.dev/es/cepe/practice/paralelismo-mpi\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Ejercicios de MPI: preguntas de Concorrencia e Paralelismo\",\"url\":\"https://pe.pablopl.dev/es/cepe/practice/paralelismo-mpi\",\"inLanguage\":\"es\",\"description\":\"Practica 13 preguntas de Ejercicios de MPI de exámenes de Concorrencia e Paralelismo, con respuestas modelo y autocorrección. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Ejercicios de MPI\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/es/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Ejercicios de MPI\",\"item\":\"https://pe.pablopl.dev/es/cepe/practice/paralelismo-mpi\"}],\"url\":\"https://pe.pablopl.dev/es/cepe/practice/paralelismo-mpi\"}]}"
   },
   {
     "url": "seo/es/cepe/exam/2018-06.html",
@@ -5222,8 +5222,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/deese",
-    "title": "Deseño de Software: \"exámenes\" y preguntas resueltas",
-    "description": "Practica 55 preguntas de Deseño de Software de 2 \"exámenes\" anteriores con respuestas modelo y autocorrección. 202317, Universidade da Coruña.",
+    "title": "Deseño de Software: recopilatorios y preguntas resueltas",
+    "description": "Practica 55 preguntas de Deseño de Software de 2 recopilatorios de práctica con respuestas modelo y autocorrección. 202317, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/deese",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -5247,7 +5247,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Deseño de Software: \\\"exámenes\\\" y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/deese\",\"inLanguage\":\"es\",\"description\":\"Practica 55 preguntas de Deseño de Software de 2 \\\"exámenes\\\" anteriores con respuestas modelo y autocorrección. 202317, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/es/deese\"}],\"url\":\"https://pe.pablopl.dev/es/deese\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Deseño de Software: recopilatorios y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/deese\",\"inLanguage\":\"es\",\"description\":\"Practica 55 preguntas de Deseño de Software de 2 recopilatorios de práctica con respuestas modelo y autocorrección. 202317, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/es/deese\"}],\"url\":\"https://pe.pablopl.dev/es/deese\"}]}"
   },
   {
     "url": "seo/es/deese/practice/intro-y-objetos.html",
@@ -5255,7 +5255,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/deese/practice/intro-y-objetos",
     "title": "Introducción y Elementos Básicos de la OO: preguntas de Deseño de Software",
-    "description": "Practica 12 preguntas de Introducción y Elementos Básicos de la OO de \"exámenes\" anteriores de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.",
+    "description": "Practica 12 preguntas de Introducción y Elementos Básicos de la OO de recopilatorios de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/deese/practice/intro-y-objetos",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -5279,7 +5279,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/practice/intro-y-objetos"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Introducción y Elementos Básicos de la OO: preguntas de Deseño de Software\",\"url\":\"https://pe.pablopl.dev/es/deese/practice/intro-y-objetos\",\"inLanguage\":\"es\",\"description\":\"Practica 12 preguntas de Introducción y Elementos Básicos de la OO de \\\"exámenes\\\" anteriores de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Introducción y Elementos Básicos de la OO\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/es/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Introducción y Elementos Básicos de la OO\",\"item\":\"https://pe.pablopl.dev/es/deese/practice/intro-y-objetos\"}],\"url\":\"https://pe.pablopl.dev/es/deese/practice/intro-y-objetos\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Introducción y Elementos Básicos de la OO: preguntas de Deseño de Software\",\"url\":\"https://pe.pablopl.dev/es/deese/practice/intro-y-objetos\",\"inLanguage\":\"es\",\"description\":\"Practica 12 preguntas de Introducción y Elementos Básicos de la OO de recopilatorios de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Introducción y Elementos Básicos de la OO\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/es/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Introducción y Elementos Básicos de la OO\",\"item\":\"https://pe.pablopl.dev/es/deese/practice/intro-y-objetos\"}],\"url\":\"https://pe.pablopl.dev/es/deese/practice/intro-y-objetos\"}]}"
   },
   {
     "url": "seo/es/deese/practice/propiedades-oo.html",
@@ -5287,7 +5287,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/deese/practice/propiedades-oo",
     "title": "Propiedades Básicas de la OO: preguntas de Deseño de Software",
-    "description": "Practica 11 preguntas de Propiedades Básicas de la OO de \"exámenes\" anteriores de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.",
+    "description": "Practica 11 preguntas de Propiedades Básicas de la OO de recopilatorios de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/deese/practice/propiedades-oo",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -5311,7 +5311,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/practice/propiedades-oo"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Propiedades Básicas de la OO: preguntas de Deseño de Software\",\"url\":\"https://pe.pablopl.dev/es/deese/practice/propiedades-oo\",\"inLanguage\":\"es\",\"description\":\"Practica 11 preguntas de Propiedades Básicas de la OO de \\\"exámenes\\\" anteriores de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Propiedades Básicas de la OO\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/es/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Propiedades Básicas de la OO\",\"item\":\"https://pe.pablopl.dev/es/deese/practice/propiedades-oo\"}],\"url\":\"https://pe.pablopl.dev/es/deese/practice/propiedades-oo\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Propiedades Básicas de la OO: preguntas de Deseño de Software\",\"url\":\"https://pe.pablopl.dev/es/deese/practice/propiedades-oo\",\"inLanguage\":\"es\",\"description\":\"Practica 11 preguntas de Propiedades Básicas de la OO de recopilatorios de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Propiedades Básicas de la OO\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/es/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Propiedades Básicas de la OO\",\"item\":\"https://pe.pablopl.dev/es/deese/practice/propiedades-oo\"}],\"url\":\"https://pe.pablopl.dev/es/deese/practice/propiedades-oo\"}]}"
   },
   {
     "url": "seo/es/deese/practice/uml.html",
@@ -5319,7 +5319,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/deese/practice/uml",
     "title": "UML: preguntas de Deseño de Software | Pásame Exámenes",
-    "description": "Practica 10 preguntas de UML de \"exámenes\" anteriores de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.",
+    "description": "Practica 10 preguntas de UML de recopilatorios de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/deese/practice/uml",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -5343,7 +5343,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/practice/uml"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"UML: preguntas de Deseño de Software | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/deese/practice/uml\",\"inLanguage\":\"es\",\"description\":\"Practica 10 preguntas de UML de \\\"exámenes\\\" anteriores de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"UML\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/es/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"UML\",\"item\":\"https://pe.pablopl.dev/es/deese/practice/uml\"}],\"url\":\"https://pe.pablopl.dev/es/deese/practice/uml\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"UML: preguntas de Deseño de Software | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/deese/practice/uml\",\"inLanguage\":\"es\",\"description\":\"Practica 10 preguntas de UML de recopilatorios de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"UML\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/es/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"UML\",\"item\":\"https://pe.pablopl.dev/es/deese/practice/uml\"}],\"url\":\"https://pe.pablopl.dev/es/deese/practice/uml\"}]}"
   },
   {
     "url": "seo/es/deese/practice/principios-diseno.html",
@@ -5351,7 +5351,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/deese/practice/principios-diseno",
     "title": "Principios de Diseño: preguntas de Deseño de Software",
-    "description": "Practica 12 preguntas de Principios de Diseño de \"exámenes\" anteriores de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.",
+    "description": "Practica 12 preguntas de Principios de Diseño de recopilatorios de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/deese/practice/principios-diseno",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -5375,7 +5375,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/practice/principios-diseno"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Principios de Diseño: preguntas de Deseño de Software\",\"url\":\"https://pe.pablopl.dev/es/deese/practice/principios-diseno\",\"inLanguage\":\"es\",\"description\":\"Practica 12 preguntas de Principios de Diseño de \\\"exámenes\\\" anteriores de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Principios de Diseño\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/es/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Principios de Diseño\",\"item\":\"https://pe.pablopl.dev/es/deese/practice/principios-diseno\"}],\"url\":\"https://pe.pablopl.dev/es/deese/practice/principios-diseno\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Principios de Diseño: preguntas de Deseño de Software\",\"url\":\"https://pe.pablopl.dev/es/deese/practice/principios-diseno\",\"inLanguage\":\"es\",\"description\":\"Practica 12 preguntas de Principios de Diseño de recopilatorios de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Principios de Diseño\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/es/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Principios de Diseño\",\"item\":\"https://pe.pablopl.dev/es/deese/practice/principios-diseno\"}],\"url\":\"https://pe.pablopl.dev/es/deese/practice/principios-diseno\"}]}"
   },
   {
     "url": "seo/es/deese/practice/patrones-diseno.html",
@@ -5383,7 +5383,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/deese/practice/patrones-diseno",
     "title": "Patrones de Diseño: preguntas de Deseño de Software",
-    "description": "Practica 10 preguntas de Patrones de Diseño de \"exámenes\" anteriores de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.",
+    "description": "Practica 10 preguntas de Patrones de Diseño de recopilatorios de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/deese/practice/patrones-diseno",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -5407,15 +5407,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/practice/patrones-diseno"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Patrones de Diseño: preguntas de Deseño de Software\",\"url\":\"https://pe.pablopl.dev/es/deese/practice/patrones-diseno\",\"inLanguage\":\"es\",\"description\":\"Practica 10 preguntas de Patrones de Diseño de \\\"exámenes\\\" anteriores de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Patrones de Diseño\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/es/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Patrones de Diseño\",\"item\":\"https://pe.pablopl.dev/es/deese/practice/patrones-diseno\"}],\"url\":\"https://pe.pablopl.dev/es/deese/practice/patrones-diseno\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Patrones de Diseño: preguntas de Deseño de Software\",\"url\":\"https://pe.pablopl.dev/es/deese/practice/patrones-diseno\",\"inLanguage\":\"es\",\"description\":\"Practica 10 preguntas de Patrones de Diseño de recopilatorios de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Patrones de Diseño\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/es/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Patrones de Diseño\",\"item\":\"https://pe.pablopl.dev/es/deese/practice/patrones-diseno\"}],\"url\":\"https://pe.pablopl.dev/es/deese/practice/patrones-diseno\"}]}"
   },
   {
     "url": "seo/es/deese/exam/2020-01.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/deese/exam/2020-01",
-    "title": "Posibles preguntas Enero 2020 de Deseño de Software: simulador",
-    "description": "Simula el examen Posibles preguntas Enero 2020 de Deseño de Software con 30 preguntas. 30 puntos, 150 minutos, respuestas modelo y autocorrección.",
+    "title": "Posibles preguntas Enero 2020 de Deseño de Software: práctica cronometrada",
+    "description": "Practica el recopilatorio cronometrado Posibles preguntas Enero 2020 de Deseño de Software con 30 preguntas. 30 puntos, 150 minutos, respuestas modelo y autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/deese/exam/2020-01",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -5439,15 +5439,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/exam/2020-01"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Enero 2020 de Deseño de Software: simulador\",\"url\":\"https://pe.pablopl.dev/es/deese/exam/2020-01\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Posibles preguntas Enero 2020 de Deseño de Software con 30 preguntas. 30 puntos, 150 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/es/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Enero 2020\",\"item\":\"https://pe.pablopl.dev/es/deese/exam/2020-01\"}],\"url\":\"https://pe.pablopl.dev/es/deese/exam/2020-01\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Enero 2020 de Deseño de Software: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/es/deese/exam/2020-01\",\"inLanguage\":\"es\",\"description\":\"Practica el recopilatorio cronometrado Posibles preguntas Enero 2020 de Deseño de Software con 30 preguntas. 30 puntos, 150 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/es/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Enero 2020\",\"item\":\"https://pe.pablopl.dev/es/deese/exam/2020-01\"}],\"url\":\"https://pe.pablopl.dev/es/deese/exam/2020-01\"}]}"
   },
   {
     "url": "seo/es/deese/exam/2022-01.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/deese/exam/2022-01",
-    "title": "Posibles preguntas Enero 2022 de Deseño de Software: simulador",
-    "description": "Simula el examen Posibles preguntas Enero 2022 de Deseño de Software con 25 preguntas. 25 puntos, 150 minutos, respuestas modelo y autocorrección.",
+    "title": "Posibles preguntas Enero 2022 de Deseño de Software: práctica cronometrada",
+    "description": "Practica el recopilatorio cronometrado Posibles preguntas Enero 2022 de Deseño de Software con 25 preguntas. 25 puntos, 150 minutos, respuestas modelo y autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/deese/exam/2022-01",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -5471,15 +5471,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/exam/2022-01"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Enero 2022 de Deseño de Software: simulador\",\"url\":\"https://pe.pablopl.dev/es/deese/exam/2022-01\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Posibles preguntas Enero 2022 de Deseño de Software con 25 preguntas. 25 puntos, 150 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/es/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Enero 2022\",\"item\":\"https://pe.pablopl.dev/es/deese/exam/2022-01\"}],\"url\":\"https://pe.pablopl.dev/es/deese/exam/2022-01\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Enero 2022 de Deseño de Software: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/es/deese/exam/2022-01\",\"inLanguage\":\"es\",\"description\":\"Practica el recopilatorio cronometrado Posibles preguntas Enero 2022 de Deseño de Software con 25 preguntas. 25 puntos, 150 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/es/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Enero 2022\",\"item\":\"https://pe.pablopl.dev/es/deese/exam/2022-01\"}],\"url\":\"https://pe.pablopl.dev/es/deese/exam/2022-01\"}]}"
   },
   {
     "url": "seo/es/ece.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/ece",
-    "title": "Estrutura de Computadores: \"exámenes\" y preguntas resueltas",
-    "description": "Practica 51 preguntas de Estrutura de Computadores de 11 \"exámenes\" anteriores con respuestas modelo y autocorrección. 202314, Universidade da Coruña.",
+    "title": "Estrutura de Computadores: exámenes y preguntas resueltas",
+    "description": "Practica 51 preguntas de Estrutura de Computadores de 11 exámenes con respuestas modelo y autocorrección. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/ece",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -5503,7 +5503,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Estrutura de Computadores: \\\"exámenes\\\" y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/ece\",\"inLanguage\":\"es\",\"description\":\"Practica 51 preguntas de Estrutura de Computadores de 11 \\\"exámenes\\\" anteriores con respuestas modelo y autocorrección. 202314, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/es/ece\"}],\"url\":\"https://pe.pablopl.dev/es/ece\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Estrutura de Computadores: exámenes y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/ece\",\"inLanguage\":\"es\",\"description\":\"Practica 51 preguntas de Estrutura de Computadores de 11 exámenes con respuestas modelo y autocorrección. 202314, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/es/ece\"}],\"url\":\"https://pe.pablopl.dev/es/ece\"}]}"
   },
   {
     "url": "seo/es/ece/practice/rendimiento.html",
@@ -5511,7 +5511,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/ece/practice/rendimiento",
     "title": "Rendimiento: preguntas de Estrutura de Computadores",
-    "description": "Practica 7 preguntas de Rendimiento de \"exámenes\" anteriores de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.",
+    "description": "Practica 7 preguntas de Rendimiento de exámenes de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/ece/practice/rendimiento",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -5535,7 +5535,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece/practice/rendimiento"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Rendimiento: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/es/ece/practice/rendimiento\",\"inLanguage\":\"es\",\"description\":\"Practica 7 preguntas de Rendimiento de \\\"exámenes\\\" anteriores de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Rendimiento\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/es/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Rendimiento\",\"item\":\"https://pe.pablopl.dev/es/ece/practice/rendimiento\"}],\"url\":\"https://pe.pablopl.dev/es/ece/practice/rendimiento\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Rendimiento: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/es/ece/practice/rendimiento\",\"inLanguage\":\"es\",\"description\":\"Practica 7 preguntas de Rendimiento de exámenes de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Rendimiento\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/es/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Rendimiento\",\"item\":\"https://pe.pablopl.dev/es/ece/practice/rendimiento\"}],\"url\":\"https://pe.pablopl.dev/es/ece/practice/rendimiento\"}]}"
   },
   {
     "url": "seo/es/ece/practice/segmentacion.html",
@@ -5543,7 +5543,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/ece/practice/segmentacion",
     "title": "Segmentación: preguntas de Estrutura de Computadores",
-    "description": "Practica 7 preguntas de Segmentación de \"exámenes\" anteriores de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.",
+    "description": "Practica 7 preguntas de Segmentación de exámenes de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/ece/practice/segmentacion",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -5567,7 +5567,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece/practice/segmentacion"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Segmentación: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/es/ece/practice/segmentacion\",\"inLanguage\":\"es\",\"description\":\"Practica 7 preguntas de Segmentación de \\\"exámenes\\\" anteriores de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Segmentación\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/es/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Segmentación\",\"item\":\"https://pe.pablopl.dev/es/ece/practice/segmentacion\"}],\"url\":\"https://pe.pablopl.dev/es/ece/practice/segmentacion\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Segmentación: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/es/ece/practice/segmentacion\",\"inLanguage\":\"es\",\"description\":\"Practica 7 preguntas de Segmentación de exámenes de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Segmentación\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/es/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Segmentación\",\"item\":\"https://pe.pablopl.dev/es/ece/practice/segmentacion\"}],\"url\":\"https://pe.pablopl.dev/es/ece/practice/segmentacion\"}]}"
   },
   {
     "url": "seo/es/ece/practice/cache.html",
@@ -5575,7 +5575,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/ece/practice/cache",
     "title": "Memoria caché: preguntas de Estrutura de Computadores",
-    "description": "Practica 7 preguntas de Memoria caché de \"exámenes\" anteriores de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.",
+    "description": "Practica 7 preguntas de Memoria caché de exámenes de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/ece/practice/cache",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -5599,7 +5599,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece/practice/cache"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Memoria caché: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/es/ece/practice/cache\",\"inLanguage\":\"es\",\"description\":\"Practica 7 preguntas de Memoria caché de \\\"exámenes\\\" anteriores de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Memoria caché\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/es/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Memoria caché\",\"item\":\"https://pe.pablopl.dev/es/ece/practice/cache\"}],\"url\":\"https://pe.pablopl.dev/es/ece/practice/cache\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Memoria caché: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/es/ece/practice/cache\",\"inLanguage\":\"es\",\"description\":\"Practica 7 preguntas de Memoria caché de exámenes de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Memoria caché\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/es/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Memoria caché\",\"item\":\"https://pe.pablopl.dev/es/ece/practice/cache\"}],\"url\":\"https://pe.pablopl.dev/es/ece/practice/cache\"}]}"
   },
   {
     "url": "seo/es/ece/practice/memoria-virtual.html",
@@ -5607,7 +5607,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/ece/practice/memoria-virtual",
     "title": "Memoria virtual: preguntas de Estrutura de Computadores",
-    "description": "Practica 11 preguntas de Memoria virtual de \"exámenes\" anteriores de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.",
+    "description": "Practica 11 preguntas de Memoria virtual de exámenes de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/ece/practice/memoria-virtual",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -5631,7 +5631,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece/practice/memoria-virtual"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Memoria virtual: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/es/ece/practice/memoria-virtual\",\"inLanguage\":\"es\",\"description\":\"Practica 11 preguntas de Memoria virtual de \\\"exámenes\\\" anteriores de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Memoria virtual\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/es/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Memoria virtual\",\"item\":\"https://pe.pablopl.dev/es/ece/practice/memoria-virtual\"}],\"url\":\"https://pe.pablopl.dev/es/ece/practice/memoria-virtual\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Memoria virtual: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/es/ece/practice/memoria-virtual\",\"inLanguage\":\"es\",\"description\":\"Practica 11 preguntas de Memoria virtual de exámenes de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Memoria virtual\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/es/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Memoria virtual\",\"item\":\"https://pe.pablopl.dev/es/ece/practice/memoria-virtual\"}],\"url\":\"https://pe.pablopl.dev/es/ece/practice/memoria-virtual\"}]}"
   },
   {
     "url": "seo/es/ece/practice/buses.html",
@@ -5639,7 +5639,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/ece/practice/buses",
     "title": "Buses y E/S: preguntas de Estrutura de Computadores",
-    "description": "Practica 11 preguntas de Buses y E/S de \"exámenes\" anteriores de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.",
+    "description": "Practica 11 preguntas de Buses y E/S de exámenes de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/ece/practice/buses",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -5663,7 +5663,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece/practice/buses"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Buses y E/S: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/es/ece/practice/buses\",\"inLanguage\":\"es\",\"description\":\"Practica 11 preguntas de Buses y E/S de \\\"exámenes\\\" anteriores de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Buses y E/S\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/es/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Buses y E/S\",\"item\":\"https://pe.pablopl.dev/es/ece/practice/buses\"}],\"url\":\"https://pe.pablopl.dev/es/ece/practice/buses\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Buses y E/S: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/es/ece/practice/buses\",\"inLanguage\":\"es\",\"description\":\"Practica 11 preguntas de Buses y E/S de exámenes de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Buses y E/S\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/es/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Buses y E/S\",\"item\":\"https://pe.pablopl.dev/es/ece/practice/buses\"}],\"url\":\"https://pe.pablopl.dev/es/ece/practice/buses\"}]}"
   },
   {
     "url": "seo/es/ece/practice/raid.html",
@@ -5671,7 +5671,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/ece/practice/raid",
     "title": "RAID y almacenamiento: preguntas de Estrutura de Computadores",
-    "description": "Practica 8 preguntas de RAID y almacenamiento de \"exámenes\" anteriores de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.",
+    "description": "Practica 8 preguntas de RAID y almacenamiento de exámenes de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/ece/practice/raid",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -5695,7 +5695,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece/practice/raid"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"RAID y almacenamiento: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/es/ece/practice/raid\",\"inLanguage\":\"es\",\"description\":\"Practica 8 preguntas de RAID y almacenamiento de \\\"exámenes\\\" anteriores de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"RAID y almacenamiento\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/es/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"RAID y almacenamiento\",\"item\":\"https://pe.pablopl.dev/es/ece/practice/raid\"}],\"url\":\"https://pe.pablopl.dev/es/ece/practice/raid\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"RAID y almacenamiento: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/es/ece/practice/raid\",\"inLanguage\":\"es\",\"description\":\"Practica 8 preguntas de RAID y almacenamiento de exámenes de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"RAID y almacenamiento\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/es/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"RAID y almacenamiento\",\"item\":\"https://pe.pablopl.dev/es/ece/practice/raid\"}],\"url\":\"https://pe.pablopl.dev/es/ece/practice/raid\"}]}"
   },
   {
     "url": "seo/es/ece/exam/2021-01.html",
@@ -6054,8 +6054,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/emeele",
-    "title": "Introduction to Machine Learning: \"exámenes\" y preguntas resueltas",
-    "description": "Practica 47 preguntas de Introduction to Machine Learning de 2 \"exámenes\" anteriores con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
+    "title": "Introduction to Machine Learning: exámenes y preguntas resueltas",
+    "description": "Practica 47 preguntas de Introduction to Machine Learning de 2 exámenes con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/emeele",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -6079,7 +6079,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Introduction to Machine Learning: \\\"exámenes\\\" y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/emeele\",\"inLanguage\":\"es\",\"description\":\"Practica 47 preguntas de Introduction to Machine Learning de 2 \\\"exámenes\\\" anteriores con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Linnaeus University\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"}],\"url\":\"https://pe.pablopl.dev/es/emeele\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Introduction to Machine Learning: exámenes y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/emeele\",\"inLanguage\":\"es\",\"description\":\"Practica 47 preguntas de Introduction to Machine Learning de 2 exámenes con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Linnaeus University\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"}],\"url\":\"https://pe.pablopl.dev/es/emeele\"}]}"
   },
   {
     "url": "seo/es/emeele/practice/kNN.html",
@@ -6087,7 +6087,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/emeele/practice/kNN",
     "title": "k-Nearest Neighbors: preguntas de Introduction to Machine Learning",
-    "description": "Practica 6 preguntas de k-Nearest Neighbors de \"exámenes\" anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
+    "description": "Practica 6 preguntas de k-Nearest Neighbors de exámenes de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/emeele/practice/kNN",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -6111,7 +6111,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/kNN"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"k-Nearest Neighbors: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/es/emeele/practice/kNN\",\"inLanguage\":\"es\",\"description\":\"Practica 6 preguntas de k-Nearest Neighbors de \\\"exámenes\\\" anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"k-Nearest Neighbors\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"k-Nearest Neighbors\",\"item\":\"https://pe.pablopl.dev/es/emeele/practice/kNN\"}],\"url\":\"https://pe.pablopl.dev/es/emeele/practice/kNN\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"k-Nearest Neighbors: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/es/emeele/practice/kNN\",\"inLanguage\":\"es\",\"description\":\"Practica 6 preguntas de k-Nearest Neighbors de exámenes de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"k-Nearest Neighbors\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"k-Nearest Neighbors\",\"item\":\"https://pe.pablopl.dev/es/emeele/practice/kNN\"}],\"url\":\"https://pe.pablopl.dev/es/emeele/practice/kNN\"}]}"
   },
   {
     "url": "seo/es/emeele/practice/Bias-Variance.html",
@@ -6119,7 +6119,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/emeele/practice/Bias-Variance",
     "title": "Bias-Variance Tradeoff: preguntas de Introduction to Machine Learning",
-    "description": "Practica 5 preguntas de Bias-Variance Tradeoff de \"exámenes\" anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
+    "description": "Practica 5 preguntas de Bias-Variance Tradeoff de exámenes de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/emeele/practice/Bias-Variance",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -6143,7 +6143,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Bias-Variance"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Bias-Variance Tradeoff: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Bias-Variance\",\"inLanguage\":\"es\",\"description\":\"Practica 5 preguntas de Bias-Variance Tradeoff de \\\"exámenes\\\" anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Bias-Variance Tradeoff\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Bias-Variance Tradeoff\",\"item\":\"https://pe.pablopl.dev/es/emeele/practice/Bias-Variance\"}],\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Bias-Variance\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Bias-Variance Tradeoff: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Bias-Variance\",\"inLanguage\":\"es\",\"description\":\"Practica 5 preguntas de Bias-Variance Tradeoff de exámenes de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Bias-Variance Tradeoff\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Bias-Variance Tradeoff\",\"item\":\"https://pe.pablopl.dev/es/emeele/practice/Bias-Variance\"}],\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Bias-Variance\"}]}"
   },
   {
     "url": "seo/es/emeele/practice/Linear%20%26%20Logistic%20Regression.html",
@@ -6151,7 +6151,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/emeele/practice/Linear & Logistic Regression",
     "title": "Linear & Logistic Regression: preguntas de Introduction to Machine Learning",
-    "description": "Practica 5 preguntas de Linear & Logistic Regression de \"exámenes\" anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
+    "description": "Practica 5 preguntas de Linear & Logistic Regression de exámenes de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/emeele/practice/Linear%20%26%20Logistic%20Regression",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -6175,7 +6175,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Linear%20%26%20Logistic%20Regression"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Linear & Logistic Regression: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Linear%20%26%20Logistic%20Regression\",\"inLanguage\":\"es\",\"description\":\"Practica 5 preguntas de Linear & Logistic Regression de \\\"exámenes\\\" anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Linear & Logistic Regression\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Linear & Logistic Regression\",\"item\":\"https://pe.pablopl.dev/es/emeele/practice/Linear%20%26%20Logistic%20Regression\"}],\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Linear%20%26%20Logistic%20Regression\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Linear & Logistic Regression: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Linear%20%26%20Logistic%20Regression\",\"inLanguage\":\"es\",\"description\":\"Practica 5 preguntas de Linear & Logistic Regression de exámenes de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Linear & Logistic Regression\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Linear & Logistic Regression\",\"item\":\"https://pe.pablopl.dev/es/emeele/practice/Linear%20%26%20Logistic%20Regression\"}],\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Linear%20%26%20Logistic%20Regression\"}]}"
   },
   {
     "url": "seo/es/emeele/practice/Model%20Selection%20%26%20Regularization.html",
@@ -6183,7 +6183,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/emeele/practice/Model Selection & Regularization",
     "title": "Model Selection & Regularization: preguntas de Introduction to Machine Learning",
-    "description": "Practica 5 preguntas de Model Selection & Regularization de \"exámenes\" anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
+    "description": "Practica 5 preguntas de Model Selection & Regularization de exámenes de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/emeele/practice/Model%20Selection%20%26%20Regularization",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -6207,7 +6207,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Model%20Selection%20%26%20Regularization"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Model Selection & Regularization: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Model%20Selection%20%26%20Regularization\",\"inLanguage\":\"es\",\"description\":\"Practica 5 preguntas de Model Selection & Regularization de \\\"exámenes\\\" anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Model Selection & Regularization\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Model Selection & Regularization\",\"item\":\"https://pe.pablopl.dev/es/emeele/practice/Model%20Selection%20%26%20Regularization\"}],\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Model%20Selection%20%26%20Regularization\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Model Selection & Regularization: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Model%20Selection%20%26%20Regularization\",\"inLanguage\":\"es\",\"description\":\"Practica 5 preguntas de Model Selection & Regularization de exámenes de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Model Selection & Regularization\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Model Selection & Regularization\",\"item\":\"https://pe.pablopl.dev/es/emeele/practice/Model%20Selection%20%26%20Regularization\"}],\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Model%20Selection%20%26%20Regularization\"}]}"
   },
   {
     "url": "seo/es/emeele/practice/Neural%20Networks.html",
@@ -6215,7 +6215,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/emeele/practice/Neural Networks",
     "title": "Neural Networks: preguntas de Introduction to Machine Learning",
-    "description": "Practica 6 preguntas de Neural Networks de \"exámenes\" anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
+    "description": "Practica 6 preguntas de Neural Networks de exámenes de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/emeele/practice/Neural%20Networks",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -6239,7 +6239,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Neural%20Networks"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Neural Networks: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Neural%20Networks\",\"inLanguage\":\"es\",\"description\":\"Practica 6 preguntas de Neural Networks de \\\"exámenes\\\" anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Neural Networks\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Neural Networks\",\"item\":\"https://pe.pablopl.dev/es/emeele/practice/Neural%20Networks\"}],\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Neural%20Networks\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Neural Networks: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Neural%20Networks\",\"inLanguage\":\"es\",\"description\":\"Practica 6 preguntas de Neural Networks de exámenes de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Neural Networks\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Neural Networks\",\"item\":\"https://pe.pablopl.dev/es/emeele/practice/Neural%20Networks\"}],\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Neural%20Networks\"}]}"
   },
   {
     "url": "seo/es/emeele/practice/Decision%20Trees%20%26%20Ensembles.html",
@@ -6247,7 +6247,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/emeele/practice/Decision Trees & Ensembles",
     "title": "Decision Trees & Ensembles: preguntas de Introduction to Machine Learning",
-    "description": "Practica 4 preguntas de Decision Trees & Ensembles de \"exámenes\" anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
+    "description": "Practica 4 preguntas de Decision Trees & Ensembles de exámenes de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/emeele/practice/Decision%20Trees%20%26%20Ensembles",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -6271,7 +6271,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Decision%20Trees%20%26%20Ensembles"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Decision Trees & Ensembles: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Decision%20Trees%20%26%20Ensembles\",\"inLanguage\":\"es\",\"description\":\"Practica 4 preguntas de Decision Trees & Ensembles de \\\"exámenes\\\" anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Decision Trees & Ensembles\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Decision Trees & Ensembles\",\"item\":\"https://pe.pablopl.dev/es/emeele/practice/Decision%20Trees%20%26%20Ensembles\"}],\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Decision%20Trees%20%26%20Ensembles\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Decision Trees & Ensembles: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Decision%20Trees%20%26%20Ensembles\",\"inLanguage\":\"es\",\"description\":\"Practica 4 preguntas de Decision Trees & Ensembles de exámenes de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Decision Trees & Ensembles\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Decision Trees & Ensembles\",\"item\":\"https://pe.pablopl.dev/es/emeele/practice/Decision%20Trees%20%26%20Ensembles\"}],\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Decision%20Trees%20%26%20Ensembles\"}]}"
   },
   {
     "url": "seo/es/emeele/practice/Support%20Vector%20Machines.html",
@@ -6279,7 +6279,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/emeele/practice/Support Vector Machines",
     "title": "Support Vector Machines: preguntas de Introduction to Machine Learning",
-    "description": "Practica 6 preguntas de Support Vector Machines de \"exámenes\" anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
+    "description": "Practica 6 preguntas de Support Vector Machines de exámenes de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/emeele/practice/Support%20Vector%20Machines",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -6303,7 +6303,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Support%20Vector%20Machines"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Support Vector Machines: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Support%20Vector%20Machines\",\"inLanguage\":\"es\",\"description\":\"Practica 6 preguntas de Support Vector Machines de \\\"exámenes\\\" anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Support Vector Machines\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Support Vector Machines\",\"item\":\"https://pe.pablopl.dev/es/emeele/practice/Support%20Vector%20Machines\"}],\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Support%20Vector%20Machines\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Support Vector Machines: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Support%20Vector%20Machines\",\"inLanguage\":\"es\",\"description\":\"Practica 6 preguntas de Support Vector Machines de exámenes de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Support Vector Machines\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Support Vector Machines\",\"item\":\"https://pe.pablopl.dev/es/emeele/practice/Support%20Vector%20Machines\"}],\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Support%20Vector%20Machines\"}]}"
   },
   {
     "url": "seo/es/emeele/practice/Clustering.html",
@@ -6311,7 +6311,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/emeele/practice/Clustering",
     "title": "Clustering: preguntas de Introduction to Machine Learning",
-    "description": "Practica 6 preguntas de Clustering de \"exámenes\" anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
+    "description": "Practica 6 preguntas de Clustering de exámenes de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/emeele/practice/Clustering",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -6335,7 +6335,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Clustering"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Clustering: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Clustering\",\"inLanguage\":\"es\",\"description\":\"Practica 6 preguntas de Clustering de \\\"exámenes\\\" anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Clustering\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Clustering\",\"item\":\"https://pe.pablopl.dev/es/emeele/practice/Clustering\"}],\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Clustering\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Clustering: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Clustering\",\"inLanguage\":\"es\",\"description\":\"Practica 6 preguntas de Clustering de exámenes de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Clustering\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Clustering\",\"item\":\"https://pe.pablopl.dev/es/emeele/practice/Clustering\"}],\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Clustering\"}]}"
   },
   {
     "url": "seo/es/emeele/practice/Dimensionality%20Reduction.html",
@@ -6343,7 +6343,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/emeele/practice/Dimensionality Reduction",
     "title": "Dimensionality Reduction: preguntas de Introduction to Machine Learning",
-    "description": "Practica 4 preguntas de Dimensionality Reduction de \"exámenes\" anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
+    "description": "Practica 4 preguntas de Dimensionality Reduction de exámenes de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/emeele/practice/Dimensionality%20Reduction",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -6367,7 +6367,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Dimensionality%20Reduction"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Dimensionality Reduction: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Dimensionality%20Reduction\",\"inLanguage\":\"es\",\"description\":\"Practica 4 preguntas de Dimensionality Reduction de \\\"exámenes\\\" anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Dimensionality Reduction\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Dimensionality Reduction\",\"item\":\"https://pe.pablopl.dev/es/emeele/practice/Dimensionality%20Reduction\"}],\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Dimensionality%20Reduction\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Dimensionality Reduction: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Dimensionality%20Reduction\",\"inLanguage\":\"es\",\"description\":\"Practica 4 preguntas de Dimensionality Reduction de exámenes de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Dimensionality Reduction\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Dimensionality Reduction\",\"item\":\"https://pe.pablopl.dev/es/emeele/practice/Dimensionality%20Reduction\"}],\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Dimensionality%20Reduction\"}]}"
   },
   {
     "url": "seo/es/emeele/exam/2024.html",
@@ -6438,8 +6438,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/equisi",
-    "title": "Xestión de Infraestruturas: \"exámenes\" y preguntas resueltas",
-    "description": "Practica 381 preguntas de Xestión de Infraestruturas de 4 \"exámenes\" anteriores con respuestas modelo y autocorrección. 200190, Universidade da Coruña.",
+    "title": "Xestión de Infraestruturas: recopilatorios y preguntas resueltas",
+    "description": "Practica 381 preguntas de Xestión de Infraestruturas de 4 recopilatorios de práctica con respuestas modelo y autocorrección. 200190, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/equisi",
     "ogImage": "https://pe.pablopl.dev/og/equisi.png",
@@ -6463,7 +6463,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equisi"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Xestión de Infraestruturas: \\\"exámenes\\\" y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/equisi\",\"inLanguage\":\"es\",\"description\":\"Practica 381 preguntas de Xestión de Infraestruturas de 4 \\\"exámenes\\\" anteriores con respuestas modelo y autocorrección. 200190, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/es/equisi\"}],\"url\":\"https://pe.pablopl.dev/es/equisi\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Xestión de Infraestruturas: recopilatorios y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/equisi\",\"inLanguage\":\"es\",\"description\":\"Practica 381 preguntas de Xestión de Infraestruturas de 4 recopilatorios de práctica con respuestas modelo y autocorrección. 200190, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/es/equisi\"}],\"url\":\"https://pe.pablopl.dev/es/equisi\"}]}"
   },
   {
     "url": "seo/es/equisi/practice/modulo-i.html",
@@ -6471,7 +6471,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/equisi/practice/modulo-i",
     "title": "Módulo I: Sinais e Comunicacións: preguntas de Xestión de Infraestruturas",
-    "description": "Practica 130 preguntas de Módulo I: Sinais e Comunicacións de \"exámenes\" anteriores de Xestión de Infraestruturas, con respuestas modelo y autocorrección. 200190, Universidade da Coruña.",
+    "description": "Practica 130 preguntas de Módulo I: Sinais e Comunicacións de recopilatorios de Xestión de Infraestruturas, con respuestas modelo y autocorrección. 200190, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/equisi/practice/modulo-i",
     "ogImage": "https://pe.pablopl.dev/og/equisi.png",
@@ -6495,7 +6495,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equisi/practice/modulo-i"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Módulo I: Sinais e Comunicacións: preguntas de Xestión de Infraestruturas\",\"url\":\"https://pe.pablopl.dev/es/equisi/practice/modulo-i\",\"inLanguage\":\"es\",\"description\":\"Practica 130 preguntas de Módulo I: Sinais e Comunicacións de \\\"exámenes\\\" anteriores de Xestión de Infraestruturas, con respuestas modelo y autocorrección. 200190, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Módulo I: Sinais e Comunicacións\"},{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/es/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Módulo I: Sinais e Comunicacións\",\"item\":\"https://pe.pablopl.dev/es/equisi/practice/modulo-i\"}],\"url\":\"https://pe.pablopl.dev/es/equisi/practice/modulo-i\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Módulo I: Sinais e Comunicacións: preguntas de Xestión de Infraestruturas\",\"url\":\"https://pe.pablopl.dev/es/equisi/practice/modulo-i\",\"inLanguage\":\"es\",\"description\":\"Practica 130 preguntas de Módulo I: Sinais e Comunicacións de recopilatorios de Xestión de Infraestruturas, con respuestas modelo y autocorrección. 200190, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Módulo I: Sinais e Comunicacións\"},{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/es/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Módulo I: Sinais e Comunicacións\",\"item\":\"https://pe.pablopl.dev/es/equisi/practice/modulo-i\"}],\"url\":\"https://pe.pablopl.dev/es/equisi/practice/modulo-i\"}]}"
   },
   {
     "url": "seo/es/equisi/practice/modulo-ii.html",
@@ -6503,7 +6503,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/equisi/practice/modulo-ii",
     "title": "Módulo II: Infraestruturas TI: preguntas de Xestión de Infraestruturas",
-    "description": "Practica 251 preguntas de Módulo II: Infraestruturas TI de \"exámenes\" anteriores de Xestión de Infraestruturas, con respuestas modelo y autocorrección. 200190, Universidade da Coruña.",
+    "description": "Practica 251 preguntas de Módulo II: Infraestruturas TI de recopilatorios de Xestión de Infraestruturas, con respuestas modelo y autocorrección. 200190, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/equisi/practice/modulo-ii",
     "ogImage": "https://pe.pablopl.dev/og/equisi.png",
@@ -6527,15 +6527,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equisi/practice/modulo-ii"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Módulo II: Infraestruturas TI: preguntas de Xestión de Infraestruturas\",\"url\":\"https://pe.pablopl.dev/es/equisi/practice/modulo-ii\",\"inLanguage\":\"es\",\"description\":\"Practica 251 preguntas de Módulo II: Infraestruturas TI de \\\"exámenes\\\" anteriores de Xestión de Infraestruturas, con respuestas modelo y autocorrección. 200190, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Módulo II: Infraestruturas TI\"},{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/es/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Módulo II: Infraestruturas TI\",\"item\":\"https://pe.pablopl.dev/es/equisi/practice/modulo-ii\"}],\"url\":\"https://pe.pablopl.dev/es/equisi/practice/modulo-ii\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Módulo II: Infraestruturas TI: preguntas de Xestión de Infraestruturas\",\"url\":\"https://pe.pablopl.dev/es/equisi/practice/modulo-ii\",\"inLanguage\":\"es\",\"description\":\"Practica 251 preguntas de Módulo II: Infraestruturas TI de recopilatorios de Xestión de Infraestruturas, con respuestas modelo y autocorrección. 200190, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Módulo II: Infraestruturas TI\"},{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/es/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Módulo II: Infraestruturas TI\",\"item\":\"https://pe.pablopl.dev/es/equisi/practice/modulo-ii\"}],\"url\":\"https://pe.pablopl.dev/es/equisi/practice/modulo-ii\"}]}"
   },
   {
     "url": "seo/es/equisi/exam/2024-07.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/equisi/exam/2024-07",
-    "title": "Posibles preguntas Xullo 2024 de Xestión de Infraestruturas: simulador",
-    "description": "Simula el examen Posibles preguntas Xullo 2024 de Xestión de Infraestruturas con 20 preguntas. 10 puntos, 45 minutos, respuestas modelo y autocorrección.",
+    "title": "Posibles preguntas Xullo 2024 de Xestión de Infraestruturas: práctica cronometrada",
+    "description": "Practica el recopilatorio cronometrado Posibles preguntas Xullo 2024 de Xestión de Infraestruturas con 20 preguntas. 10 puntos, 45 minutos, respuestas modelo y autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/equisi/exam/2024-07",
     "ogImage": "https://pe.pablopl.dev/og/equisi.png",
@@ -6559,15 +6559,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equisi/exam/2024-07"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Xullo 2024 de Xestión de Infraestruturas: simulador\",\"url\":\"https://pe.pablopl.dev/es/equisi/exam/2024-07\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Posibles preguntas Xullo 2024 de Xestión de Infraestruturas con 20 preguntas. 10 puntos, 45 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/es/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Xullo 2024\",\"item\":\"https://pe.pablopl.dev/es/equisi/exam/2024-07\"}],\"url\":\"https://pe.pablopl.dev/es/equisi/exam/2024-07\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Xullo 2024 de Xestión de Infraestruturas: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/es/equisi/exam/2024-07\",\"inLanguage\":\"es\",\"description\":\"Practica el recopilatorio cronometrado Posibles preguntas Xullo 2024 de Xestión de Infraestruturas con 20 preguntas. 10 puntos, 45 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/es/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Xullo 2024\",\"item\":\"https://pe.pablopl.dev/es/equisi/exam/2024-07\"}],\"url\":\"https://pe.pablopl.dev/es/equisi/exam/2024-07\"}]}"
   },
   {
     "url": "seo/es/equisi/exam/daypo-modulo-i.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/equisi/exam/daypo-modulo-i",
-    "title": "Daypo Módulo I de Xestión de Infraestruturas: simulador",
-    "description": "Simula el examen Daypo Módulo I de Xestión de Infraestruturas con 130 preguntas. 130 puntos, 120 minutos, respuestas modelo y autocorrección.",
+    "title": "Daypo Módulo I de Xestión de Infraestruturas: práctica cronometrada",
+    "description": "Practica el recopilatorio cronometrado Daypo Módulo I de Xestión de Infraestruturas con 130 preguntas. 130 puntos, 120 minutos, respuestas modelo y autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/equisi/exam/daypo-modulo-i",
     "ogImage": "https://pe.pablopl.dev/og/equisi.png",
@@ -6591,15 +6591,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equisi/exam/daypo-modulo-i"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Módulo I de Xestión de Infraestruturas: simulador\",\"url\":\"https://pe.pablopl.dev/es/equisi/exam/daypo-modulo-i\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Daypo Módulo I de Xestión de Infraestruturas con 130 preguntas. 130 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/es/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Módulo I\",\"item\":\"https://pe.pablopl.dev/es/equisi/exam/daypo-modulo-i\"}],\"url\":\"https://pe.pablopl.dev/es/equisi/exam/daypo-modulo-i\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Módulo I de Xestión de Infraestruturas: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/es/equisi/exam/daypo-modulo-i\",\"inLanguage\":\"es\",\"description\":\"Practica el recopilatorio cronometrado Daypo Módulo I de Xestión de Infraestruturas con 130 preguntas. 130 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/es/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Módulo I\",\"item\":\"https://pe.pablopl.dev/es/equisi/exam/daypo-modulo-i\"}],\"url\":\"https://pe.pablopl.dev/es/equisi/exam/daypo-modulo-i\"}]}"
   },
   {
     "url": "seo/es/equisi/exam/daypo-modulo-ii.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/equisi/exam/daypo-modulo-ii",
-    "title": "Daypo Módulo II de Xestión de Infraestruturas: simulador",
-    "description": "Simula el examen Daypo Módulo II de Xestión de Infraestruturas con 109 preguntas. 109 puntos, 120 minutos, respuestas modelo y autocorrección.",
+    "title": "Daypo Módulo II de Xestión de Infraestruturas: práctica cronometrada",
+    "description": "Practica el recopilatorio cronometrado Daypo Módulo II de Xestión de Infraestruturas con 109 preguntas. 109 puntos, 120 minutos, respuestas modelo y autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/equisi/exam/daypo-modulo-ii",
     "ogImage": "https://pe.pablopl.dev/og/equisi.png",
@@ -6623,15 +6623,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equisi/exam/daypo-modulo-ii"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Módulo II de Xestión de Infraestruturas: simulador\",\"url\":\"https://pe.pablopl.dev/es/equisi/exam/daypo-modulo-ii\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Daypo Módulo II de Xestión de Infraestruturas con 109 preguntas. 109 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/es/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Módulo II\",\"item\":\"https://pe.pablopl.dev/es/equisi/exam/daypo-modulo-ii\"}],\"url\":\"https://pe.pablopl.dev/es/equisi/exam/daypo-modulo-ii\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Módulo II de Xestión de Infraestruturas: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/es/equisi/exam/daypo-modulo-ii\",\"inLanguage\":\"es\",\"description\":\"Practica el recopilatorio cronometrado Daypo Módulo II de Xestión de Infraestruturas con 109 preguntas. 109 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/es/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Módulo II\",\"item\":\"https://pe.pablopl.dev/es/equisi/exam/daypo-modulo-ii\"}],\"url\":\"https://pe.pablopl.dev/es/equisi/exam/daypo-modulo-ii\"}]}"
   },
   {
     "url": "seo/es/equisi/exam/megarecopilacion.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/equisi/exam/megarecopilacion",
-    "title": "Megarecopilación Test XI de Xestión de Infraestruturas: simulador",
-    "description": "Simula el examen Megarecopilación Test XI de Xestión de Infraestruturas con 122 preguntas. 122 puntos, 90 minutos, respuestas modelo y autocorrección.",
+    "title": "Megarecopilación Test XI de Xestión de Infraestruturas: práctica cronometrada",
+    "description": "Practica el recopilatorio cronometrado Megarecopilación Test XI de Xestión de Infraestruturas con 122 preguntas. 122 puntos, 90 minutos, respuestas modelo y autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/equisi/exam/megarecopilacion",
     "ogImage": "https://pe.pablopl.dev/og/equisi.png",
@@ -6655,15 +6655,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equisi/exam/megarecopilacion"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Megarecopilación Test XI de Xestión de Infraestruturas: simulador\",\"url\":\"https://pe.pablopl.dev/es/equisi/exam/megarecopilacion\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Megarecopilación Test XI de Xestión de Infraestruturas con 122 preguntas. 122 puntos, 90 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/es/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Megarecopilación Test XI\",\"item\":\"https://pe.pablopl.dev/es/equisi/exam/megarecopilacion\"}],\"url\":\"https://pe.pablopl.dev/es/equisi/exam/megarecopilacion\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Megarecopilación Test XI de Xestión de Infraestruturas: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/es/equisi/exam/megarecopilacion\",\"inLanguage\":\"es\",\"description\":\"Practica el recopilatorio cronometrado Megarecopilación Test XI de Xestión de Infraestruturas con 122 preguntas. 122 puntos, 90 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/es/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Megarecopilación Test XI\",\"item\":\"https://pe.pablopl.dev/es/equisi/exam/megarecopilacion\"}],\"url\":\"https://pe.pablopl.dev/es/equisi/exam/megarecopilacion\"}]}"
   },
   {
     "url": "seo/es/equispe.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/equispe",
-    "title": "Xestión de Proxectos: \"exámenes\" y preguntas resueltas",
-    "description": "Practica 175 preguntas de Xestión de Proxectos de 5 \"exámenes\" anteriores con respuestas modelo y autocorrección. 202323, Universidade da Coruña.",
+    "title": "Xestión de Proxectos: recopilatorios y preguntas resueltas",
+    "description": "Practica 175 preguntas de Xestión de Proxectos de 5 recopilatorios de práctica con respuestas modelo y autocorrección. 202323, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/equispe",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -6687,7 +6687,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Xestión de Proxectos: \\\"exámenes\\\" y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/equispe\",\"inLanguage\":\"es\",\"description\":\"Practica 175 preguntas de Xestión de Proxectos de 5 \\\"exámenes\\\" anteriores con respuestas modelo y autocorrección. 202323, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/es/equispe\"}],\"url\":\"https://pe.pablopl.dev/es/equispe\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Xestión de Proxectos: recopilatorios y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/equispe\",\"inLanguage\":\"es\",\"description\":\"Practica 175 preguntas de Xestión de Proxectos de 5 recopilatorios de práctica con respuestas modelo y autocorrección. 202323, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/es/equispe\"}],\"url\":\"https://pe.pablopl.dev/es/equispe\"}]}"
   },
   {
     "url": "seo/es/equispe/practice/teoria.html",
@@ -6695,7 +6695,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/equispe/practice/teoria",
     "title": "Teoría: preguntas de Xestión de Proxectos | Pásame Exámenes",
-    "description": "Practica 107 preguntas de Teoría de \"exámenes\" anteriores de Xestión de Proxectos, con respuestas modelo y autocorrección. 202323, Universidade da Coruña.",
+    "description": "Practica 107 preguntas de Teoría de recopilatorios de Xestión de Proxectos, con respuestas modelo y autocorrección. 202323, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/equispe/practice/teoria",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -6719,7 +6719,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe/practice/teoria"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Teoría: preguntas de Xestión de Proxectos | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/equispe/practice/teoria\",\"inLanguage\":\"es\",\"description\":\"Practica 107 preguntas de Teoría de \\\"exámenes\\\" anteriores de Xestión de Proxectos, con respuestas modelo y autocorrección. 202323, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Teoría\"},{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/es/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Teoría\",\"item\":\"https://pe.pablopl.dev/es/equispe/practice/teoria\"}],\"url\":\"https://pe.pablopl.dev/es/equispe/practice/teoria\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Teoría: preguntas de Xestión de Proxectos | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/equispe/practice/teoria\",\"inLanguage\":\"es\",\"description\":\"Practica 107 preguntas de Teoría de recopilatorios de Xestión de Proxectos, con respuestas modelo y autocorrección. 202323, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Teoría\"},{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/es/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Teoría\",\"item\":\"https://pe.pablopl.dev/es/equispe/practice/teoria\"}],\"url\":\"https://pe.pablopl.dev/es/equispe/practice/teoria\"}]}"
   },
   {
     "url": "seo/es/equispe/practice/practica.html",
@@ -6727,7 +6727,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/equispe/practice/practica",
     "title": "Práctica: preguntas de Xestión de Proxectos | Pásame Exámenes",
-    "description": "Practica 68 preguntas de Práctica de \"exámenes\" anteriores de Xestión de Proxectos, con respuestas modelo y autocorrección. 202323, Universidade da Coruña.",
+    "description": "Practica 68 preguntas de Práctica de recopilatorios de Xestión de Proxectos, con respuestas modelo y autocorrección. 202323, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/equispe/practice/practica",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -6751,15 +6751,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe/practice/practica"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Práctica: preguntas de Xestión de Proxectos | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/equispe/practice/practica\",\"inLanguage\":\"es\",\"description\":\"Practica 68 preguntas de Práctica de \\\"exámenes\\\" anteriores de Xestión de Proxectos, con respuestas modelo y autocorrección. 202323, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Práctica\"},{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/es/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Práctica\",\"item\":\"https://pe.pablopl.dev/es/equispe/practice/practica\"}],\"url\":\"https://pe.pablopl.dev/es/equispe/practice/practica\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Práctica: preguntas de Xestión de Proxectos | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/equispe/practice/practica\",\"inLanguage\":\"es\",\"description\":\"Practica 68 preguntas de Práctica de recopilatorios de Xestión de Proxectos, con respuestas modelo y autocorrección. 202323, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Práctica\"},{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/es/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Práctica\",\"item\":\"https://pe.pablopl.dev/es/equispe/practice/practica\"}],\"url\":\"https://pe.pablopl.dev/es/equispe/practice/practica\"}]}"
   },
   {
     "url": "seo/es/equispe/exam/2024-01.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/equispe/exam/2024-01",
-    "title": "Posibles preguntas Xaneiro 2024 de Xestión de Proxectos: simulador",
-    "description": "Simula el examen Posibles preguntas Xaneiro 2024 de Xestión de Proxectos con 7 preguntas. 10 puntos, 120 minutos, respuestas modelo y autocorrección.",
+    "title": "Posibles preguntas Xaneiro 2024 de Xestión de Proxectos: práctica cronometrada",
+    "description": "Practica el recopilatorio cronometrado Posibles preguntas Xaneiro 2024 de Xestión de Proxectos con 7 preguntas. 10 puntos, 120 minutos, respuestas modelo y autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/equispe/exam/2024-01",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -6783,15 +6783,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe/exam/2024-01"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Xaneiro 2024 de Xestión de Proxectos: simulador\",\"url\":\"https://pe.pablopl.dev/es/equispe/exam/2024-01\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Posibles preguntas Xaneiro 2024 de Xestión de Proxectos con 7 preguntas. 10 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/es/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Xaneiro 2024\",\"item\":\"https://pe.pablopl.dev/es/equispe/exam/2024-01\"}],\"url\":\"https://pe.pablopl.dev/es/equispe/exam/2024-01\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Xaneiro 2024 de Xestión de Proxectos: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/es/equispe/exam/2024-01\",\"inLanguage\":\"es\",\"description\":\"Practica el recopilatorio cronometrado Posibles preguntas Xaneiro 2024 de Xestión de Proxectos con 7 preguntas. 10 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/es/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Xaneiro 2024\",\"item\":\"https://pe.pablopl.dev/es/equispe/exam/2024-01\"}],\"url\":\"https://pe.pablopl.dev/es/equispe/exam/2024-01\"}]}"
   },
   {
     "url": "seo/es/equispe/exam/2026-01.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/equispe/exam/2026-01",
-    "title": "Posibles preguntas Xaneiro 2026 de Xestión de Proxectos: simulador",
-    "description": "Simula el examen Posibles preguntas Xaneiro 2026 de Xestión de Proxectos con 13 preguntas. 25 puntos, 180 minutos, respuestas modelo y autocorrección.",
+    "title": "Posibles preguntas Xaneiro 2026 de Xestión de Proxectos: práctica cronometrada",
+    "description": "Practica el recopilatorio cronometrado Posibles preguntas Xaneiro 2026 de Xestión de Proxectos con 13 preguntas. 25 puntos, 180 minutos, respuestas modelo y autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/equispe/exam/2026-01",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -6815,15 +6815,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe/exam/2026-01"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Xaneiro 2026 de Xestión de Proxectos: simulador\",\"url\":\"https://pe.pablopl.dev/es/equispe/exam/2026-01\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Posibles preguntas Xaneiro 2026 de Xestión de Proxectos con 13 preguntas. 25 puntos, 180 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/es/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Xaneiro 2026\",\"item\":\"https://pe.pablopl.dev/es/equispe/exam/2026-01\"}],\"url\":\"https://pe.pablopl.dev/es/equispe/exam/2026-01\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Xaneiro 2026 de Xestión de Proxectos: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/es/equispe/exam/2026-01\",\"inLanguage\":\"es\",\"description\":\"Practica el recopilatorio cronometrado Posibles preguntas Xaneiro 2026 de Xestión de Proxectos con 13 preguntas. 25 puntos, 180 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/es/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Xaneiro 2026\",\"item\":\"https://pe.pablopl.dev/es/equispe/exam/2026-01\"}],\"url\":\"https://pe.pablopl.dev/es/equispe/exam/2026-01\"}]}"
   },
   {
     "url": "seo/es/equispe/exam/daypo-tipo-udc.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/equispe/exam/daypo-tipo-udc",
-    "title": "Daypo Tipo UDC de Xestión de Proxectos: simulador",
-    "description": "Simula el examen Daypo Tipo UDC de Xestión de Proxectos con 63 preguntas. 63 puntos, 90 minutos, respuestas modelo y autocorrección.",
+    "title": "Daypo Tipo UDC de Xestión de Proxectos: práctica cronometrada",
+    "description": "Practica el recopilatorio cronometrado Daypo Tipo UDC de Xestión de Proxectos con 63 preguntas. 63 puntos, 90 minutos, respuestas modelo y autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/equispe/exam/daypo-tipo-udc",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -6847,15 +6847,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe/exam/daypo-tipo-udc"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Tipo UDC de Xestión de Proxectos: simulador\",\"url\":\"https://pe.pablopl.dev/es/equispe/exam/daypo-tipo-udc\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Daypo Tipo UDC de Xestión de Proxectos con 63 preguntas. 63 puntos, 90 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/es/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Tipo UDC\",\"item\":\"https://pe.pablopl.dev/es/equispe/exam/daypo-tipo-udc\"}],\"url\":\"https://pe.pablopl.dev/es/equispe/exam/daypo-tipo-udc\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Tipo UDC de Xestión de Proxectos: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/es/equispe/exam/daypo-tipo-udc\",\"inLanguage\":\"es\",\"description\":\"Practica el recopilatorio cronometrado Daypo Tipo UDC de Xestión de Proxectos con 63 preguntas. 63 puntos, 90 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/es/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Tipo UDC\",\"item\":\"https://pe.pablopl.dev/es/equispe/exam/daypo-tipo-udc\"}],\"url\":\"https://pe.pablopl.dev/es/equispe/exam/daypo-tipo-udc\"}]}"
   },
   {
     "url": "seo/es/equispe/exam/daypo-teoria.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/equispe/exam/daypo-teoria",
-    "title": "Daypo Teoría de Xestión de Proxectos: simulador",
-    "description": "Simula el examen Daypo Teoría de Xestión de Proxectos con 34 preguntas. 34 puntos, 60 minutos, respuestas modelo y autocorrección.",
+    "title": "Daypo Teoría de Xestión de Proxectos: práctica cronometrada",
+    "description": "Practica el recopilatorio cronometrado Daypo Teoría de Xestión de Proxectos con 34 preguntas. 34 puntos, 60 minutos, respuestas modelo y autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/equispe/exam/daypo-teoria",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -6879,15 +6879,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe/exam/daypo-teoria"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Teoría de Xestión de Proxectos: simulador\",\"url\":\"https://pe.pablopl.dev/es/equispe/exam/daypo-teoria\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Daypo Teoría de Xestión de Proxectos con 34 preguntas. 34 puntos, 60 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/es/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Teoría\",\"item\":\"https://pe.pablopl.dev/es/equispe/exam/daypo-teoria\"}],\"url\":\"https://pe.pablopl.dev/es/equispe/exam/daypo-teoria\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Teoría de Xestión de Proxectos: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/es/equispe/exam/daypo-teoria\",\"inLanguage\":\"es\",\"description\":\"Practica el recopilatorio cronometrado Daypo Teoría de Xestión de Proxectos con 34 preguntas. 34 puntos, 60 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/es/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Teoría\",\"item\":\"https://pe.pablopl.dev/es/equispe/exam/daypo-teoria\"}],\"url\":\"https://pe.pablopl.dev/es/equispe/exam/daypo-teoria\"}]}"
   },
   {
     "url": "seo/es/equispe/exam/daypo-practica.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/equispe/exam/daypo-practica",
-    "title": "Daypo Práctica de Xestión de Proxectos: simulador",
-    "description": "Simula el examen Daypo Práctica de Xestión de Proxectos con 58 preguntas. 58 puntos, 90 minutos, respuestas modelo y autocorrección.",
+    "title": "Daypo Práctica de Xestión de Proxectos: práctica cronometrada",
+    "description": "Practica el recopilatorio cronometrado Daypo Práctica de Xestión de Proxectos con 58 preguntas. 58 puntos, 90 minutos, respuestas modelo y autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/equispe/exam/daypo-practica",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -6911,15 +6911,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe/exam/daypo-practica"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Práctica de Xestión de Proxectos: simulador\",\"url\":\"https://pe.pablopl.dev/es/equispe/exam/daypo-practica\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Daypo Práctica de Xestión de Proxectos con 58 preguntas. 58 puntos, 90 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/es/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Práctica\",\"item\":\"https://pe.pablopl.dev/es/equispe/exam/daypo-practica\"}],\"url\":\"https://pe.pablopl.dev/es/equispe/exam/daypo-practica\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Práctica de Xestión de Proxectos: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/es/equispe/exam/daypo-practica\",\"inLanguage\":\"es\",\"description\":\"Practica el recopilatorio cronometrado Daypo Práctica de Xestión de Proxectos con 58 preguntas. 58 puntos, 90 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/es/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Práctica\",\"item\":\"https://pe.pablopl.dev/es/equispe/exam/daypo-practica\"}],\"url\":\"https://pe.pablopl.dev/es/equispe/exam/daypo-practica\"}]}"
   },
   {
     "url": "seo/es/esei.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/esei",
-    "title": "Sistemas Intelixentes: \"exámenes\" y preguntas resueltas",
-    "description": "Practica 234 preguntas de Sistemas Intelixentes de 5 \"exámenes\" anteriores con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
+    "title": "Sistemas Intelixentes: recopilatorios y preguntas resueltas",
+    "description": "Practica 234 preguntas de Sistemas Intelixentes de 5 recopilatorios de práctica con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/esei",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -6943,7 +6943,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Sistemas Intelixentes: \\\"exámenes\\\" y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/esei\",\"inLanguage\":\"es\",\"description\":\"Practica 234 preguntas de Sistemas Intelixentes de 5 \\\"exámenes\\\" anteriores con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"}],\"url\":\"https://pe.pablopl.dev/es/esei\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Sistemas Intelixentes: recopilatorios y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/esei\",\"inLanguage\":\"es\",\"description\":\"Practica 234 preguntas de Sistemas Intelixentes de 5 recopilatorios de práctica con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"}],\"url\":\"https://pe.pablopl.dev/es/esei\"}]}"
   },
   {
     "url": "seo/es/esei/practice/t1.html",
@@ -6951,7 +6951,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/esei/practice/t1",
     "title": "Tema 1: Introducción: preguntas de Sistemas Intelixentes",
-    "description": "Practica 4 preguntas de Tema 1: Introducción de \"exámenes\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 4 preguntas de Tema 1: Introducción de recopilatorios de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/esei/practice/t1",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -6975,7 +6975,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t1"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 1: Introducción: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t1\",\"inLanguage\":\"es\",\"description\":\"Practica 4 preguntas de Tema 1: Introducción de \\\"exámenes\\\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 1: Introducción\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 1: Introducción\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t1\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t1\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 1: Introducción: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t1\",\"inLanguage\":\"es\",\"description\":\"Practica 4 preguntas de Tema 1: Introducción de recopilatorios de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 1: Introducción\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 1: Introducción\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t1\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t1\"}]}"
   },
   {
     "url": "seo/es/esei/practice/t2.html",
@@ -6983,7 +6983,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/esei/practice/t2",
     "title": "Tema 2: Búsqueda: preguntas de Sistemas Intelixentes",
-    "description": "Practica 24 preguntas de Tema 2: Búsqueda de \"exámenes\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 24 preguntas de Tema 2: Búsqueda de recopilatorios de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/esei/practice/t2",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -7007,7 +7007,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t2"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 2: Búsqueda: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t2\",\"inLanguage\":\"es\",\"description\":\"Practica 24 preguntas de Tema 2: Búsqueda de \\\"exámenes\\\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 2: Búsqueda\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 2: Búsqueda\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t2\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t2\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 2: Búsqueda: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t2\",\"inLanguage\":\"es\",\"description\":\"Practica 24 preguntas de Tema 2: Búsqueda de recopilatorios de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 2: Búsqueda\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 2: Búsqueda\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t2\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t2\"}]}"
   },
   {
     "url": "seo/es/esei/practice/t3.html",
@@ -7015,7 +7015,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/esei/practice/t3",
     "title": "Tema 3: Representación: preguntas de Sistemas Intelixentes",
-    "description": "Practica 17 preguntas de Tema 3: Representación de \"exámenes\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 17 preguntas de Tema 3: Representación de recopilatorios de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/esei/practice/t3",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -7039,7 +7039,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t3"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 3: Representación: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t3\",\"inLanguage\":\"es\",\"description\":\"Practica 17 preguntas de Tema 3: Representación de \\\"exámenes\\\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 3: Representación\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 3: Representación\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t3\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t3\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 3: Representación: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t3\",\"inLanguage\":\"es\",\"description\":\"Practica 17 preguntas de Tema 3: Representación de recopilatorios de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 3: Representación\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 3: Representación\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t3\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t3\"}]}"
   },
   {
     "url": "seo/es/esei/practice/t4.html",
@@ -7047,7 +7047,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/esei/practice/t4",
     "title": "Tema 4: Razonamiento: preguntas de Sistemas Intelixentes",
-    "description": "Practica 12 preguntas de Tema 4: Razonamiento de \"exámenes\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 12 preguntas de Tema 4: Razonamiento de recopilatorios de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/esei/practice/t4",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -7071,7 +7071,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t4"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 4: Razonamiento: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t4\",\"inLanguage\":\"es\",\"description\":\"Practica 12 preguntas de Tema 4: Razonamiento de \\\"exámenes\\\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 4: Razonamiento\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 4: Razonamiento\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t4\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t4\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 4: Razonamiento: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t4\",\"inLanguage\":\"es\",\"description\":\"Practica 12 preguntas de Tema 4: Razonamiento de recopilatorios de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 4: Razonamiento\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 4: Razonamiento\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t4\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t4\"}]}"
   },
   {
     "url": "seo/es/esei/practice/t5.html",
@@ -7079,7 +7079,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/esei/practice/t5",
     "title": "Tema 5: Planificación: preguntas de Sistemas Intelixentes",
-    "description": "Practica 2 preguntas de Tema 5: Planificación de \"exámenes\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 2 preguntas de Tema 5: Planificación de recopilatorios de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/esei/practice/t5",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -7103,7 +7103,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t5"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 5: Planificación: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t5\",\"inLanguage\":\"es\",\"description\":\"Practica 2 preguntas de Tema 5: Planificación de \\\"exámenes\\\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 5: Planificación\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 5: Planificación\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t5\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t5\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 5: Planificación: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t5\",\"inLanguage\":\"es\",\"description\":\"Practica 2 preguntas de Tema 5: Planificación de recopilatorios de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 5: Planificación\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 5: Planificación\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t5\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t5\"}]}"
   },
   {
     "url": "seo/es/esei/practice/t6.html",
@@ -7111,7 +7111,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/esei/practice/t6",
     "title": "Tema 6: Introducción a los sistemas subsimbólicos: preguntas de Sistemas Intelixentes",
-    "description": "Practica 18 preguntas de Tema 6: Introducción a los sistemas subsimbólicos de \"exámenes\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 18 preguntas de Tema 6: Introducción a los sistemas subsimbólicos de recopilatorios de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/esei/practice/t6",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -7135,7 +7135,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t6"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 6: Introducción a los sistemas subsimbólicos: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t6\",\"inLanguage\":\"es\",\"description\":\"Practica 18 preguntas de Tema 6: Introducción a los sistemas subsimbólicos de \\\"exámenes\\\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 6: Introducción a los sistemas subsimbólicos\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 6: Introducción a los sistemas subsimbólicos\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t6\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t6\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 6: Introducción a los sistemas subsimbólicos: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t6\",\"inLanguage\":\"es\",\"description\":\"Practica 18 preguntas de Tema 6: Introducción a los sistemas subsimbólicos de recopilatorios de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 6: Introducción a los sistemas subsimbólicos\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 6: Introducción a los sistemas subsimbólicos\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t6\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t6\"}]}"
   },
   {
     "url": "seo/es/esei/practice/t7.html",
@@ -7143,7 +7143,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/esei/practice/t7",
     "title": "Tema 7: Redes Neuronales Artificiales: modelos y características: preguntas de Sistemas Intelixentes",
-    "description": "Practica 40 preguntas de Tema 7: Redes Neuronales Artificiales: modelos y características de \"exámenes\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 40 preguntas de Tema 7: Redes Neuronales Artificiales: modelos y características de recopilatorios de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/esei/practice/t7",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -7167,7 +7167,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t7"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 7: Redes Neuronales Artificiales: modelos y características: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t7\",\"inLanguage\":\"es\",\"description\":\"Practica 40 preguntas de Tema 7: Redes Neuronales Artificiales: modelos y características de \\\"exámenes\\\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 7: Redes Neuronales Artificiales: modelos y características\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 7: Redes Neuronales Artificiales: modelos y características\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t7\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t7\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 7: Redes Neuronales Artificiales: modelos y características: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t7\",\"inLanguage\":\"es\",\"description\":\"Practica 40 preguntas de Tema 7: Redes Neuronales Artificiales: modelos y características de recopilatorios de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 7: Redes Neuronales Artificiales: modelos y características\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 7: Redes Neuronales Artificiales: modelos y características\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t7\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t7\"}]}"
   },
   {
     "url": "seo/es/esei/practice/t8.html",
@@ -7175,7 +7175,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/esei/practice/t8",
     "title": "Tema 8: Entrenamiento de Redes Neuronales Artificiales: preguntas de Sistemas Intelixentes",
-    "description": "Practica 20 preguntas de Tema 8: Entrenamiento de Redes Neuronales Artificiales de \"exámenes\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 20 preguntas de Tema 8: Entrenamiento de Redes Neuronales Artificiales de recopilatorios de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/esei/practice/t8",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -7199,7 +7199,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t8"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 8: Entrenamiento de Redes Neuronales Artificiales: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t8\",\"inLanguage\":\"es\",\"description\":\"Practica 20 preguntas de Tema 8: Entrenamiento de Redes Neuronales Artificiales de \\\"exámenes\\\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 8: Entrenamiento de Redes Neuronales Artificiales\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 8: Entrenamiento de Redes Neuronales Artificiales\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t8\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t8\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 8: Entrenamiento de Redes Neuronales Artificiales: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t8\",\"inLanguage\":\"es\",\"description\":\"Practica 20 preguntas de Tema 8: Entrenamiento de Redes Neuronales Artificiales de recopilatorios de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 8: Entrenamiento de Redes Neuronales Artificiales\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 8: Entrenamiento de Redes Neuronales Artificiales\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t8\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t8\"}]}"
   },
   {
     "url": "seo/es/esei/practice/t9.html",
@@ -7207,7 +7207,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/esei/practice/t9",
     "title": "Tema 9: Sistemas autoorganizativos: preguntas de Sistemas Intelixentes",
-    "description": "Practica 59 preguntas de Tema 9: Sistemas autoorganizativos de \"exámenes\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 59 preguntas de Tema 9: Sistemas autoorganizativos de recopilatorios de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/esei/practice/t9",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -7231,7 +7231,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t9"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 9: Sistemas autoorganizativos: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t9\",\"inLanguage\":\"es\",\"description\":\"Practica 59 preguntas de Tema 9: Sistemas autoorganizativos de \\\"exámenes\\\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 9: Sistemas autoorganizativos\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 9: Sistemas autoorganizativos\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t9\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t9\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 9: Sistemas autoorganizativos: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t9\",\"inLanguage\":\"es\",\"description\":\"Practica 59 preguntas de Tema 9: Sistemas autoorganizativos de recopilatorios de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 9: Sistemas autoorganizativos\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 9: Sistemas autoorganizativos\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t9\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t9\"}]}"
   },
   {
     "url": "seo/es/esei/practice/t10.html",
@@ -7239,7 +7239,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/esei/practice/t10",
     "title": "Tema 10: Computación Evolutiva: preguntas de Sistemas Intelixentes",
-    "description": "Practica 38 preguntas de Tema 10: Computación Evolutiva de \"exámenes\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 38 preguntas de Tema 10: Computación Evolutiva de recopilatorios de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/esei/practice/t10",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -7263,15 +7263,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t10"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 10: Computación Evolutiva: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t10\",\"inLanguage\":\"es\",\"description\":\"Practica 38 preguntas de Tema 10: Computación Evolutiva de \\\"exámenes\\\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 10: Computación Evolutiva\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 10: Computación Evolutiva\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t10\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t10\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 10: Computación Evolutiva: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t10\",\"inLanguage\":\"es\",\"description\":\"Practica 38 preguntas de Tema 10: Computación Evolutiva de recopilatorios de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 10: Computación Evolutiva\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 10: Computación Evolutiva\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t10\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t10\"}]}"
   },
   {
     "url": "seo/es/esei/exam/2023.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/esei/exam/2023",
-    "title": "Posibles preguntas 2023 de Sistemas Intelixentes: simulador",
-    "description": "Simula el examen Posibles preguntas 2023 de Sistemas Intelixentes con 45 preguntas. 45 puntos, 120 minutos, respuestas modelo y autocorrección.",
+    "title": "Posibles preguntas 2023 de Sistemas Intelixentes: práctica cronometrada",
+    "description": "Practica el recopilatorio cronometrado Posibles preguntas 2023 de Sistemas Intelixentes con 45 preguntas. 45 puntos, 120 minutos, respuestas modelo y autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/esei/exam/2023",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -7295,15 +7295,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/exam/2023"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas 2023 de Sistemas Intelixentes: simulador\",\"url\":\"https://pe.pablopl.dev/es/esei/exam/2023\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Posibles preguntas 2023 de Sistemas Intelixentes con 45 preguntas. 45 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas 2023\",\"item\":\"https://pe.pablopl.dev/es/esei/exam/2023\"}],\"url\":\"https://pe.pablopl.dev/es/esei/exam/2023\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas 2023 de Sistemas Intelixentes: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/es/esei/exam/2023\",\"inLanguage\":\"es\",\"description\":\"Practica el recopilatorio cronometrado Posibles preguntas 2023 de Sistemas Intelixentes con 45 preguntas. 45 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas 2023\",\"item\":\"https://pe.pablopl.dev/es/esei/exam/2023\"}],\"url\":\"https://pe.pablopl.dev/es/esei/exam/2023\"}]}"
   },
   {
     "url": "seo/es/esei/exam/2024.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/esei/exam/2024",
-    "title": "Posibles preguntas 2024 de Sistemas Intelixentes: simulador",
-    "description": "Simula el examen Posibles preguntas 2024 de Sistemas Intelixentes con 44 preguntas. 44 puntos, 120 minutos, respuestas modelo y autocorrección.",
+    "title": "Posibles preguntas 2024 de Sistemas Intelixentes: práctica cronometrada",
+    "description": "Practica el recopilatorio cronometrado Posibles preguntas 2024 de Sistemas Intelixentes con 44 preguntas. 44 puntos, 120 minutos, respuestas modelo y autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/esei/exam/2024",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -7327,15 +7327,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/exam/2024"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas 2024 de Sistemas Intelixentes: simulador\",\"url\":\"https://pe.pablopl.dev/es/esei/exam/2024\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Posibles preguntas 2024 de Sistemas Intelixentes con 44 preguntas. 44 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas 2024\",\"item\":\"https://pe.pablopl.dev/es/esei/exam/2024\"}],\"url\":\"https://pe.pablopl.dev/es/esei/exam/2024\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas 2024 de Sistemas Intelixentes: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/es/esei/exam/2024\",\"inLanguage\":\"es\",\"description\":\"Practica el recopilatorio cronometrado Posibles preguntas 2024 de Sistemas Intelixentes con 44 preguntas. 44 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas 2024\",\"item\":\"https://pe.pablopl.dev/es/esei/exam/2024\"}],\"url\":\"https://pe.pablopl.dev/es/esei/exam/2024\"}]}"
   },
   {
     "url": "seo/es/esei/exam/2025-05.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/esei/exam/2025-05",
-    "title": "Posibles preguntas Mayo 2025 de Sistemas Intelixentes: simulador",
-    "description": "Simula el examen Posibles preguntas Mayo 2025 de Sistemas Intelixentes con 42 preguntas. 42 puntos, 120 minutos, respuestas modelo y autocorrección.",
+    "title": "Posibles preguntas Mayo 2025 de Sistemas Intelixentes: práctica cronometrada",
+    "description": "Practica el recopilatorio cronometrado Posibles preguntas Mayo 2025 de Sistemas Intelixentes con 42 preguntas. 42 puntos, 120 minutos, respuestas modelo y autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/esei/exam/2025-05",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -7359,15 +7359,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/exam/2025-05"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Mayo 2025 de Sistemas Intelixentes: simulador\",\"url\":\"https://pe.pablopl.dev/es/esei/exam/2025-05\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Posibles preguntas Mayo 2025 de Sistemas Intelixentes con 42 preguntas. 42 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Mayo 2025\",\"item\":\"https://pe.pablopl.dev/es/esei/exam/2025-05\"}],\"url\":\"https://pe.pablopl.dev/es/esei/exam/2025-05\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Mayo 2025 de Sistemas Intelixentes: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/es/esei/exam/2025-05\",\"inLanguage\":\"es\",\"description\":\"Practica el recopilatorio cronometrado Posibles preguntas Mayo 2025 de Sistemas Intelixentes con 42 preguntas. 42 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Mayo 2025\",\"item\":\"https://pe.pablopl.dev/es/esei/exam/2025-05\"}],\"url\":\"https://pe.pablopl.dev/es/esei/exam/2025-05\"}]}"
   },
   {
     "url": "seo/es/esei/exam/2025-07.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/esei/exam/2025-07",
-    "title": "Posibles preguntas Julio 2025 de Sistemas Intelixentes: simulador",
-    "description": "Simula el examen Posibles preguntas Julio 2025 de Sistemas Intelixentes con 47 preguntas. 47 puntos, 120 minutos, respuestas modelo y autocorrección.",
+    "title": "Posibles preguntas Julio 2025 de Sistemas Intelixentes: práctica cronometrada",
+    "description": "Practica el recopilatorio cronometrado Posibles preguntas Julio 2025 de Sistemas Intelixentes con 47 preguntas. 47 puntos, 120 minutos, respuestas modelo y autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/esei/exam/2025-07",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -7391,15 +7391,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/exam/2025-07"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Julio 2025 de Sistemas Intelixentes: simulador\",\"url\":\"https://pe.pablopl.dev/es/esei/exam/2025-07\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Posibles preguntas Julio 2025 de Sistemas Intelixentes con 47 preguntas. 47 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Julio 2025\",\"item\":\"https://pe.pablopl.dev/es/esei/exam/2025-07\"}],\"url\":\"https://pe.pablopl.dev/es/esei/exam/2025-07\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Julio 2025 de Sistemas Intelixentes: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/es/esei/exam/2025-07\",\"inLanguage\":\"es\",\"description\":\"Practica el recopilatorio cronometrado Posibles preguntas Julio 2025 de Sistemas Intelixentes con 47 preguntas. 47 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Julio 2025\",\"item\":\"https://pe.pablopl.dev/es/esei/exam/2025-07\"}],\"url\":\"https://pe.pablopl.dev/es/esei/exam/2025-07\"}]}"
   },
   {
     "url": "seo/es/esei/exam/2026-06.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/esei/exam/2026-06",
-    "title": "Posibles preguntas Junio 2026 de Sistemas Intelixentes: simulador",
-    "description": "Simula el examen Posibles preguntas Junio 2026 de Sistemas Intelixentes con 56 preguntas. 56 puntos, 120 minutos, respuestas modelo y autocorrección.",
+    "title": "Posibles preguntas Junio 2026 de Sistemas Intelixentes: práctica cronometrada",
+    "description": "Practica el recopilatorio cronometrado Posibles preguntas Junio 2026 de Sistemas Intelixentes con 56 preguntas. 56 puntos, 120 minutos, respuestas modelo y autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/esei/exam/2026-06",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -7423,15 +7423,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/exam/2026-06"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Junio 2026 de Sistemas Intelixentes: simulador\",\"url\":\"https://pe.pablopl.dev/es/esei/exam/2026-06\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Posibles preguntas Junio 2026 de Sistemas Intelixentes con 56 preguntas. 56 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Junio 2026\",\"item\":\"https://pe.pablopl.dev/es/esei/exam/2026-06\"}],\"url\":\"https://pe.pablopl.dev/es/esei/exam/2026-06\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Junio 2026 de Sistemas Intelixentes: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/es/esei/exam/2026-06\",\"inLanguage\":\"es\",\"description\":\"Practica el recopilatorio cronometrado Posibles preguntas Junio 2026 de Sistemas Intelixentes con 56 preguntas. 56 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Junio 2026\",\"item\":\"https://pe.pablopl.dev/es/esei/exam/2026-06\"}],\"url\":\"https://pe.pablopl.dev/es/esei/exam/2026-06\"}]}"
   },
   {
     "url": "seo/es/eseo.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/eseo",
-    "title": "Sistemas Operativos: \"exámenes\" y preguntas resueltas",
-    "description": "Practica 119 preguntas de Sistemas Operativos de 9 \"exámenes\" anteriores con respuestas modelo y autocorrección. 202318, Universidade da Coruña.",
+    "title": "Sistemas Operativos: exámenes y preguntas resueltas",
+    "description": "Practica 119 preguntas de Sistemas Operativos de 9 exámenes con respuestas modelo y autocorrección. 202318, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/eseo",
     "ogImage": "https://pe.pablopl.dev/og/eseo.png",
@@ -7455,7 +7455,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/eseo"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Sistemas Operativos: \\\"exámenes\\\" y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/eseo\",\"inLanguage\":\"es\",\"description\":\"Practica 119 preguntas de Sistemas Operativos de 9 \\\"exámenes\\\" anteriores con respuestas modelo y autocorrección. 202318, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/es/eseo\"}],\"url\":\"https://pe.pablopl.dev/es/eseo\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Sistemas Operativos: exámenes y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/eseo\",\"inLanguage\":\"es\",\"description\":\"Practica 119 preguntas de Sistemas Operativos de 9 exámenes con respuestas modelo y autocorrección. 202318, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/es/eseo\"}],\"url\":\"https://pe.pablopl.dev/es/eseo\"}]}"
   },
   {
     "url": "seo/es/eseo/practice/sistema-ficheros.html",
@@ -7463,7 +7463,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/eseo/practice/sistema-ficheros",
     "title": "Sistema de Ficheros: preguntas de Sistemas Operativos",
-    "description": "Practica 36 preguntas de Sistema de Ficheros de \"exámenes\" anteriores de Sistemas Operativos, con respuestas modelo y autocorrección. 202318, Universidade da Coruña.",
+    "description": "Practica 36 preguntas de Sistema de Ficheros de exámenes de Sistemas Operativos, con respuestas modelo y autocorrección. 202318, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/eseo/practice/sistema-ficheros",
     "ogImage": "https://pe.pablopl.dev/og/eseo.png",
@@ -7487,7 +7487,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/eseo/practice/sistema-ficheros"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Sistema de Ficheros: preguntas de Sistemas Operativos\",\"url\":\"https://pe.pablopl.dev/es/eseo/practice/sistema-ficheros\",\"inLanguage\":\"es\",\"description\":\"Practica 36 preguntas de Sistema de Ficheros de \\\"exámenes\\\" anteriores de Sistemas Operativos, con respuestas modelo y autocorrección. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Sistema de Ficheros\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/es/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Sistema de Ficheros\",\"item\":\"https://pe.pablopl.dev/es/eseo/practice/sistema-ficheros\"}],\"url\":\"https://pe.pablopl.dev/es/eseo/practice/sistema-ficheros\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Sistema de Ficheros: preguntas de Sistemas Operativos\",\"url\":\"https://pe.pablopl.dev/es/eseo/practice/sistema-ficheros\",\"inLanguage\":\"es\",\"description\":\"Practica 36 preguntas de Sistema de Ficheros de exámenes de Sistemas Operativos, con respuestas modelo y autocorrección. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Sistema de Ficheros\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/es/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Sistema de Ficheros\",\"item\":\"https://pe.pablopl.dev/es/eseo/practice/sistema-ficheros\"}],\"url\":\"https://pe.pablopl.dev/es/eseo/practice/sistema-ficheros\"}]}"
   },
   {
     "url": "seo/es/eseo/practice/memoria.html",
@@ -7495,7 +7495,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/eseo/practice/memoria",
     "title": "Gestión de Memoria: preguntas de Sistemas Operativos",
-    "description": "Practica 25 preguntas de Gestión de Memoria de \"exámenes\" anteriores de Sistemas Operativos, con respuestas modelo y autocorrección. 202318, Universidade da Coruña.",
+    "description": "Practica 25 preguntas de Gestión de Memoria de exámenes de Sistemas Operativos, con respuestas modelo y autocorrección. 202318, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/eseo/practice/memoria",
     "ogImage": "https://pe.pablopl.dev/og/eseo.png",
@@ -7519,7 +7519,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/eseo/practice/memoria"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Gestión de Memoria: preguntas de Sistemas Operativos\",\"url\":\"https://pe.pablopl.dev/es/eseo/practice/memoria\",\"inLanguage\":\"es\",\"description\":\"Practica 25 preguntas de Gestión de Memoria de \\\"exámenes\\\" anteriores de Sistemas Operativos, con respuestas modelo y autocorrección. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Gestión de Memoria\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/es/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Gestión de Memoria\",\"item\":\"https://pe.pablopl.dev/es/eseo/practice/memoria\"}],\"url\":\"https://pe.pablopl.dev/es/eseo/practice/memoria\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Gestión de Memoria: preguntas de Sistemas Operativos\",\"url\":\"https://pe.pablopl.dev/es/eseo/practice/memoria\",\"inLanguage\":\"es\",\"description\":\"Practica 25 preguntas de Gestión de Memoria de exámenes de Sistemas Operativos, con respuestas modelo y autocorrección. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Gestión de Memoria\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/es/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Gestión de Memoria\",\"item\":\"https://pe.pablopl.dev/es/eseo/practice/memoria\"}],\"url\":\"https://pe.pablopl.dev/es/eseo/practice/memoria\"}]}"
   },
   {
     "url": "seo/es/eseo/practice/procesos.html",
@@ -7527,7 +7527,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/eseo/practice/procesos",
     "title": "Procesos e Hilos: preguntas de Sistemas Operativos",
-    "description": "Practica 30 preguntas de Procesos e Hilos de \"exámenes\" anteriores de Sistemas Operativos, con respuestas modelo y autocorrección. 202318, Universidade da Coruña.",
+    "description": "Practica 30 preguntas de Procesos e Hilos de exámenes de Sistemas Operativos, con respuestas modelo y autocorrección. 202318, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/eseo/practice/procesos",
     "ogImage": "https://pe.pablopl.dev/og/eseo.png",
@@ -7551,7 +7551,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/eseo/practice/procesos"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Procesos e Hilos: preguntas de Sistemas Operativos\",\"url\":\"https://pe.pablopl.dev/es/eseo/practice/procesos\",\"inLanguage\":\"es\",\"description\":\"Practica 30 preguntas de Procesos e Hilos de \\\"exámenes\\\" anteriores de Sistemas Operativos, con respuestas modelo y autocorrección. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Procesos e Hilos\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/es/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Procesos e Hilos\",\"item\":\"https://pe.pablopl.dev/es/eseo/practice/procesos\"}],\"url\":\"https://pe.pablopl.dev/es/eseo/practice/procesos\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Procesos e Hilos: preguntas de Sistemas Operativos\",\"url\":\"https://pe.pablopl.dev/es/eseo/practice/procesos\",\"inLanguage\":\"es\",\"description\":\"Practica 30 preguntas de Procesos e Hilos de exámenes de Sistemas Operativos, con respuestas modelo y autocorrección. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Procesos e Hilos\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/es/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Procesos e Hilos\",\"item\":\"https://pe.pablopl.dev/es/eseo/practice/procesos\"}],\"url\":\"https://pe.pablopl.dev/es/eseo/practice/procesos\"}]}"
   },
   {
     "url": "seo/es/eseo/practice/entrada-salida.html",
@@ -7559,7 +7559,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/eseo/practice/entrada-salida",
     "title": "Entrada/Salida: preguntas de Sistemas Operativos",
-    "description": "Practica 28 preguntas de Entrada/Salida de \"exámenes\" anteriores de Sistemas Operativos, con respuestas modelo y autocorrección. 202318, Universidade da Coruña.",
+    "description": "Practica 28 preguntas de Entrada/Salida de exámenes de Sistemas Operativos, con respuestas modelo y autocorrección. 202318, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/eseo/practice/entrada-salida",
     "ogImage": "https://pe.pablopl.dev/og/eseo.png",
@@ -7583,7 +7583,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/eseo/practice/entrada-salida"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Entrada/Salida: preguntas de Sistemas Operativos\",\"url\":\"https://pe.pablopl.dev/es/eseo/practice/entrada-salida\",\"inLanguage\":\"es\",\"description\":\"Practica 28 preguntas de Entrada/Salida de \\\"exámenes\\\" anteriores de Sistemas Operativos, con respuestas modelo y autocorrección. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Entrada/Salida\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/es/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Entrada/Salida\",\"item\":\"https://pe.pablopl.dev/es/eseo/practice/entrada-salida\"}],\"url\":\"https://pe.pablopl.dev/es/eseo/practice/entrada-salida\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Entrada/Salida: preguntas de Sistemas Operativos\",\"url\":\"https://pe.pablopl.dev/es/eseo/practice/entrada-salida\",\"inLanguage\":\"es\",\"description\":\"Practica 28 preguntas de Entrada/Salida de exámenes de Sistemas Operativos, con respuestas modelo y autocorrección. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Entrada/Salida\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/es/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Entrada/Salida\",\"item\":\"https://pe.pablopl.dev/es/eseo/practice/entrada-salida\"}],\"url\":\"https://pe.pablopl.dev/es/eseo/practice/entrada-salida\"}]}"
   },
   {
     "url": "seo/es/eseo/exam/2020-01.html",
@@ -7878,8 +7878,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/iesede",
-    "title": "Internet y Sistemas Distribuidos: \"exámenes\" y preguntas resueltas",
-    "description": "Practica 18 preguntas de Internet y Sistemas Distribuidos de 1 \"exámenes\" anteriores con respuestas modelo y autocorrección. 200188, Universidade da Coruña.",
+    "title": "Internet y Sistemas Distribuidos: recopilatorios y preguntas resueltas",
+    "description": "Practica 18 preguntas de Internet y Sistemas Distribuidos de 1 recopilatorios de práctica con respuestas modelo y autocorrección. 200188, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/iesede",
     "ogImage": "https://pe.pablopl.dev/og/iesede.png",
@@ -7903,7 +7903,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/iesede"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Internet y Sistemas Distribuidos: \\\"exámenes\\\" y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/iesede\",\"inLanguage\":\"es\",\"description\":\"Practica 18 preguntas de Internet y Sistemas Distribuidos de 1 \\\"exámenes\\\" anteriores con respuestas modelo y autocorrección. 200188, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Internet y Sistemas Distribuidos\",\"courseCode\":\"200188\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Internet y Sistemas Distribuidos\",\"item\":\"https://pe.pablopl.dev/es/iesede\"}],\"url\":\"https://pe.pablopl.dev/es/iesede\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Internet y Sistemas Distribuidos: recopilatorios y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/iesede\",\"inLanguage\":\"es\",\"description\":\"Practica 18 preguntas de Internet y Sistemas Distribuidos de 1 recopilatorios de práctica con respuestas modelo y autocorrección. 200188, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Internet y Sistemas Distribuidos\",\"courseCode\":\"200188\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Internet y Sistemas Distribuidos\",\"item\":\"https://pe.pablopl.dev/es/iesede\"}],\"url\":\"https://pe.pablopl.dev/es/iesede\"}]}"
   },
   {
     "url": "seo/es/iesede/practice/general.html",
@@ -7911,7 +7911,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/iesede/practice/general",
     "title": "General: preguntas de Internet y Sistemas Distribuidos",
-    "description": "Practica 18 preguntas de General de \"exámenes\" anteriores de Internet y Sistemas Distribuidos, con respuestas modelo y autocorrección. 200188, Universidade da Coruña.",
+    "description": "Practica 18 preguntas de General de recopilatorios de Internet y Sistemas Distribuidos, con respuestas modelo y autocorrección. 200188, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/iesede/practice/general",
     "ogImage": "https://pe.pablopl.dev/og/iesede.png",
@@ -7935,15 +7935,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/iesede/practice/general"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"General: preguntas de Internet y Sistemas Distribuidos\",\"url\":\"https://pe.pablopl.dev/es/iesede/practice/general\",\"inLanguage\":\"es\",\"description\":\"Practica 18 preguntas de General de \\\"exámenes\\\" anteriores de Internet y Sistemas Distribuidos, con respuestas modelo y autocorrección. 200188, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"General\"},{\"@type\":\"Course\",\"name\":\"Internet y Sistemas Distribuidos\",\"courseCode\":\"200188\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Internet y Sistemas Distribuidos\",\"item\":\"https://pe.pablopl.dev/es/iesede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"General\",\"item\":\"https://pe.pablopl.dev/es/iesede/practice/general\"}],\"url\":\"https://pe.pablopl.dev/es/iesede/practice/general\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"General: preguntas de Internet y Sistemas Distribuidos\",\"url\":\"https://pe.pablopl.dev/es/iesede/practice/general\",\"inLanguage\":\"es\",\"description\":\"Practica 18 preguntas de General de recopilatorios de Internet y Sistemas Distribuidos, con respuestas modelo y autocorrección. 200188, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"General\"},{\"@type\":\"Course\",\"name\":\"Internet y Sistemas Distribuidos\",\"courseCode\":\"200188\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Internet y Sistemas Distribuidos\",\"item\":\"https://pe.pablopl.dev/es/iesede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"General\",\"item\":\"https://pe.pablopl.dev/es/iesede/practice/general\"}],\"url\":\"https://pe.pablopl.dev/es/iesede/practice/general\"}]}"
   },
   {
     "url": "seo/es/iesede/exam/examen_recopilatorio.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/iesede/exam/examen_recopilatorio",
-    "title": "Recopilación de Internet y Sistemas Distribuidos: simulador",
-    "description": "Simula el examen Recopilación de Internet y Sistemas Distribuidos con 18 preguntas. 18 puntos, 120 minutos, respuestas modelo y autocorrección.",
+    "title": "Recopilación de Internet y Sistemas Distribuidos: práctica cronometrada",
+    "description": "Practica el recopilatorio cronometrado Recopilación de Internet y Sistemas Distribuidos con 18 preguntas. 18 puntos, 120 minutos, respuestas modelo y autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/iesede/exam/examen_recopilatorio",
     "ogImage": "https://pe.pablopl.dev/og/iesede.png",
@@ -7967,15 +7967,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/iesede/exam/examen_recopilatorio"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Recopilación de Internet y Sistemas Distribuidos: simulador\",\"url\":\"https://pe.pablopl.dev/es/iesede/exam/examen_recopilatorio\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Recopilación de Internet y Sistemas Distribuidos con 18 preguntas. 18 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Internet y Sistemas Distribuidos\",\"courseCode\":\"200188\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Internet y Sistemas Distribuidos\",\"item\":\"https://pe.pablopl.dev/es/iesede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Recopilación\",\"item\":\"https://pe.pablopl.dev/es/iesede/exam/examen_recopilatorio\"}],\"url\":\"https://pe.pablopl.dev/es/iesede/exam/examen_recopilatorio\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Recopilación de Internet y Sistemas Distribuidos: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/es/iesede/exam/examen_recopilatorio\",\"inLanguage\":\"es\",\"description\":\"Practica el recopilatorio cronometrado Recopilación de Internet y Sistemas Distribuidos con 18 preguntas. 18 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Internet y Sistemas Distribuidos\",\"courseCode\":\"200188\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Internet y Sistemas Distribuidos\",\"item\":\"https://pe.pablopl.dev/es/iesede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Recopilación\",\"item\":\"https://pe.pablopl.dev/es/iesede/exam/examen_recopilatorio\"}],\"url\":\"https://pe.pablopl.dev/es/iesede/exam/examen_recopilatorio\"}]}"
   },
   {
     "url": "seo/es/peese.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/peese",
-    "title": "Proceso Software: \"exámenes\" y preguntas resueltas",
-    "description": "Practica 17 preguntas de Proceso Software de 1 \"exámenes\" anteriores con respuestas modelo y autocorrección. 202321, Universidade da Coruña.",
+    "title": "Proceso Software: recopilatorios y preguntas resueltas",
+    "description": "Practica 17 preguntas de Proceso Software de 1 recopilatorios de práctica con respuestas modelo y autocorrección. 202321, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/peese",
     "ogImage": "https://pe.pablopl.dev/og/peese.png",
@@ -7999,7 +7999,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/peese"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Proceso Software: \\\"exámenes\\\" y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/peese\",\"inLanguage\":\"es\",\"description\":\"Practica 17 preguntas de Proceso Software de 1 \\\"exámenes\\\" anteriores con respuestas modelo y autocorrección. 202321, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Proceso Software\",\"courseCode\":\"202321\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Proceso Software\",\"item\":\"https://pe.pablopl.dev/es/peese\"}],\"url\":\"https://pe.pablopl.dev/es/peese\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Proceso Software: recopilatorios y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/peese\",\"inLanguage\":\"es\",\"description\":\"Practica 17 preguntas de Proceso Software de 1 recopilatorios de práctica con respuestas modelo y autocorrección. 202321, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Proceso Software\",\"courseCode\":\"202321\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Proceso Software\",\"item\":\"https://pe.pablopl.dev/es/peese\"}],\"url\":\"https://pe.pablopl.dev/es/peese\"}]}"
   },
   {
     "url": "seo/es/peese/practice/teoria.html",
@@ -8007,7 +8007,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/peese/practice/teoria",
     "title": "Teoría: preguntas de Proceso Software | Pásame Exámenes",
-    "description": "Practica 17 preguntas de Teoría de \"exámenes\" anteriores de Proceso Software, con respuestas modelo y autocorrección. 202321, Universidade da Coruña.",
+    "description": "Practica 17 preguntas de Teoría de recopilatorios de Proceso Software, con respuestas modelo y autocorrección. 202321, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/peese/practice/teoria",
     "ogImage": "https://pe.pablopl.dev/og/peese.png",
@@ -8031,15 +8031,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/peese/practice/teoria"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Teoría: preguntas de Proceso Software | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/peese/practice/teoria\",\"inLanguage\":\"es\",\"description\":\"Practica 17 preguntas de Teoría de \\\"exámenes\\\" anteriores de Proceso Software, con respuestas modelo y autocorrección. 202321, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Teoría\"},{\"@type\":\"Course\",\"name\":\"Proceso Software\",\"courseCode\":\"202321\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Proceso Software\",\"item\":\"https://pe.pablopl.dev/es/peese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Teoría\",\"item\":\"https://pe.pablopl.dev/es/peese/practice/teoria\"}],\"url\":\"https://pe.pablopl.dev/es/peese/practice/teoria\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Teoría: preguntas de Proceso Software | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/peese/practice/teoria\",\"inLanguage\":\"es\",\"description\":\"Practica 17 preguntas de Teoría de recopilatorios de Proceso Software, con respuestas modelo y autocorrección. 202321, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Teoría\"},{\"@type\":\"Course\",\"name\":\"Proceso Software\",\"courseCode\":\"202321\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Proceso Software\",\"item\":\"https://pe.pablopl.dev/es/peese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Teoría\",\"item\":\"https://pe.pablopl.dev/es/peese/practice/teoria\"}],\"url\":\"https://pe.pablopl.dev/es/peese/practice/teoria\"}]}"
   },
   {
     "url": "seo/es/peese/exam/2026-05.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/peese/exam/2026-05",
-    "title": "Posibles preguntas Mayo 2026 de Proceso Software: simulador",
-    "description": "Simula el examen Posibles preguntas Mayo 2026 de Proceso Software con 17 preguntas. 8.5 puntos, 120 minutos, respuestas modelo y autocorrección.",
+    "title": "Posibles preguntas Mayo 2026 de Proceso Software: práctica cronometrada",
+    "description": "Practica el recopilatorio cronometrado Posibles preguntas Mayo 2026 de Proceso Software con 17 preguntas. 8.5 puntos, 120 minutos, respuestas modelo y autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/peese/exam/2026-05",
     "ogImage": "https://pe.pablopl.dev/og/peese.png",
@@ -8063,15 +8063,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/peese/exam/2026-05"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Mayo 2026 de Proceso Software: simulador\",\"url\":\"https://pe.pablopl.dev/es/peese/exam/2026-05\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Posibles preguntas Mayo 2026 de Proceso Software con 17 preguntas. 8.5 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Proceso Software\",\"courseCode\":\"202321\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Proceso Software\",\"item\":\"https://pe.pablopl.dev/es/peese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Mayo 2026\",\"item\":\"https://pe.pablopl.dev/es/peese/exam/2026-05\"}],\"url\":\"https://pe.pablopl.dev/es/peese/exam/2026-05\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Mayo 2026 de Proceso Software: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/es/peese/exam/2026-05\",\"inLanguage\":\"es\",\"description\":\"Practica el recopilatorio cronometrado Posibles preguntas Mayo 2026 de Proceso Software con 17 preguntas. 8.5 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Proceso Software\",\"courseCode\":\"202321\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Proceso Software\",\"item\":\"https://pe.pablopl.dev/es/peese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Mayo 2026\",\"item\":\"https://pe.pablopl.dev/es/peese/exam/2026-05\"}],\"url\":\"https://pe.pablopl.dev/es/peese/exam/2026-05\"}]}"
   },
   {
     "url": "seo/es/pei.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/pei",
-    "title": "Programación Integrativa: \"exámenes\" y preguntas resueltas",
-    "description": "Practica 54 preguntas de Programación Integrativa de 1 \"exámenes\" anteriores con respuestas modelo y autocorrección. 200214, Universidade da Coruña.",
+    "title": "Programación Integrativa: recopilatorios y preguntas resueltas",
+    "description": "Practica 54 preguntas de Programación Integrativa de 1 recopilatorios de práctica con respuestas modelo y autocorrección. 200214, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/pei",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -8095,7 +8095,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Programación Integrativa: \\\"exámenes\\\" y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/pei\",\"inLanguage\":\"es\",\"description\":\"Practica 54 preguntas de Programación Integrativa de 1 \\\"exámenes\\\" anteriores con respuestas modelo y autocorrección. 200214, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/es/pei\"}],\"url\":\"https://pe.pablopl.dev/es/pei\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Programación Integrativa: recopilatorios y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/pei\",\"inLanguage\":\"es\",\"description\":\"Practica 54 preguntas de Programación Integrativa de 1 recopilatorios de práctica con respuestas modelo y autocorrección. 200214, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/es/pei\"}],\"url\":\"https://pe.pablopl.dev/es/pei\"}]}"
   },
   {
     "url": "seo/es/pei/practice/pandas.html",
@@ -8103,7 +8103,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/pei/practice/pandas",
     "title": "Pandas y Datos Estructurados: preguntas de Programación Integrativa",
-    "description": "Practica 8 preguntas de Pandas y Datos Estructurados de \"exámenes\" anteriores de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.",
+    "description": "Practica 8 preguntas de Pandas y Datos Estructurados de recopilatorios de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/pei/practice/pandas",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -8127,7 +8127,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei/practice/pandas"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Pandas y Datos Estructurados: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/es/pei/practice/pandas\",\"inLanguage\":\"es\",\"description\":\"Practica 8 preguntas de Pandas y Datos Estructurados de \\\"exámenes\\\" anteriores de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Pandas y Datos Estructurados\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/es/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Pandas y Datos Estructurados\",\"item\":\"https://pe.pablopl.dev/es/pei/practice/pandas\"}],\"url\":\"https://pe.pablopl.dev/es/pei/practice/pandas\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Pandas y Datos Estructurados: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/es/pei/practice/pandas\",\"inLanguage\":\"es\",\"description\":\"Practica 8 preguntas de Pandas y Datos Estructurados de recopilatorios de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Pandas y Datos Estructurados\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/es/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Pandas y Datos Estructurados\",\"item\":\"https://pe.pablopl.dev/es/pei/practice/pandas\"}],\"url\":\"https://pe.pablopl.dev/es/pei/practice/pandas\"}]}"
   },
   {
     "url": "seo/es/pei/practice/poo.html",
@@ -8135,7 +8135,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/pei/practice/poo",
     "title": "POO en Python: preguntas de Programación Integrativa",
-    "description": "Practica 8 preguntas de POO en Python de \"exámenes\" anteriores de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.",
+    "description": "Practica 8 preguntas de POO en Python de recopilatorios de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/pei/practice/poo",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -8159,7 +8159,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei/practice/poo"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"POO en Python: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/es/pei/practice/poo\",\"inLanguage\":\"es\",\"description\":\"Practica 8 preguntas de POO en Python de \\\"exámenes\\\" anteriores de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"POO en Python\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/es/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"POO en Python\",\"item\":\"https://pe.pablopl.dev/es/pei/practice/poo\"}],\"url\":\"https://pe.pablopl.dev/es/pei/practice/poo\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"POO en Python: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/es/pei/practice/poo\",\"inLanguage\":\"es\",\"description\":\"Practica 8 preguntas de POO en Python de recopilatorios de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"POO en Python\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/es/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"POO en Python\",\"item\":\"https://pe.pablopl.dev/es/pei/practice/poo\"}],\"url\":\"https://pe.pablopl.dev/es/pei/practice/poo\"}]}"
   },
   {
     "url": "seo/es/pei/practice/scripting.html",
@@ -8167,7 +8167,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/pei/practice/scripting",
     "title": "Scripting y Regex: preguntas de Programación Integrativa",
-    "description": "Practica 15 preguntas de Scripting y Regex de \"exámenes\" anteriores de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.",
+    "description": "Practica 15 preguntas de Scripting y Regex de recopilatorios de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/pei/practice/scripting",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -8191,7 +8191,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei/practice/scripting"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Scripting y Regex: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/es/pei/practice/scripting\",\"inLanguage\":\"es\",\"description\":\"Practica 15 preguntas de Scripting y Regex de \\\"exámenes\\\" anteriores de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Scripting y Regex\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/es/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Scripting y Regex\",\"item\":\"https://pe.pablopl.dev/es/pei/practice/scripting\"}],\"url\":\"https://pe.pablopl.dev/es/pei/practice/scripting\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Scripting y Regex: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/es/pei/practice/scripting\",\"inLanguage\":\"es\",\"description\":\"Practica 15 preguntas de Scripting y Regex de recopilatorios de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Scripting y Regex\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/es/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Scripting y Regex\",\"item\":\"https://pe.pablopl.dev/es/pei/practice/scripting\"}],\"url\":\"https://pe.pablopl.dev/es/pei/practice/scripting\"}]}"
   },
   {
     "url": "seo/es/pei/practice/django-apis.html",
@@ -8199,7 +8199,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/pei/practice/django-apis",
     "title": "Django, APIs e Integración: preguntas de Programación Integrativa",
-    "description": "Practica 14 preguntas de Django, APIs e Integración de \"exámenes\" anteriores de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.",
+    "description": "Practica 14 preguntas de Django, APIs e Integración de recopilatorios de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/pei/practice/django-apis",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -8223,7 +8223,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei/practice/django-apis"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Django, APIs e Integración: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/es/pei/practice/django-apis\",\"inLanguage\":\"es\",\"description\":\"Practica 14 preguntas de Django, APIs e Integración de \\\"exámenes\\\" anteriores de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Django, APIs e Integración\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/es/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Django, APIs e Integración\",\"item\":\"https://pe.pablopl.dev/es/pei/practice/django-apis\"}],\"url\":\"https://pe.pablopl.dev/es/pei/practice/django-apis\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Django, APIs e Integración: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/es/pei/practice/django-apis\",\"inLanguage\":\"es\",\"description\":\"Practica 14 preguntas de Django, APIs e Integración de recopilatorios de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Django, APIs e Integración\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/es/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Django, APIs e Integración\",\"item\":\"https://pe.pablopl.dev/es/pei/practice/django-apis\"}],\"url\":\"https://pe.pablopl.dev/es/pei/practice/django-apis\"}]}"
   },
   {
     "url": "seo/es/pei/practice/conceptos.html",
@@ -8231,7 +8231,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/pei/practice/conceptos",
     "title": "Conceptos y Test: preguntas de Programación Integrativa",
-    "description": "Practica 9 preguntas de Conceptos y Test de \"exámenes\" anteriores de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.",
+    "description": "Practica 9 preguntas de Conceptos y Test de recopilatorios de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/pei/practice/conceptos",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -8255,15 +8255,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei/practice/conceptos"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Conceptos y Test: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/es/pei/practice/conceptos\",\"inLanguage\":\"es\",\"description\":\"Practica 9 preguntas de Conceptos y Test de \\\"exámenes\\\" anteriores de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Conceptos y Test\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/es/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Conceptos y Test\",\"item\":\"https://pe.pablopl.dev/es/pei/practice/conceptos\"}],\"url\":\"https://pe.pablopl.dev/es/pei/practice/conceptos\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Conceptos y Test: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/es/pei/practice/conceptos\",\"inLanguage\":\"es\",\"description\":\"Practica 9 preguntas de Conceptos y Test de recopilatorios de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Conceptos y Test\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/es/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Conceptos y Test\",\"item\":\"https://pe.pablopl.dev/es/pei/practice/conceptos\"}],\"url\":\"https://pe.pablopl.dev/es/pei/practice/conceptos\"}]}"
   },
   {
     "url": "seo/es/pei/exam/recopilacion.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/pei/exam/recopilacion",
-    "title": "Recopilación de Programación Integrativa: simulador",
-    "description": "Simula el examen Recopilación de Programación Integrativa con 54 preguntas. 30 puntos, 120 minutos, respuestas modelo y autocorrección.",
+    "title": "Recopilación de Programación Integrativa: práctica cronometrada",
+    "description": "Practica el recopilatorio cronometrado Recopilación de Programación Integrativa con 54 preguntas. 30 puntos, 120 minutos, respuestas modelo y autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/pei/exam/recopilacion",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -8287,15 +8287,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei/exam/recopilacion"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Recopilación de Programación Integrativa: simulador\",\"url\":\"https://pe.pablopl.dev/es/pei/exam/recopilacion\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Recopilación de Programación Integrativa con 54 preguntas. 30 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/es/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Recopilación\",\"item\":\"https://pe.pablopl.dev/es/pei/exam/recopilacion\"}],\"url\":\"https://pe.pablopl.dev/es/pei/exam/recopilacion\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Recopilación de Programación Integrativa: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/es/pei/exam/recopilacion\",\"inLanguage\":\"es\",\"description\":\"Practica el recopilatorio cronometrado Recopilación de Programación Integrativa con 54 preguntas. 30 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/es/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Recopilación\",\"item\":\"https://pe.pablopl.dev/es/pei/exam/recopilacion\"}],\"url\":\"https://pe.pablopl.dev/es/pei/exam/recopilacion\"}]}"
   },
   {
     "url": "seo/es/redes.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/redes",
-    "title": "Redes: \"exámenes\" y preguntas resueltas | Pásame Exámenes",
-    "description": "Practica 460 preguntas de Redes de 3 \"exámenes\" anteriores con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
+    "title": "Redes: recopilatorios y preguntas resueltas | Pásame Exámenes",
+    "description": "Practica 460 preguntas de Redes de 3 recopilatorios de práctica con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/redes",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -8319,7 +8319,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Redes: \\\"exámenes\\\" y preguntas resueltas | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/redes\",\"inLanguage\":\"es\",\"description\":\"Practica 460 preguntas de Redes de 3 \\\"exámenes\\\" anteriores con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"}],\"url\":\"https://pe.pablopl.dev/es/redes\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Redes: recopilatorios y preguntas resueltas | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/redes\",\"inLanguage\":\"es\",\"description\":\"Practica 460 preguntas de Redes de 3 recopilatorios de práctica con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"}],\"url\":\"https://pe.pablopl.dev/es/redes\"}]}"
   },
   {
     "url": "seo/es/redes/practice/tema-1.html",
@@ -8327,7 +8327,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/redes/practice/tema-1",
     "title": "Tema 1. Redes de ordenadores e Internet: preguntas de Redes",
-    "description": "Practica 54 preguntas de Tema 1. Redes de ordenadores e Internet de \"exámenes\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 54 preguntas de Tema 1. Redes de ordenadores e Internet de recopilatorios de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/redes/practice/tema-1",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -8351,7 +8351,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-1"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 1. Redes de ordenadores e Internet: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-1\",\"inLanguage\":\"es\",\"description\":\"Practica 54 preguntas de Tema 1. Redes de ordenadores e Internet de \\\"exámenes\\\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 1. Redes de ordenadores e Internet\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 1. Redes de ordenadores e Internet\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-1\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-1\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 1. Redes de ordenadores e Internet: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-1\",\"inLanguage\":\"es\",\"description\":\"Practica 54 preguntas de Tema 1. Redes de ordenadores e Internet de recopilatorios de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 1. Redes de ordenadores e Internet\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 1. Redes de ordenadores e Internet\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-1\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-1\"}]}"
   },
   {
     "url": "seo/es/redes/practice/tema-2.html",
@@ -8359,7 +8359,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/redes/practice/tema-2",
     "title": "Tema 2. Introducción a TCP/IP: preguntas de Redes",
-    "description": "Practica 19 preguntas de Tema 2. Introducción a TCP/IP de \"exámenes\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 19 preguntas de Tema 2. Introducción a TCP/IP de recopilatorios de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/redes/practice/tema-2",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -8383,7 +8383,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-2"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 2. Introducción a TCP/IP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-2\",\"inLanguage\":\"es\",\"description\":\"Practica 19 preguntas de Tema 2. Introducción a TCP/IP de \\\"exámenes\\\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 2. Introducción a TCP/IP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 2. Introducción a TCP/IP\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-2\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-2\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 2. Introducción a TCP/IP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-2\",\"inLanguage\":\"es\",\"description\":\"Practica 19 preguntas de Tema 2. Introducción a TCP/IP de recopilatorios de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 2. Introducción a TCP/IP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 2. Introducción a TCP/IP\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-2\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-2\"}]}"
   },
   {
     "url": "seo/es/redes/practice/tema-3-4.html",
@@ -8391,7 +8391,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/redes/practice/tema-3-4",
     "title": "Tema 3-4. Protocolos nivel de aplicación: preguntas de Redes",
-    "description": "Practica 77 preguntas de Tema 3-4. Protocolos nivel de aplicación de \"exámenes\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 77 preguntas de Tema 3-4. Protocolos nivel de aplicación de recopilatorios de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/redes/practice/tema-3-4",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -8415,7 +8415,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-3-4"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 3-4. Protocolos nivel de aplicación: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-3-4\",\"inLanguage\":\"es\",\"description\":\"Practica 77 preguntas de Tema 3-4. Protocolos nivel de aplicación de \\\"exámenes\\\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 3-4. Protocolos nivel de aplicación\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 3-4. Protocolos nivel de aplicación\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-3-4\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-3-4\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 3-4. Protocolos nivel de aplicación: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-3-4\",\"inLanguage\":\"es\",\"description\":\"Practica 77 preguntas de Tema 3-4. Protocolos nivel de aplicación de recopilatorios de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 3-4. Protocolos nivel de aplicación\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 3-4. Protocolos nivel de aplicación\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-3-4\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-3-4\"}]}"
   },
   {
     "url": "seo/es/redes/practice/tema-5.html",
@@ -8423,7 +8423,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/redes/practice/tema-5",
     "title": "Tema 5. Protocolos de transporte UDP y TCP: preguntas de Redes",
-    "description": "Practica 51 preguntas de Tema 5. Protocolos de transporte UDP y TCP de \"exámenes\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 51 preguntas de Tema 5. Protocolos de transporte UDP y TCP de recopilatorios de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/redes/practice/tema-5",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -8447,7 +8447,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-5"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 5. Protocolos de transporte UDP y TCP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-5\",\"inLanguage\":\"es\",\"description\":\"Practica 51 preguntas de Tema 5. Protocolos de transporte UDP y TCP de \\\"exámenes\\\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 5. Protocolos de transporte UDP y TCP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 5. Protocolos de transporte UDP y TCP\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-5\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-5\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 5. Protocolos de transporte UDP y TCP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-5\",\"inLanguage\":\"es\",\"description\":\"Practica 51 preguntas de Tema 5. Protocolos de transporte UDP y TCP de recopilatorios de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 5. Protocolos de transporte UDP y TCP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 5. Protocolos de transporte UDP y TCP\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-5\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-5\"}]}"
   },
   {
     "url": "seo/es/redes/practice/tema-6.html",
@@ -8455,7 +8455,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/redes/practice/tema-6",
     "title": "Tema 6. Intercambio de datos TCP: preguntas de Redes",
-    "description": "Practica 48 preguntas de Tema 6. Intercambio de datos TCP de \"exámenes\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 48 preguntas de Tema 6. Intercambio de datos TCP de recopilatorios de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/redes/practice/tema-6",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -8479,7 +8479,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-6"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 6. Intercambio de datos TCP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-6\",\"inLanguage\":\"es\",\"description\":\"Practica 48 preguntas de Tema 6. Intercambio de datos TCP de \\\"exámenes\\\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 6. Intercambio de datos TCP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 6. Intercambio de datos TCP\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-6\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-6\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 6. Intercambio de datos TCP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-6\",\"inLanguage\":\"es\",\"description\":\"Practica 48 preguntas de Tema 6. Intercambio de datos TCP de recopilatorios de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 6. Intercambio de datos TCP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 6. Intercambio de datos TCP\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-6\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-6\"}]}"
   },
   {
     "url": "seo/es/redes/practice/tema-7.html",
@@ -8487,7 +8487,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/redes/practice/tema-7",
     "title": "Tema 7. Nivel de red: protocolo IP: preguntas de Redes",
-    "description": "Practica 81 preguntas de Tema 7. Nivel de red: protocolo IP de \"exámenes\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 81 preguntas de Tema 7. Nivel de red: protocolo IP de recopilatorios de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/redes/practice/tema-7",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -8511,7 +8511,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-7"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 7. Nivel de red: protocolo IP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-7\",\"inLanguage\":\"es\",\"description\":\"Practica 81 preguntas de Tema 7. Nivel de red: protocolo IP de \\\"exámenes\\\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 7. Nivel de red: protocolo IP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 7. Nivel de red: protocolo IP\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-7\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-7\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 7. Nivel de red: protocolo IP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-7\",\"inLanguage\":\"es\",\"description\":\"Practica 81 preguntas de Tema 7. Nivel de red: protocolo IP de recopilatorios de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 7. Nivel de red: protocolo IP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 7. Nivel de red: protocolo IP\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-7\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-7\"}]}"
   },
   {
     "url": "seo/es/redes/practice/tema-8.html",
@@ -8519,7 +8519,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/redes/practice/tema-8",
     "title": "Tema 8. Enrutamiento: preguntas de Redes | Pásame Exámenes",
-    "description": "Practica 22 preguntas de Tema 8. Enrutamiento de \"exámenes\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 22 preguntas de Tema 8. Enrutamiento de recopilatorios de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/redes/practice/tema-8",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -8543,7 +8543,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-8"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 8. Enrutamiento: preguntas de Redes | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-8\",\"inLanguage\":\"es\",\"description\":\"Practica 22 preguntas de Tema 8. Enrutamiento de \\\"exámenes\\\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 8. Enrutamiento\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 8. Enrutamiento\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-8\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-8\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 8. Enrutamiento: preguntas de Redes | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-8\",\"inLanguage\":\"es\",\"description\":\"Practica 22 preguntas de Tema 8. Enrutamiento de recopilatorios de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 8. Enrutamiento\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 8. Enrutamiento\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-8\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-8\"}]}"
   },
   {
     "url": "seo/es/redes/practice/tema-9.html",
@@ -8551,7 +8551,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/redes/practice/tema-9",
     "title": "Tema 9. ICMP y fragmentación IP: preguntas de Redes",
-    "description": "Practica 24 preguntas de Tema 9. ICMP y fragmentación IP de \"exámenes\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 24 preguntas de Tema 9. ICMP y fragmentación IP de recopilatorios de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/redes/practice/tema-9",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -8575,7 +8575,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-9"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 9. ICMP y fragmentación IP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-9\",\"inLanguage\":\"es\",\"description\":\"Practica 24 preguntas de Tema 9. ICMP y fragmentación IP de \\\"exámenes\\\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 9. ICMP y fragmentación IP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 9. ICMP y fragmentación IP\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-9\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-9\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 9. ICMP y fragmentación IP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-9\",\"inLanguage\":\"es\",\"description\":\"Practica 24 preguntas de Tema 9. ICMP y fragmentación IP de recopilatorios de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 9. ICMP y fragmentación IP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 9. ICMP y fragmentación IP\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-9\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-9\"}]}"
   },
   {
     "url": "seo/es/redes/practice/tema-10.html",
@@ -8583,7 +8583,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/redes/practice/tema-10",
     "title": "Tema 10. Protocolo IPv6: preguntas de Redes | Pásame Exámenes",
-    "description": "Practica 11 preguntas de Tema 10. Protocolo IPv6 de \"exámenes\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 11 preguntas de Tema 10. Protocolo IPv6 de recopilatorios de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/redes/practice/tema-10",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -8607,7 +8607,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-10"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 10. Protocolo IPv6: preguntas de Redes | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-10\",\"inLanguage\":\"es\",\"description\":\"Practica 11 preguntas de Tema 10. Protocolo IPv6 de \\\"exámenes\\\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 10. Protocolo IPv6\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 10. Protocolo IPv6\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-10\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-10\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 10. Protocolo IPv6: preguntas de Redes | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-10\",\"inLanguage\":\"es\",\"description\":\"Practica 11 preguntas de Tema 10. Protocolo IPv6 de recopilatorios de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 10. Protocolo IPv6\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 10. Protocolo IPv6\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-10\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-10\"}]}"
   },
   {
     "url": "seo/es/redes/practice/tema-11.html",
@@ -8615,7 +8615,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/redes/practice/tema-11",
     "title": "Tema 11. TCP/IP y nivel de enlace: preguntas de Redes",
-    "description": "Practica 24 preguntas de Tema 11. TCP/IP y nivel de enlace de \"exámenes\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 24 preguntas de Tema 11. TCP/IP y nivel de enlace de recopilatorios de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/redes/practice/tema-11",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -8639,7 +8639,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-11"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 11. TCP/IP y nivel de enlace: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-11\",\"inLanguage\":\"es\",\"description\":\"Practica 24 preguntas de Tema 11. TCP/IP y nivel de enlace de \\\"exámenes\\\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 11. TCP/IP y nivel de enlace\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 11. TCP/IP y nivel de enlace\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-11\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-11\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 11. TCP/IP y nivel de enlace: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-11\",\"inLanguage\":\"es\",\"description\":\"Practica 24 preguntas de Tema 11. TCP/IP y nivel de enlace de recopilatorios de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 11. TCP/IP y nivel de enlace\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 11. TCP/IP y nivel de enlace\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-11\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-11\"}]}"
   },
   {
     "url": "seo/es/redes/practice/tema-12.html",
@@ -8647,7 +8647,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/redes/practice/tema-12",
     "title": "Tema 12. Tecnologías del nivel de enlace: preguntas de Redes",
-    "description": "Practica 49 preguntas de Tema 12. Tecnologías del nivel de enlace de \"exámenes\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 49 preguntas de Tema 12. Tecnologías del nivel de enlace de recopilatorios de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/redes/practice/tema-12",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -8671,15 +8671,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-12"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 12. Tecnologías del nivel de enlace: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-12\",\"inLanguage\":\"es\",\"description\":\"Practica 49 preguntas de Tema 12. Tecnologías del nivel de enlace de \\\"exámenes\\\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 12. Tecnologías del nivel de enlace\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 12. Tecnologías del nivel de enlace\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-12\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-12\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 12. Tecnologías del nivel de enlace: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-12\",\"inLanguage\":\"es\",\"description\":\"Practica 49 preguntas de Tema 12. Tecnologías del nivel de enlace de recopilatorios de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 12. Tecnologías del nivel de enlace\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 12. Tecnologías del nivel de enlace\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-12\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-12\"}]}"
   },
   {
     "url": "seo/es/redes/exam/daypo-recopilatorio-lara.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/redes/exam/daypo-recopilatorio-lara",
-    "title": "Daypo Recopilatorio (des. 2008) de Redes: simulador",
-    "description": "Simula el examen Daypo Recopilatorio (des. 2008) de Redes con 125 preguntas. 125 puntos, 120 minutos, respuestas modelo y autocorrección.",
+    "title": "Daypo Recopilatorio (des. 2008) de Redes: práctica cronometrada",
+    "description": "Practica el recopilatorio cronometrado Daypo Recopilatorio (des. 2008) de Redes con 125 preguntas. 125 puntos, 120 minutos, respuestas modelo y autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/redes/exam/daypo-recopilatorio-lara",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -8703,15 +8703,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/exam/daypo-recopilatorio-lara"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Recopilatorio (des. 2008) de Redes: simulador\",\"url\":\"https://pe.pablopl.dev/es/redes/exam/daypo-recopilatorio-lara\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Daypo Recopilatorio (des. 2008) de Redes con 125 preguntas. 125 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Recopilatorio (des. 2008)\",\"item\":\"https://pe.pablopl.dev/es/redes/exam/daypo-recopilatorio-lara\"}],\"url\":\"https://pe.pablopl.dev/es/redes/exam/daypo-recopilatorio-lara\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Recopilatorio (des. 2008) de Redes: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/es/redes/exam/daypo-recopilatorio-lara\",\"inLanguage\":\"es\",\"description\":\"Practica el recopilatorio cronometrado Daypo Recopilatorio (des. 2008) de Redes con 125 preguntas. 125 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Recopilatorio (des. 2008)\",\"item\":\"https://pe.pablopl.dev/es/redes/exam/daypo-recopilatorio-lara\"}],\"url\":\"https://pe.pablopl.dev/es/redes/exam/daypo-recopilatorio-lara\"}]}"
   },
   {
     "url": "seo/es/redes/exam/daypo-recopilatorio-udc.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/redes/exam/daypo-recopilatorio-udc",
-    "title": "Daypo Recopilatorio (UDC) de Redes: simulador",
-    "description": "Simula el examen Daypo Recopilatorio (UDC) de Redes con 298 preguntas. 298 puntos, 240 minutos, respuestas modelo y autocorrección.",
+    "title": "Daypo Recopilatorio (UDC) de Redes: práctica cronometrada",
+    "description": "Practica el recopilatorio cronometrado Daypo Recopilatorio (UDC) de Redes con 298 preguntas. 298 puntos, 240 minutos, respuestas modelo y autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/redes/exam/daypo-recopilatorio-udc",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -8735,15 +8735,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/exam/daypo-recopilatorio-udc"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Recopilatorio (UDC) de Redes: simulador\",\"url\":\"https://pe.pablopl.dev/es/redes/exam/daypo-recopilatorio-udc\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Daypo Recopilatorio (UDC) de Redes con 298 preguntas. 298 puntos, 240 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Recopilatorio (UDC)\",\"item\":\"https://pe.pablopl.dev/es/redes/exam/daypo-recopilatorio-udc\"}],\"url\":\"https://pe.pablopl.dev/es/redes/exam/daypo-recopilatorio-udc\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Recopilatorio (UDC) de Redes: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/es/redes/exam/daypo-recopilatorio-udc\",\"inLanguage\":\"es\",\"description\":\"Practica el recopilatorio cronometrado Daypo Recopilatorio (UDC) de Redes con 298 preguntas. 298 puntos, 240 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Recopilatorio (UDC)\",\"item\":\"https://pe.pablopl.dev/es/redes/exam/daypo-recopilatorio-udc\"}],\"url\":\"https://pe.pablopl.dev/es/redes/exam/daypo-recopilatorio-udc\"}]}"
   },
   {
     "url": "seo/es/redes/exam/2025-05.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/redes/exam/2025-05",
-    "title": "Posibles preguntas Mayo 2025 de Redes: simulador",
-    "description": "Simula el examen Posibles preguntas Mayo 2025 de Redes con 37 preguntas. 37 puntos, 120 minutos, respuestas modelo y autocorrección.",
+    "title": "Posibles preguntas Mayo 2025 de Redes: práctica cronometrada",
+    "description": "Practica el recopilatorio cronometrado Posibles preguntas Mayo 2025 de Redes con 37 preguntas. 37 puntos, 120 minutos, respuestas modelo y autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/redes/exam/2025-05",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -8767,15 +8767,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/exam/2025-05"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Mayo 2025 de Redes: simulador\",\"url\":\"https://pe.pablopl.dev/es/redes/exam/2025-05\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Posibles preguntas Mayo 2025 de Redes con 37 preguntas. 37 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Mayo 2025\",\"item\":\"https://pe.pablopl.dev/es/redes/exam/2025-05\"}],\"url\":\"https://pe.pablopl.dev/es/redes/exam/2025-05\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Mayo 2025 de Redes: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/es/redes/exam/2025-05\",\"inLanguage\":\"es\",\"description\":\"Practica el recopilatorio cronometrado Posibles preguntas Mayo 2025 de Redes con 37 preguntas. 37 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Mayo 2025\",\"item\":\"https://pe.pablopl.dev/es/redes/exam/2025-05\"}],\"url\":\"https://pe.pablopl.dev/es/redes/exam/2025-05\"}]}"
   },
   {
     "url": "seo/gl.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/",
-    "title": "Practica exames universitarios | Pásame Exámenes",
-    "description": "Practica exames universitarios anteriores por tema ou simula exames completos con respostas modelo, autocorrección e preguntas tipo test ou desenvolvemento.",
+    "title": "Practica preguntas universitarias | Pásame Exámenes",
+    "description": "Practica preguntas universitarias por tema ou en modo cronometrado con respostas modelo, autocorrección e preguntas tipo test ou desenvolvemento.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl",
     "ogImage": "https://pe.pablopl.dev/og.jpg",
@@ -8799,15 +8799,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebSite\",\"name\":\"Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl\",\"inLanguage\":\"gl\",\"description\":\"Practica exames universitarios anteriores por tema ou simula exames completos con respostas modelo, autocorrección e preguntas tipo test ou desenvolvemento.\"},{\"@type\":\"WebPage\",\"name\":\"Practica exames universitarios | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl\",\"inLanguage\":\"gl\",\"description\":\"Practica exames universitarios anteriores por tema ou simula exames completos con respostas modelo, autocorrección e preguntas tipo test ou desenvolvemento.\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebSite\",\"name\":\"Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl\",\"inLanguage\":\"gl\",\"description\":\"Practica preguntas universitarias por tema ou en modo cronometrado con respostas modelo, autocorrección e preguntas tipo test ou desenvolvemento.\"},{\"@type\":\"WebPage\",\"name\":\"Practica preguntas universitarias | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl\",\"inLanguage\":\"gl\",\"description\":\"Practica preguntas universitarias por tema ou en modo cronometrado con respostas modelo, autocorrección e preguntas tipo test ou desenvolvemento.\"}]}"
   },
   {
     "url": "seo/gl/bede.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/bede",
-    "title": "Bases de Datos: \"exames\" e preguntas resoltas",
-    "description": "Practica 98 preguntas de Bases de Datos de 1 \"exames\" anteriores con respostas modelo e autocorrección. 202315, Universidade da Coruña.",
+    "title": "Bases de Datos: recompilacións e preguntas resoltas",
+    "description": "Practica 98 preguntas de Bases de Datos de 1 recompilacións de práctica con respostas modelo e autocorrección. 202315, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/bede",
     "ogImage": "https://pe.pablopl.dev/og/bede.png",
@@ -8831,7 +8831,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/bede"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Bases de Datos: \\\"exames\\\" e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/bede\",\"inLanguage\":\"gl\",\"description\":\"Practica 98 preguntas de Bases de Datos de 1 \\\"exames\\\" anteriores con respostas modelo e autocorrección. 202315, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/gl/bede\"}],\"url\":\"https://pe.pablopl.dev/gl/bede\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Bases de Datos: recompilacións e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/bede\",\"inLanguage\":\"gl\",\"description\":\"Practica 98 preguntas de Bases de Datos de 1 recompilacións de práctica con respostas modelo e autocorrección. 202315, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/gl/bede\"}],\"url\":\"https://pe.pablopl.dev/gl/bede\"}]}"
   },
   {
     "url": "seo/gl/bede/practice/recuperacion-concurrencia.html",
@@ -8839,7 +8839,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/bede/practice/recuperacion-concurrencia",
     "title": "Recuperación y Concurrencia: preguntas de Bases de Datos",
-    "description": "Practica 48 preguntas de Recuperación y Concurrencia de \"exames\" anteriores de Bases de Datos, con respostas modelo e autocorrección. 202315, Universidade da Coruña.",
+    "description": "Practica 48 preguntas de Recuperación y Concurrencia de recompilacións de Bases de Datos, con respostas modelo e autocorrección. 202315, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/bede/practice/recuperacion-concurrencia",
     "ogImage": "https://pe.pablopl.dev/og/bede.png",
@@ -8863,7 +8863,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/bede/practice/recuperacion-concurrencia"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Recuperación y Concurrencia: preguntas de Bases de Datos\",\"url\":\"https://pe.pablopl.dev/gl/bede/practice/recuperacion-concurrencia\",\"inLanguage\":\"gl\",\"description\":\"Practica 48 preguntas de Recuperación y Concurrencia de \\\"exames\\\" anteriores de Bases de Datos, con respostas modelo e autocorrección. 202315, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Recuperación y Concurrencia\"},{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/gl/bede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Recuperación y Concurrencia\",\"item\":\"https://pe.pablopl.dev/gl/bede/practice/recuperacion-concurrencia\"}],\"url\":\"https://pe.pablopl.dev/gl/bede/practice/recuperacion-concurrencia\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Recuperación y Concurrencia: preguntas de Bases de Datos\",\"url\":\"https://pe.pablopl.dev/gl/bede/practice/recuperacion-concurrencia\",\"inLanguage\":\"gl\",\"description\":\"Practica 48 preguntas de Recuperación y Concurrencia de recompilacións de Bases de Datos, con respostas modelo e autocorrección. 202315, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Recuperación y Concurrencia\"},{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/gl/bede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Recuperación y Concurrencia\",\"item\":\"https://pe.pablopl.dev/gl/bede/practice/recuperacion-concurrencia\"}],\"url\":\"https://pe.pablopl.dev/gl/bede/practice/recuperacion-concurrencia\"}]}"
   },
   {
     "url": "seo/gl/bede/practice/ficheros.html",
@@ -8871,7 +8871,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/bede/practice/ficheros",
     "title": "Ficheros: preguntas de Bases de Datos | Pásame Exámenes",
-    "description": "Practica 50 preguntas de Ficheros de \"exames\" anteriores de Bases de Datos, con respostas modelo e autocorrección. 202315, Universidade da Coruña.",
+    "description": "Practica 50 preguntas de Ficheros de recompilacións de Bases de Datos, con respostas modelo e autocorrección. 202315, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/bede/practice/ficheros",
     "ogImage": "https://pe.pablopl.dev/og/bede.png",
@@ -8895,15 +8895,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/bede/practice/ficheros"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Ficheros: preguntas de Bases de Datos | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/bede/practice/ficheros\",\"inLanguage\":\"gl\",\"description\":\"Practica 50 preguntas de Ficheros de \\\"exames\\\" anteriores de Bases de Datos, con respostas modelo e autocorrección. 202315, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Ficheros\"},{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/gl/bede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Ficheros\",\"item\":\"https://pe.pablopl.dev/gl/bede/practice/ficheros\"}],\"url\":\"https://pe.pablopl.dev/gl/bede/practice/ficheros\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Ficheros: preguntas de Bases de Datos | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/bede/practice/ficheros\",\"inLanguage\":\"gl\",\"description\":\"Practica 50 preguntas de Ficheros de recompilacións de Bases de Datos, con respostas modelo e autocorrección. 202315, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Ficheros\"},{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/gl/bede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Ficheros\",\"item\":\"https://pe.pablopl.dev/gl/bede/practice/ficheros\"}],\"url\":\"https://pe.pablopl.dev/gl/bede/practice/ficheros\"}]}"
   },
   {
     "url": "seo/gl/bede/exam/daypo-preguntas.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/bede/exam/daypo-preguntas",
-    "title": "Daypo Preguntas de Bases de Datos: simulador | Pásame Exámenes",
-    "description": "Simula o exame Daypo Preguntas de Bases de Datos con 98 preguntas. 98 puntos, 120 minutos, respostas modelo e autocorrección.",
+    "title": "Daypo Preguntas de Bases de Datos: práctica cronometrada",
+    "description": "Practica a recompilación cronometrada Daypo Preguntas de Bases de Datos con 98 preguntas. 98 puntos, 120 minutos, respostas modelo e autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/bede/exam/daypo-preguntas",
     "ogImage": "https://pe.pablopl.dev/og/bede.png",
@@ -8927,15 +8927,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/bede/exam/daypo-preguntas"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Preguntas de Bases de Datos: simulador | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/bede/exam/daypo-preguntas\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Daypo Preguntas de Bases de Datos con 98 preguntas. 98 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/gl/bede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Preguntas\",\"item\":\"https://pe.pablopl.dev/gl/bede/exam/daypo-preguntas\"}],\"url\":\"https://pe.pablopl.dev/gl/bede/exam/daypo-preguntas\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Preguntas de Bases de Datos: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/gl/bede/exam/daypo-preguntas\",\"inLanguage\":\"gl\",\"description\":\"Practica a recompilación cronometrada Daypo Preguntas de Bases de Datos con 98 preguntas. 98 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/gl/bede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Preguntas\",\"item\":\"https://pe.pablopl.dev/gl/bede/exam/daypo-preguntas\"}],\"url\":\"https://pe.pablopl.dev/gl/bede/exam/daypo-preguntas\"}]}"
   },
   {
     "url": "seo/gl/cepe.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/cepe",
-    "title": "Concorrencia e Paralelismo: \"exames\" e preguntas resoltas",
-    "description": "Practica 76 preguntas de Concorrencia e Paralelismo de 16 \"exames\" anteriores con respostas modelo e autocorrección. 202320, Universidade da Coruña.",
+    "title": "Concorrencia e Paralelismo: exames e preguntas resoltas",
+    "description": "Practica 76 preguntas de Concorrencia e Paralelismo de 16 exames con respostas modelo e autocorrección. 202320, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/cepe",
     "ogImage": "https://pe.pablopl.dev/og/cepe.png",
@@ -8959,7 +8959,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/cepe"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Concorrencia e Paralelismo: \\\"exames\\\" e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/cepe\",\"inLanguage\":\"gl\",\"description\":\"Practica 76 preguntas de Concorrencia e Paralelismo de 16 \\\"exames\\\" anteriores con respostas modelo e autocorrección. 202320, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/gl/cepe\"}],\"url\":\"https://pe.pablopl.dev/gl/cepe\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Concorrencia e Paralelismo: exames e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/cepe\",\"inLanguage\":\"gl\",\"description\":\"Practica 76 preguntas de Concorrencia e Paralelismo de 16 exames con respostas modelo e autocorrección. 202320, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/gl/cepe\"}],\"url\":\"https://pe.pablopl.dev/gl/cepe\"}]}"
   },
   {
     "url": "seo/gl/cepe/practice/concurrencia-mutex.html",
@@ -8967,7 +8967,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/cepe/practice/concurrencia-mutex",
     "title": "Mutex y Condiciones: preguntas de Concorrencia e Paralelismo",
-    "description": "Practica 32 preguntas de Mutex y Condiciones de \"exames\" anteriores de Concorrencia e Paralelismo, con respostas modelo e autocorrección. 202320, Universidade da Coruña.",
+    "description": "Practica 32 preguntas de Mutex y Condiciones de exames de Concorrencia e Paralelismo, con respostas modelo e autocorrección. 202320, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/cepe/practice/concurrencia-mutex",
     "ogImage": "https://pe.pablopl.dev/og/cepe.png",
@@ -8991,7 +8991,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/cepe/practice/concurrencia-mutex"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Mutex y Condiciones: preguntas de Concorrencia e Paralelismo\",\"url\":\"https://pe.pablopl.dev/gl/cepe/practice/concurrencia-mutex\",\"inLanguage\":\"gl\",\"description\":\"Practica 32 preguntas de Mutex y Condiciones de \\\"exames\\\" anteriores de Concorrencia e Paralelismo, con respostas modelo e autocorrección. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Mutex y Condiciones\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/gl/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Mutex y Condiciones\",\"item\":\"https://pe.pablopl.dev/gl/cepe/practice/concurrencia-mutex\"}],\"url\":\"https://pe.pablopl.dev/gl/cepe/practice/concurrencia-mutex\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Mutex y Condiciones: preguntas de Concorrencia e Paralelismo\",\"url\":\"https://pe.pablopl.dev/gl/cepe/practice/concurrencia-mutex\",\"inLanguage\":\"gl\",\"description\":\"Practica 32 preguntas de Mutex y Condiciones de exames de Concorrencia e Paralelismo, con respostas modelo e autocorrección. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Mutex y Condiciones\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/gl/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Mutex y Condiciones\",\"item\":\"https://pe.pablopl.dev/gl/cepe/practice/concurrencia-mutex\"}],\"url\":\"https://pe.pablopl.dev/gl/cepe/practice/concurrencia-mutex\"}]}"
   },
   {
     "url": "seo/gl/cepe/practice/concurrencia-erlang.html",
@@ -8999,7 +8999,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/cepe/practice/concurrencia-erlang",
     "title": "Erlang: preguntas de Concorrencia e Paralelismo",
-    "description": "Practica 12 preguntas de Erlang de \"exames\" anteriores de Concorrencia e Paralelismo, con respostas modelo e autocorrección. 202320, Universidade da Coruña.",
+    "description": "Practica 12 preguntas de Erlang de exames de Concorrencia e Paralelismo, con respostas modelo e autocorrección. 202320, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/cepe/practice/concurrencia-erlang",
     "ogImage": "https://pe.pablopl.dev/og/cepe.png",
@@ -9023,7 +9023,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/cepe/practice/concurrencia-erlang"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Erlang: preguntas de Concorrencia e Paralelismo\",\"url\":\"https://pe.pablopl.dev/gl/cepe/practice/concurrencia-erlang\",\"inLanguage\":\"gl\",\"description\":\"Practica 12 preguntas de Erlang de \\\"exames\\\" anteriores de Concorrencia e Paralelismo, con respostas modelo e autocorrección. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Erlang\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/gl/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Erlang\",\"item\":\"https://pe.pablopl.dev/gl/cepe/practice/concurrencia-erlang\"}],\"url\":\"https://pe.pablopl.dev/gl/cepe/practice/concurrencia-erlang\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Erlang: preguntas de Concorrencia e Paralelismo\",\"url\":\"https://pe.pablopl.dev/gl/cepe/practice/concurrencia-erlang\",\"inLanguage\":\"gl\",\"description\":\"Practica 12 preguntas de Erlang de exames de Concorrencia e Paralelismo, con respostas modelo e autocorrección. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Erlang\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/gl/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Erlang\",\"item\":\"https://pe.pablopl.dev/gl/cepe/practice/concurrencia-erlang\"}],\"url\":\"https://pe.pablopl.dev/gl/cepe/practice/concurrencia-erlang\"}]}"
   },
   {
     "url": "seo/gl/cepe/practice/paralelismo-teoria.html",
@@ -9031,7 +9031,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/cepe/practice/paralelismo-teoria",
     "title": "Preguntas Teóricas: preguntas de Concorrencia e Paralelismo",
-    "description": "Practica 19 preguntas de Preguntas Teóricas de \"exames\" anteriores de Concorrencia e Paralelismo, con respostas modelo e autocorrección. 202320, Universidade da Coruña.",
+    "description": "Practica 19 preguntas de Preguntas Teóricas de exames de Concorrencia e Paralelismo, con respostas modelo e autocorrección. 202320, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/cepe/practice/paralelismo-teoria",
     "ogImage": "https://pe.pablopl.dev/og/cepe.png",
@@ -9055,7 +9055,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/cepe/practice/paralelismo-teoria"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Preguntas Teóricas: preguntas de Concorrencia e Paralelismo\",\"url\":\"https://pe.pablopl.dev/gl/cepe/practice/paralelismo-teoria\",\"inLanguage\":\"gl\",\"description\":\"Practica 19 preguntas de Preguntas Teóricas de \\\"exames\\\" anteriores de Concorrencia e Paralelismo, con respostas modelo e autocorrección. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Preguntas Teóricas\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/gl/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Preguntas Teóricas\",\"item\":\"https://pe.pablopl.dev/gl/cepe/practice/paralelismo-teoria\"}],\"url\":\"https://pe.pablopl.dev/gl/cepe/practice/paralelismo-teoria\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Preguntas Teóricas: preguntas de Concorrencia e Paralelismo\",\"url\":\"https://pe.pablopl.dev/gl/cepe/practice/paralelismo-teoria\",\"inLanguage\":\"gl\",\"description\":\"Practica 19 preguntas de Preguntas Teóricas de exames de Concorrencia e Paralelismo, con respostas modelo e autocorrección. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Preguntas Teóricas\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/gl/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Preguntas Teóricas\",\"item\":\"https://pe.pablopl.dev/gl/cepe/practice/paralelismo-teoria\"}],\"url\":\"https://pe.pablopl.dev/gl/cepe/practice/paralelismo-teoria\"}]}"
   },
   {
     "url": "seo/gl/cepe/practice/paralelismo-mpi.html",
@@ -9063,7 +9063,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/cepe/practice/paralelismo-mpi",
     "title": "Ejercicios de MPI: preguntas de Concorrencia e Paralelismo",
-    "description": "Practica 13 preguntas de Ejercicios de MPI de \"exames\" anteriores de Concorrencia e Paralelismo, con respostas modelo e autocorrección. 202320, Universidade da Coruña.",
+    "description": "Practica 13 preguntas de Ejercicios de MPI de exames de Concorrencia e Paralelismo, con respostas modelo e autocorrección. 202320, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/cepe/practice/paralelismo-mpi",
     "ogImage": "https://pe.pablopl.dev/og/cepe.png",
@@ -9087,7 +9087,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/cepe/practice/paralelismo-mpi"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Ejercicios de MPI: preguntas de Concorrencia e Paralelismo\",\"url\":\"https://pe.pablopl.dev/gl/cepe/practice/paralelismo-mpi\",\"inLanguage\":\"gl\",\"description\":\"Practica 13 preguntas de Ejercicios de MPI de \\\"exames\\\" anteriores de Concorrencia e Paralelismo, con respostas modelo e autocorrección. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Ejercicios de MPI\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/gl/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Ejercicios de MPI\",\"item\":\"https://pe.pablopl.dev/gl/cepe/practice/paralelismo-mpi\"}],\"url\":\"https://pe.pablopl.dev/gl/cepe/practice/paralelismo-mpi\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Ejercicios de MPI: preguntas de Concorrencia e Paralelismo\",\"url\":\"https://pe.pablopl.dev/gl/cepe/practice/paralelismo-mpi\",\"inLanguage\":\"gl\",\"description\":\"Practica 13 preguntas de Ejercicios de MPI de exames de Concorrencia e Paralelismo, con respostas modelo e autocorrección. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Ejercicios de MPI\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/gl/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Ejercicios de MPI\",\"item\":\"https://pe.pablopl.dev/gl/cepe/practice/paralelismo-mpi\"}],\"url\":\"https://pe.pablopl.dev/gl/cepe/practice/paralelismo-mpi\"}]}"
   },
   {
     "url": "seo/gl/cepe/exam/2018-06.html",
@@ -9606,8 +9606,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/deese",
-    "title": "Deseño de Software: \"exames\" e preguntas resoltas",
-    "description": "Practica 55 preguntas de Deseño de Software de 2 \"exames\" anteriores con respostas modelo e autocorrección. 202317, Universidade da Coruña.",
+    "title": "Deseño de Software: recompilacións e preguntas resoltas",
+    "description": "Practica 55 preguntas de Deseño de Software de 2 recompilacións de práctica con respostas modelo e autocorrección. 202317, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/deese",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -9631,7 +9631,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Deseño de Software: \\\"exames\\\" e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/deese\",\"inLanguage\":\"gl\",\"description\":\"Practica 55 preguntas de Deseño de Software de 2 \\\"exames\\\" anteriores con respostas modelo e autocorrección. 202317, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/gl/deese\"}],\"url\":\"https://pe.pablopl.dev/gl/deese\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Deseño de Software: recompilacións e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/deese\",\"inLanguage\":\"gl\",\"description\":\"Practica 55 preguntas de Deseño de Software de 2 recompilacións de práctica con respostas modelo e autocorrección. 202317, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/gl/deese\"}],\"url\":\"https://pe.pablopl.dev/gl/deese\"}]}"
   },
   {
     "url": "seo/gl/deese/practice/intro-y-objetos.html",
@@ -9639,7 +9639,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/deese/practice/intro-y-objetos",
     "title": "Introducción y Elementos Básicos de la OO: preguntas de Deseño de Software",
-    "description": "Practica 12 preguntas de Introducción y Elementos Básicos de la OO de \"exames\" anteriores de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.",
+    "description": "Practica 12 preguntas de Introducción y Elementos Básicos de la OO de recompilacións de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/deese/practice/intro-y-objetos",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -9663,7 +9663,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/practice/intro-y-objetos"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Introducción y Elementos Básicos de la OO: preguntas de Deseño de Software\",\"url\":\"https://pe.pablopl.dev/gl/deese/practice/intro-y-objetos\",\"inLanguage\":\"gl\",\"description\":\"Practica 12 preguntas de Introducción y Elementos Básicos de la OO de \\\"exames\\\" anteriores de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Introducción y Elementos Básicos de la OO\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/gl/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Introducción y Elementos Básicos de la OO\",\"item\":\"https://pe.pablopl.dev/gl/deese/practice/intro-y-objetos\"}],\"url\":\"https://pe.pablopl.dev/gl/deese/practice/intro-y-objetos\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Introducción y Elementos Básicos de la OO: preguntas de Deseño de Software\",\"url\":\"https://pe.pablopl.dev/gl/deese/practice/intro-y-objetos\",\"inLanguage\":\"gl\",\"description\":\"Practica 12 preguntas de Introducción y Elementos Básicos de la OO de recompilacións de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Introducción y Elementos Básicos de la OO\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/gl/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Introducción y Elementos Básicos de la OO\",\"item\":\"https://pe.pablopl.dev/gl/deese/practice/intro-y-objetos\"}],\"url\":\"https://pe.pablopl.dev/gl/deese/practice/intro-y-objetos\"}]}"
   },
   {
     "url": "seo/gl/deese/practice/propiedades-oo.html",
@@ -9671,7 +9671,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/deese/practice/propiedades-oo",
     "title": "Propiedades Básicas de la OO: preguntas de Deseño de Software",
-    "description": "Practica 11 preguntas de Propiedades Básicas de la OO de \"exames\" anteriores de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.",
+    "description": "Practica 11 preguntas de Propiedades Básicas de la OO de recompilacións de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/deese/practice/propiedades-oo",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -9695,7 +9695,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/practice/propiedades-oo"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Propiedades Básicas de la OO: preguntas de Deseño de Software\",\"url\":\"https://pe.pablopl.dev/gl/deese/practice/propiedades-oo\",\"inLanguage\":\"gl\",\"description\":\"Practica 11 preguntas de Propiedades Básicas de la OO de \\\"exames\\\" anteriores de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Propiedades Básicas de la OO\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/gl/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Propiedades Básicas de la OO\",\"item\":\"https://pe.pablopl.dev/gl/deese/practice/propiedades-oo\"}],\"url\":\"https://pe.pablopl.dev/gl/deese/practice/propiedades-oo\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Propiedades Básicas de la OO: preguntas de Deseño de Software\",\"url\":\"https://pe.pablopl.dev/gl/deese/practice/propiedades-oo\",\"inLanguage\":\"gl\",\"description\":\"Practica 11 preguntas de Propiedades Básicas de la OO de recompilacións de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Propiedades Básicas de la OO\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/gl/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Propiedades Básicas de la OO\",\"item\":\"https://pe.pablopl.dev/gl/deese/practice/propiedades-oo\"}],\"url\":\"https://pe.pablopl.dev/gl/deese/practice/propiedades-oo\"}]}"
   },
   {
     "url": "seo/gl/deese/practice/uml.html",
@@ -9703,7 +9703,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/deese/practice/uml",
     "title": "UML: preguntas de Deseño de Software | Pásame Exámenes",
-    "description": "Practica 10 preguntas de UML de \"exames\" anteriores de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.",
+    "description": "Practica 10 preguntas de UML de recompilacións de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/deese/practice/uml",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -9727,7 +9727,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/practice/uml"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"UML: preguntas de Deseño de Software | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/deese/practice/uml\",\"inLanguage\":\"gl\",\"description\":\"Practica 10 preguntas de UML de \\\"exames\\\" anteriores de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"UML\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/gl/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"UML\",\"item\":\"https://pe.pablopl.dev/gl/deese/practice/uml\"}],\"url\":\"https://pe.pablopl.dev/gl/deese/practice/uml\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"UML: preguntas de Deseño de Software | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/deese/practice/uml\",\"inLanguage\":\"gl\",\"description\":\"Practica 10 preguntas de UML de recompilacións de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"UML\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/gl/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"UML\",\"item\":\"https://pe.pablopl.dev/gl/deese/practice/uml\"}],\"url\":\"https://pe.pablopl.dev/gl/deese/practice/uml\"}]}"
   },
   {
     "url": "seo/gl/deese/practice/principios-diseno.html",
@@ -9735,7 +9735,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/deese/practice/principios-diseno",
     "title": "Principios de Diseño: preguntas de Deseño de Software",
-    "description": "Practica 12 preguntas de Principios de Diseño de \"exames\" anteriores de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.",
+    "description": "Practica 12 preguntas de Principios de Diseño de recompilacións de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/deese/practice/principios-diseno",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -9759,7 +9759,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/practice/principios-diseno"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Principios de Diseño: preguntas de Deseño de Software\",\"url\":\"https://pe.pablopl.dev/gl/deese/practice/principios-diseno\",\"inLanguage\":\"gl\",\"description\":\"Practica 12 preguntas de Principios de Diseño de \\\"exames\\\" anteriores de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Principios de Diseño\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/gl/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Principios de Diseño\",\"item\":\"https://pe.pablopl.dev/gl/deese/practice/principios-diseno\"}],\"url\":\"https://pe.pablopl.dev/gl/deese/practice/principios-diseno\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Principios de Diseño: preguntas de Deseño de Software\",\"url\":\"https://pe.pablopl.dev/gl/deese/practice/principios-diseno\",\"inLanguage\":\"gl\",\"description\":\"Practica 12 preguntas de Principios de Diseño de recompilacións de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Principios de Diseño\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/gl/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Principios de Diseño\",\"item\":\"https://pe.pablopl.dev/gl/deese/practice/principios-diseno\"}],\"url\":\"https://pe.pablopl.dev/gl/deese/practice/principios-diseno\"}]}"
   },
   {
     "url": "seo/gl/deese/practice/patrones-diseno.html",
@@ -9767,7 +9767,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/deese/practice/patrones-diseno",
     "title": "Patrones de Diseño: preguntas de Deseño de Software",
-    "description": "Practica 10 preguntas de Patrones de Diseño de \"exames\" anteriores de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.",
+    "description": "Practica 10 preguntas de Patrones de Diseño de recompilacións de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/deese/practice/patrones-diseno",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -9791,15 +9791,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/practice/patrones-diseno"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Patrones de Diseño: preguntas de Deseño de Software\",\"url\":\"https://pe.pablopl.dev/gl/deese/practice/patrones-diseno\",\"inLanguage\":\"gl\",\"description\":\"Practica 10 preguntas de Patrones de Diseño de \\\"exames\\\" anteriores de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Patrones de Diseño\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/gl/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Patrones de Diseño\",\"item\":\"https://pe.pablopl.dev/gl/deese/practice/patrones-diseno\"}],\"url\":\"https://pe.pablopl.dev/gl/deese/practice/patrones-diseno\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Patrones de Diseño: preguntas de Deseño de Software\",\"url\":\"https://pe.pablopl.dev/gl/deese/practice/patrones-diseno\",\"inLanguage\":\"gl\",\"description\":\"Practica 10 preguntas de Patrones de Diseño de recompilacións de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Patrones de Diseño\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/gl/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Patrones de Diseño\",\"item\":\"https://pe.pablopl.dev/gl/deese/practice/patrones-diseno\"}],\"url\":\"https://pe.pablopl.dev/gl/deese/practice/patrones-diseno\"}]}"
   },
   {
     "url": "seo/gl/deese/exam/2020-01.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/deese/exam/2020-01",
-    "title": "Posibles preguntas Enero 2020 de Deseño de Software: simulador",
-    "description": "Simula o exame Posibles preguntas Enero 2020 de Deseño de Software con 30 preguntas. 30 puntos, 150 minutos, respostas modelo e autocorrección.",
+    "title": "Posibles preguntas Enero 2020 de Deseño de Software: práctica cronometrada",
+    "description": "Practica a recompilación cronometrada Posibles preguntas Enero 2020 de Deseño de Software con 30 preguntas. 30 puntos, 150 minutos, respostas modelo e autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/deese/exam/2020-01",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -9823,15 +9823,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/exam/2020-01"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Enero 2020 de Deseño de Software: simulador\",\"url\":\"https://pe.pablopl.dev/gl/deese/exam/2020-01\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Posibles preguntas Enero 2020 de Deseño de Software con 30 preguntas. 30 puntos, 150 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/gl/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Enero 2020\",\"item\":\"https://pe.pablopl.dev/gl/deese/exam/2020-01\"}],\"url\":\"https://pe.pablopl.dev/gl/deese/exam/2020-01\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Enero 2020 de Deseño de Software: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/gl/deese/exam/2020-01\",\"inLanguage\":\"gl\",\"description\":\"Practica a recompilación cronometrada Posibles preguntas Enero 2020 de Deseño de Software con 30 preguntas. 30 puntos, 150 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/gl/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Enero 2020\",\"item\":\"https://pe.pablopl.dev/gl/deese/exam/2020-01\"}],\"url\":\"https://pe.pablopl.dev/gl/deese/exam/2020-01\"}]}"
   },
   {
     "url": "seo/gl/deese/exam/2022-01.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/deese/exam/2022-01",
-    "title": "Posibles preguntas Enero 2022 de Deseño de Software: simulador",
-    "description": "Simula o exame Posibles preguntas Enero 2022 de Deseño de Software con 25 preguntas. 25 puntos, 150 minutos, respostas modelo e autocorrección.",
+    "title": "Posibles preguntas Enero 2022 de Deseño de Software: práctica cronometrada",
+    "description": "Practica a recompilación cronometrada Posibles preguntas Enero 2022 de Deseño de Software con 25 preguntas. 25 puntos, 150 minutos, respostas modelo e autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/deese/exam/2022-01",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -9855,15 +9855,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/exam/2022-01"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Enero 2022 de Deseño de Software: simulador\",\"url\":\"https://pe.pablopl.dev/gl/deese/exam/2022-01\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Posibles preguntas Enero 2022 de Deseño de Software con 25 preguntas. 25 puntos, 150 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/gl/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Enero 2022\",\"item\":\"https://pe.pablopl.dev/gl/deese/exam/2022-01\"}],\"url\":\"https://pe.pablopl.dev/gl/deese/exam/2022-01\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Enero 2022 de Deseño de Software: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/gl/deese/exam/2022-01\",\"inLanguage\":\"gl\",\"description\":\"Practica a recompilación cronometrada Posibles preguntas Enero 2022 de Deseño de Software con 25 preguntas. 25 puntos, 150 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/gl/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Enero 2022\",\"item\":\"https://pe.pablopl.dev/gl/deese/exam/2022-01\"}],\"url\":\"https://pe.pablopl.dev/gl/deese/exam/2022-01\"}]}"
   },
   {
     "url": "seo/gl/ece.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/ece",
-    "title": "Estrutura de Computadores: \"exames\" e preguntas resoltas",
-    "description": "Practica 51 preguntas de Estrutura de Computadores de 11 \"exames\" anteriores con respostas modelo e autocorrección. 202314, Universidade da Coruña.",
+    "title": "Estrutura de Computadores: exames e preguntas resoltas",
+    "description": "Practica 51 preguntas de Estrutura de Computadores de 11 exames con respostas modelo e autocorrección. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/ece",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -9887,7 +9887,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Estrutura de Computadores: \\\"exames\\\" e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/ece\",\"inLanguage\":\"gl\",\"description\":\"Practica 51 preguntas de Estrutura de Computadores de 11 \\\"exames\\\" anteriores con respostas modelo e autocorrección. 202314, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/gl/ece\"}],\"url\":\"https://pe.pablopl.dev/gl/ece\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Estrutura de Computadores: exames e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/ece\",\"inLanguage\":\"gl\",\"description\":\"Practica 51 preguntas de Estrutura de Computadores de 11 exames con respostas modelo e autocorrección. 202314, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/gl/ece\"}],\"url\":\"https://pe.pablopl.dev/gl/ece\"}]}"
   },
   {
     "url": "seo/gl/ece/practice/rendimiento.html",
@@ -9895,7 +9895,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/ece/practice/rendimiento",
     "title": "Rendimiento: preguntas de Estrutura de Computadores",
-    "description": "Practica 7 preguntas de Rendimiento de \"exames\" anteriores de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.",
+    "description": "Practica 7 preguntas de Rendimiento de exames de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/ece/practice/rendimiento",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -9919,7 +9919,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece/practice/rendimiento"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Rendimiento: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/gl/ece/practice/rendimiento\",\"inLanguage\":\"gl\",\"description\":\"Practica 7 preguntas de Rendimiento de \\\"exames\\\" anteriores de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Rendimiento\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/gl/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Rendimiento\",\"item\":\"https://pe.pablopl.dev/gl/ece/practice/rendimiento\"}],\"url\":\"https://pe.pablopl.dev/gl/ece/practice/rendimiento\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Rendimiento: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/gl/ece/practice/rendimiento\",\"inLanguage\":\"gl\",\"description\":\"Practica 7 preguntas de Rendimiento de exames de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Rendimiento\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/gl/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Rendimiento\",\"item\":\"https://pe.pablopl.dev/gl/ece/practice/rendimiento\"}],\"url\":\"https://pe.pablopl.dev/gl/ece/practice/rendimiento\"}]}"
   },
   {
     "url": "seo/gl/ece/practice/segmentacion.html",
@@ -9927,7 +9927,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/ece/practice/segmentacion",
     "title": "Segmentación: preguntas de Estrutura de Computadores",
-    "description": "Practica 7 preguntas de Segmentación de \"exames\" anteriores de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.",
+    "description": "Practica 7 preguntas de Segmentación de exames de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/ece/practice/segmentacion",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -9951,7 +9951,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece/practice/segmentacion"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Segmentación: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/gl/ece/practice/segmentacion\",\"inLanguage\":\"gl\",\"description\":\"Practica 7 preguntas de Segmentación de \\\"exames\\\" anteriores de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Segmentación\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/gl/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Segmentación\",\"item\":\"https://pe.pablopl.dev/gl/ece/practice/segmentacion\"}],\"url\":\"https://pe.pablopl.dev/gl/ece/practice/segmentacion\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Segmentación: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/gl/ece/practice/segmentacion\",\"inLanguage\":\"gl\",\"description\":\"Practica 7 preguntas de Segmentación de exames de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Segmentación\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/gl/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Segmentación\",\"item\":\"https://pe.pablopl.dev/gl/ece/practice/segmentacion\"}],\"url\":\"https://pe.pablopl.dev/gl/ece/practice/segmentacion\"}]}"
   },
   {
     "url": "seo/gl/ece/practice/cache.html",
@@ -9959,7 +9959,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/ece/practice/cache",
     "title": "Memoria caché: preguntas de Estrutura de Computadores",
-    "description": "Practica 7 preguntas de Memoria caché de \"exames\" anteriores de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.",
+    "description": "Practica 7 preguntas de Memoria caché de exames de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/ece/practice/cache",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -9983,7 +9983,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece/practice/cache"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Memoria caché: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/gl/ece/practice/cache\",\"inLanguage\":\"gl\",\"description\":\"Practica 7 preguntas de Memoria caché de \\\"exames\\\" anteriores de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Memoria caché\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/gl/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Memoria caché\",\"item\":\"https://pe.pablopl.dev/gl/ece/practice/cache\"}],\"url\":\"https://pe.pablopl.dev/gl/ece/practice/cache\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Memoria caché: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/gl/ece/practice/cache\",\"inLanguage\":\"gl\",\"description\":\"Practica 7 preguntas de Memoria caché de exames de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Memoria caché\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/gl/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Memoria caché\",\"item\":\"https://pe.pablopl.dev/gl/ece/practice/cache\"}],\"url\":\"https://pe.pablopl.dev/gl/ece/practice/cache\"}]}"
   },
   {
     "url": "seo/gl/ece/practice/memoria-virtual.html",
@@ -9991,7 +9991,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/ece/practice/memoria-virtual",
     "title": "Memoria virtual: preguntas de Estrutura de Computadores",
-    "description": "Practica 11 preguntas de Memoria virtual de \"exames\" anteriores de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.",
+    "description": "Practica 11 preguntas de Memoria virtual de exames de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/ece/practice/memoria-virtual",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -10015,7 +10015,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece/practice/memoria-virtual"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Memoria virtual: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/gl/ece/practice/memoria-virtual\",\"inLanguage\":\"gl\",\"description\":\"Practica 11 preguntas de Memoria virtual de \\\"exames\\\" anteriores de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Memoria virtual\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/gl/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Memoria virtual\",\"item\":\"https://pe.pablopl.dev/gl/ece/practice/memoria-virtual\"}],\"url\":\"https://pe.pablopl.dev/gl/ece/practice/memoria-virtual\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Memoria virtual: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/gl/ece/practice/memoria-virtual\",\"inLanguage\":\"gl\",\"description\":\"Practica 11 preguntas de Memoria virtual de exames de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Memoria virtual\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/gl/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Memoria virtual\",\"item\":\"https://pe.pablopl.dev/gl/ece/practice/memoria-virtual\"}],\"url\":\"https://pe.pablopl.dev/gl/ece/practice/memoria-virtual\"}]}"
   },
   {
     "url": "seo/gl/ece/practice/buses.html",
@@ -10023,7 +10023,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/ece/practice/buses",
     "title": "Buses y E/S: preguntas de Estrutura de Computadores",
-    "description": "Practica 11 preguntas de Buses y E/S de \"exames\" anteriores de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.",
+    "description": "Practica 11 preguntas de Buses y E/S de exames de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/ece/practice/buses",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -10047,7 +10047,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece/practice/buses"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Buses y E/S: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/gl/ece/practice/buses\",\"inLanguage\":\"gl\",\"description\":\"Practica 11 preguntas de Buses y E/S de \\\"exames\\\" anteriores de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Buses y E/S\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/gl/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Buses y E/S\",\"item\":\"https://pe.pablopl.dev/gl/ece/practice/buses\"}],\"url\":\"https://pe.pablopl.dev/gl/ece/practice/buses\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Buses y E/S: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/gl/ece/practice/buses\",\"inLanguage\":\"gl\",\"description\":\"Practica 11 preguntas de Buses y E/S de exames de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Buses y E/S\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/gl/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Buses y E/S\",\"item\":\"https://pe.pablopl.dev/gl/ece/practice/buses\"}],\"url\":\"https://pe.pablopl.dev/gl/ece/practice/buses\"}]}"
   },
   {
     "url": "seo/gl/ece/practice/raid.html",
@@ -10055,7 +10055,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/ece/practice/raid",
     "title": "RAID y almacenamiento: preguntas de Estrutura de Computadores",
-    "description": "Practica 8 preguntas de RAID y almacenamiento de \"exames\" anteriores de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.",
+    "description": "Practica 8 preguntas de RAID y almacenamiento de exames de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/ece/practice/raid",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -10079,7 +10079,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece/practice/raid"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"RAID y almacenamiento: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/gl/ece/practice/raid\",\"inLanguage\":\"gl\",\"description\":\"Practica 8 preguntas de RAID y almacenamiento de \\\"exames\\\" anteriores de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"RAID y almacenamiento\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/gl/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"RAID y almacenamiento\",\"item\":\"https://pe.pablopl.dev/gl/ece/practice/raid\"}],\"url\":\"https://pe.pablopl.dev/gl/ece/practice/raid\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"RAID y almacenamiento: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/gl/ece/practice/raid\",\"inLanguage\":\"gl\",\"description\":\"Practica 8 preguntas de RAID y almacenamiento de exames de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"RAID y almacenamiento\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/gl/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"RAID y almacenamiento\",\"item\":\"https://pe.pablopl.dev/gl/ece/practice/raid\"}],\"url\":\"https://pe.pablopl.dev/gl/ece/practice/raid\"}]}"
   },
   {
     "url": "seo/gl/ece/exam/2021-01.html",
@@ -10438,8 +10438,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/emeele",
-    "title": "Introduction to Machine Learning: \"exames\" e preguntas resoltas",
-    "description": "Practica 47 preguntas de Introduction to Machine Learning de 2 \"exames\" anteriores con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
+    "title": "Introduction to Machine Learning: exames e preguntas resoltas",
+    "description": "Practica 47 preguntas de Introduction to Machine Learning de 2 exames con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/emeele",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -10463,7 +10463,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Introduction to Machine Learning: \\\"exames\\\" e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/emeele\",\"inLanguage\":\"gl\",\"description\":\"Practica 47 preguntas de Introduction to Machine Learning de 2 \\\"exames\\\" anteriores con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Linnaeus University\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Introduction to Machine Learning: exames e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/emeele\",\"inLanguage\":\"gl\",\"description\":\"Practica 47 preguntas de Introduction to Machine Learning de 2 exames con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Linnaeus University\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele\"}]}"
   },
   {
     "url": "seo/gl/emeele/practice/kNN.html",
@@ -10471,7 +10471,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/emeele/practice/kNN",
     "title": "k-Nearest Neighbors: preguntas de Introduction to Machine Learning",
-    "description": "Practica 6 preguntas de k-Nearest Neighbors de \"exames\" anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
+    "description": "Practica 6 preguntas de k-Nearest Neighbors de exames de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/emeele/practice/kNN",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -10495,7 +10495,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/kNN"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"k-Nearest Neighbors: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/kNN\",\"inLanguage\":\"gl\",\"description\":\"Practica 6 preguntas de k-Nearest Neighbors de \\\"exames\\\" anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"k-Nearest Neighbors\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"k-Nearest Neighbors\",\"item\":\"https://pe.pablopl.dev/gl/emeele/practice/kNN\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/kNN\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"k-Nearest Neighbors: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/kNN\",\"inLanguage\":\"gl\",\"description\":\"Practica 6 preguntas de k-Nearest Neighbors de exames de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"k-Nearest Neighbors\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"k-Nearest Neighbors\",\"item\":\"https://pe.pablopl.dev/gl/emeele/practice/kNN\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/kNN\"}]}"
   },
   {
     "url": "seo/gl/emeele/practice/Bias-Variance.html",
@@ -10503,7 +10503,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/emeele/practice/Bias-Variance",
     "title": "Bias-Variance Tradeoff: preguntas de Introduction to Machine Learning",
-    "description": "Practica 5 preguntas de Bias-Variance Tradeoff de \"exames\" anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
+    "description": "Practica 5 preguntas de Bias-Variance Tradeoff de exames de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/emeele/practice/Bias-Variance",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -10527,7 +10527,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Bias-Variance"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Bias-Variance Tradeoff: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Bias-Variance\",\"inLanguage\":\"gl\",\"description\":\"Practica 5 preguntas de Bias-Variance Tradeoff de \\\"exames\\\" anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Bias-Variance Tradeoff\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Bias-Variance Tradeoff\",\"item\":\"https://pe.pablopl.dev/gl/emeele/practice/Bias-Variance\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Bias-Variance\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Bias-Variance Tradeoff: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Bias-Variance\",\"inLanguage\":\"gl\",\"description\":\"Practica 5 preguntas de Bias-Variance Tradeoff de exames de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Bias-Variance Tradeoff\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Bias-Variance Tradeoff\",\"item\":\"https://pe.pablopl.dev/gl/emeele/practice/Bias-Variance\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Bias-Variance\"}]}"
   },
   {
     "url": "seo/gl/emeele/practice/Linear%20%26%20Logistic%20Regression.html",
@@ -10535,7 +10535,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/emeele/practice/Linear & Logistic Regression",
     "title": "Linear & Logistic Regression: preguntas de Introduction to Machine Learning",
-    "description": "Practica 5 preguntas de Linear & Logistic Regression de \"exames\" anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
+    "description": "Practica 5 preguntas de Linear & Logistic Regression de exames de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/emeele/practice/Linear%20%26%20Logistic%20Regression",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -10559,7 +10559,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Linear%20%26%20Logistic%20Regression"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Linear & Logistic Regression: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Linear%20%26%20Logistic%20Regression\",\"inLanguage\":\"gl\",\"description\":\"Practica 5 preguntas de Linear & Logistic Regression de \\\"exames\\\" anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Linear & Logistic Regression\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Linear & Logistic Regression\",\"item\":\"https://pe.pablopl.dev/gl/emeele/practice/Linear%20%26%20Logistic%20Regression\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Linear%20%26%20Logistic%20Regression\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Linear & Logistic Regression: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Linear%20%26%20Logistic%20Regression\",\"inLanguage\":\"gl\",\"description\":\"Practica 5 preguntas de Linear & Logistic Regression de exames de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Linear & Logistic Regression\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Linear & Logistic Regression\",\"item\":\"https://pe.pablopl.dev/gl/emeele/practice/Linear%20%26%20Logistic%20Regression\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Linear%20%26%20Logistic%20Regression\"}]}"
   },
   {
     "url": "seo/gl/emeele/practice/Model%20Selection%20%26%20Regularization.html",
@@ -10567,7 +10567,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/emeele/practice/Model Selection & Regularization",
     "title": "Model Selection & Regularization: preguntas de Introduction to Machine Learning",
-    "description": "Practica 5 preguntas de Model Selection & Regularization de \"exames\" anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
+    "description": "Practica 5 preguntas de Model Selection & Regularization de exames de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/emeele/practice/Model%20Selection%20%26%20Regularization",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -10591,7 +10591,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Model%20Selection%20%26%20Regularization"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Model Selection & Regularization: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Model%20Selection%20%26%20Regularization\",\"inLanguage\":\"gl\",\"description\":\"Practica 5 preguntas de Model Selection & Regularization de \\\"exames\\\" anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Model Selection & Regularization\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Model Selection & Regularization\",\"item\":\"https://pe.pablopl.dev/gl/emeele/practice/Model%20Selection%20%26%20Regularization\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Model%20Selection%20%26%20Regularization\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Model Selection & Regularization: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Model%20Selection%20%26%20Regularization\",\"inLanguage\":\"gl\",\"description\":\"Practica 5 preguntas de Model Selection & Regularization de exames de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Model Selection & Regularization\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Model Selection & Regularization\",\"item\":\"https://pe.pablopl.dev/gl/emeele/practice/Model%20Selection%20%26%20Regularization\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Model%20Selection%20%26%20Regularization\"}]}"
   },
   {
     "url": "seo/gl/emeele/practice/Neural%20Networks.html",
@@ -10599,7 +10599,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/emeele/practice/Neural Networks",
     "title": "Neural Networks: preguntas de Introduction to Machine Learning",
-    "description": "Practica 6 preguntas de Neural Networks de \"exames\" anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
+    "description": "Practica 6 preguntas de Neural Networks de exames de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/emeele/practice/Neural%20Networks",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -10623,7 +10623,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Neural%20Networks"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Neural Networks: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Neural%20Networks\",\"inLanguage\":\"gl\",\"description\":\"Practica 6 preguntas de Neural Networks de \\\"exames\\\" anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Neural Networks\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Neural Networks\",\"item\":\"https://pe.pablopl.dev/gl/emeele/practice/Neural%20Networks\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Neural%20Networks\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Neural Networks: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Neural%20Networks\",\"inLanguage\":\"gl\",\"description\":\"Practica 6 preguntas de Neural Networks de exames de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Neural Networks\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Neural Networks\",\"item\":\"https://pe.pablopl.dev/gl/emeele/practice/Neural%20Networks\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Neural%20Networks\"}]}"
   },
   {
     "url": "seo/gl/emeele/practice/Decision%20Trees%20%26%20Ensembles.html",
@@ -10631,7 +10631,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/emeele/practice/Decision Trees & Ensembles",
     "title": "Decision Trees & Ensembles: preguntas de Introduction to Machine Learning",
-    "description": "Practica 4 preguntas de Decision Trees & Ensembles de \"exames\" anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
+    "description": "Practica 4 preguntas de Decision Trees & Ensembles de exames de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/emeele/practice/Decision%20Trees%20%26%20Ensembles",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -10655,7 +10655,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Decision%20Trees%20%26%20Ensembles"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Decision Trees & Ensembles: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Decision%20Trees%20%26%20Ensembles\",\"inLanguage\":\"gl\",\"description\":\"Practica 4 preguntas de Decision Trees & Ensembles de \\\"exames\\\" anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Decision Trees & Ensembles\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Decision Trees & Ensembles\",\"item\":\"https://pe.pablopl.dev/gl/emeele/practice/Decision%20Trees%20%26%20Ensembles\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Decision%20Trees%20%26%20Ensembles\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Decision Trees & Ensembles: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Decision%20Trees%20%26%20Ensembles\",\"inLanguage\":\"gl\",\"description\":\"Practica 4 preguntas de Decision Trees & Ensembles de exames de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Decision Trees & Ensembles\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Decision Trees & Ensembles\",\"item\":\"https://pe.pablopl.dev/gl/emeele/practice/Decision%20Trees%20%26%20Ensembles\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Decision%20Trees%20%26%20Ensembles\"}]}"
   },
   {
     "url": "seo/gl/emeele/practice/Support%20Vector%20Machines.html",
@@ -10663,7 +10663,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/emeele/practice/Support Vector Machines",
     "title": "Support Vector Machines: preguntas de Introduction to Machine Learning",
-    "description": "Practica 6 preguntas de Support Vector Machines de \"exames\" anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
+    "description": "Practica 6 preguntas de Support Vector Machines de exames de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/emeele/practice/Support%20Vector%20Machines",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -10687,7 +10687,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Support%20Vector%20Machines"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Support Vector Machines: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Support%20Vector%20Machines\",\"inLanguage\":\"gl\",\"description\":\"Practica 6 preguntas de Support Vector Machines de \\\"exames\\\" anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Support Vector Machines\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Support Vector Machines\",\"item\":\"https://pe.pablopl.dev/gl/emeele/practice/Support%20Vector%20Machines\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Support%20Vector%20Machines\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Support Vector Machines: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Support%20Vector%20Machines\",\"inLanguage\":\"gl\",\"description\":\"Practica 6 preguntas de Support Vector Machines de exames de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Support Vector Machines\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Support Vector Machines\",\"item\":\"https://pe.pablopl.dev/gl/emeele/practice/Support%20Vector%20Machines\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Support%20Vector%20Machines\"}]}"
   },
   {
     "url": "seo/gl/emeele/practice/Clustering.html",
@@ -10695,7 +10695,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/emeele/practice/Clustering",
     "title": "Clustering: preguntas de Introduction to Machine Learning",
-    "description": "Practica 6 preguntas de Clustering de \"exames\" anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
+    "description": "Practica 6 preguntas de Clustering de exames de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/emeele/practice/Clustering",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -10719,7 +10719,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Clustering"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Clustering: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Clustering\",\"inLanguage\":\"gl\",\"description\":\"Practica 6 preguntas de Clustering de \\\"exames\\\" anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Clustering\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Clustering\",\"item\":\"https://pe.pablopl.dev/gl/emeele/practice/Clustering\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Clustering\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Clustering: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Clustering\",\"inLanguage\":\"gl\",\"description\":\"Practica 6 preguntas de Clustering de exames de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Clustering\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Clustering\",\"item\":\"https://pe.pablopl.dev/gl/emeele/practice/Clustering\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Clustering\"}]}"
   },
   {
     "url": "seo/gl/emeele/practice/Dimensionality%20Reduction.html",
@@ -10727,7 +10727,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/emeele/practice/Dimensionality Reduction",
     "title": "Dimensionality Reduction: preguntas de Introduction to Machine Learning",
-    "description": "Practica 4 preguntas de Dimensionality Reduction de \"exames\" anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
+    "description": "Practica 4 preguntas de Dimensionality Reduction de exames de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/emeele/practice/Dimensionality%20Reduction",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -10751,7 +10751,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Dimensionality%20Reduction"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Dimensionality Reduction: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Dimensionality%20Reduction\",\"inLanguage\":\"gl\",\"description\":\"Practica 4 preguntas de Dimensionality Reduction de \\\"exames\\\" anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Dimensionality Reduction\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Dimensionality Reduction\",\"item\":\"https://pe.pablopl.dev/gl/emeele/practice/Dimensionality%20Reduction\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Dimensionality%20Reduction\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Dimensionality Reduction: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Dimensionality%20Reduction\",\"inLanguage\":\"gl\",\"description\":\"Practica 4 preguntas de Dimensionality Reduction de exames de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Dimensionality Reduction\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Dimensionality Reduction\",\"item\":\"https://pe.pablopl.dev/gl/emeele/practice/Dimensionality%20Reduction\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Dimensionality%20Reduction\"}]}"
   },
   {
     "url": "seo/gl/emeele/exam/2024.html",
@@ -10822,8 +10822,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/equisi",
-    "title": "Xestión de Infraestruturas: \"exames\" e preguntas resoltas",
-    "description": "Practica 381 preguntas de Xestión de Infraestruturas de 4 \"exames\" anteriores con respostas modelo e autocorrección. 200190, Universidade da Coruña.",
+    "title": "Xestión de Infraestruturas: recompilacións e preguntas resoltas",
+    "description": "Practica 381 preguntas de Xestión de Infraestruturas de 4 recompilacións de práctica con respostas modelo e autocorrección. 200190, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/equisi",
     "ogImage": "https://pe.pablopl.dev/og/equisi.png",
@@ -10847,7 +10847,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equisi"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Xestión de Infraestruturas: \\\"exames\\\" e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/equisi\",\"inLanguage\":\"gl\",\"description\":\"Practica 381 preguntas de Xestión de Infraestruturas de 4 \\\"exames\\\" anteriores con respostas modelo e autocorrección. 200190, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/gl/equisi\"}],\"url\":\"https://pe.pablopl.dev/gl/equisi\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Xestión de Infraestruturas: recompilacións e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/equisi\",\"inLanguage\":\"gl\",\"description\":\"Practica 381 preguntas de Xestión de Infraestruturas de 4 recompilacións de práctica con respostas modelo e autocorrección. 200190, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/gl/equisi\"}],\"url\":\"https://pe.pablopl.dev/gl/equisi\"}]}"
   },
   {
     "url": "seo/gl/equisi/practice/modulo-i.html",
@@ -10855,7 +10855,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/equisi/practice/modulo-i",
     "title": "Módulo I: Sinais e Comunicacións: preguntas de Xestión de Infraestruturas",
-    "description": "Practica 130 preguntas de Módulo I: Sinais e Comunicacións de \"exames\" anteriores de Xestión de Infraestruturas, con respostas modelo e autocorrección. 200190, Universidade da Coruña.",
+    "description": "Practica 130 preguntas de Módulo I: Sinais e Comunicacións de recompilacións de Xestión de Infraestruturas, con respostas modelo e autocorrección. 200190, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/equisi/practice/modulo-i",
     "ogImage": "https://pe.pablopl.dev/og/equisi.png",
@@ -10879,7 +10879,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equisi/practice/modulo-i"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Módulo I: Sinais e Comunicacións: preguntas de Xestión de Infraestruturas\",\"url\":\"https://pe.pablopl.dev/gl/equisi/practice/modulo-i\",\"inLanguage\":\"gl\",\"description\":\"Practica 130 preguntas de Módulo I: Sinais e Comunicacións de \\\"exames\\\" anteriores de Xestión de Infraestruturas, con respostas modelo e autocorrección. 200190, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Módulo I: Sinais e Comunicacións\"},{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/gl/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Módulo I: Sinais e Comunicacións\",\"item\":\"https://pe.pablopl.dev/gl/equisi/practice/modulo-i\"}],\"url\":\"https://pe.pablopl.dev/gl/equisi/practice/modulo-i\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Módulo I: Sinais e Comunicacións: preguntas de Xestión de Infraestruturas\",\"url\":\"https://pe.pablopl.dev/gl/equisi/practice/modulo-i\",\"inLanguage\":\"gl\",\"description\":\"Practica 130 preguntas de Módulo I: Sinais e Comunicacións de recompilacións de Xestión de Infraestruturas, con respostas modelo e autocorrección. 200190, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Módulo I: Sinais e Comunicacións\"},{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/gl/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Módulo I: Sinais e Comunicacións\",\"item\":\"https://pe.pablopl.dev/gl/equisi/practice/modulo-i\"}],\"url\":\"https://pe.pablopl.dev/gl/equisi/practice/modulo-i\"}]}"
   },
   {
     "url": "seo/gl/equisi/practice/modulo-ii.html",
@@ -10887,7 +10887,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/equisi/practice/modulo-ii",
     "title": "Módulo II: Infraestruturas TI: preguntas de Xestión de Infraestruturas",
-    "description": "Practica 251 preguntas de Módulo II: Infraestruturas TI de \"exames\" anteriores de Xestión de Infraestruturas, con respostas modelo e autocorrección. 200190, Universidade da Coruña.",
+    "description": "Practica 251 preguntas de Módulo II: Infraestruturas TI de recompilacións de Xestión de Infraestruturas, con respostas modelo e autocorrección. 200190, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/equisi/practice/modulo-ii",
     "ogImage": "https://pe.pablopl.dev/og/equisi.png",
@@ -10911,15 +10911,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equisi/practice/modulo-ii"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Módulo II: Infraestruturas TI: preguntas de Xestión de Infraestruturas\",\"url\":\"https://pe.pablopl.dev/gl/equisi/practice/modulo-ii\",\"inLanguage\":\"gl\",\"description\":\"Practica 251 preguntas de Módulo II: Infraestruturas TI de \\\"exames\\\" anteriores de Xestión de Infraestruturas, con respostas modelo e autocorrección. 200190, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Módulo II: Infraestruturas TI\"},{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/gl/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Módulo II: Infraestruturas TI\",\"item\":\"https://pe.pablopl.dev/gl/equisi/practice/modulo-ii\"}],\"url\":\"https://pe.pablopl.dev/gl/equisi/practice/modulo-ii\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Módulo II: Infraestruturas TI: preguntas de Xestión de Infraestruturas\",\"url\":\"https://pe.pablopl.dev/gl/equisi/practice/modulo-ii\",\"inLanguage\":\"gl\",\"description\":\"Practica 251 preguntas de Módulo II: Infraestruturas TI de recompilacións de Xestión de Infraestruturas, con respostas modelo e autocorrección. 200190, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Módulo II: Infraestruturas TI\"},{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/gl/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Módulo II: Infraestruturas TI\",\"item\":\"https://pe.pablopl.dev/gl/equisi/practice/modulo-ii\"}],\"url\":\"https://pe.pablopl.dev/gl/equisi/practice/modulo-ii\"}]}"
   },
   {
     "url": "seo/gl/equisi/exam/2024-07.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/equisi/exam/2024-07",
-    "title": "Posibles preguntas Xullo 2024 de Xestión de Infraestruturas: simulador",
-    "description": "Simula o exame Posibles preguntas Xullo 2024 de Xestión de Infraestruturas con 20 preguntas. 10 puntos, 45 minutos, respostas modelo e autocorrección.",
+    "title": "Posibles preguntas Xullo 2024 de Xestión de Infraestruturas: práctica cronometrada",
+    "description": "Practica a recompilación cronometrada Posibles preguntas Xullo 2024 de Xestión de Infraestruturas con 20 preguntas. 10 puntos, 45 minutos, respostas modelo e autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/equisi/exam/2024-07",
     "ogImage": "https://pe.pablopl.dev/og/equisi.png",
@@ -10943,15 +10943,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equisi/exam/2024-07"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Xullo 2024 de Xestión de Infraestruturas: simulador\",\"url\":\"https://pe.pablopl.dev/gl/equisi/exam/2024-07\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Posibles preguntas Xullo 2024 de Xestión de Infraestruturas con 20 preguntas. 10 puntos, 45 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/gl/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Xullo 2024\",\"item\":\"https://pe.pablopl.dev/gl/equisi/exam/2024-07\"}],\"url\":\"https://pe.pablopl.dev/gl/equisi/exam/2024-07\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Xullo 2024 de Xestión de Infraestruturas: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/gl/equisi/exam/2024-07\",\"inLanguage\":\"gl\",\"description\":\"Practica a recompilación cronometrada Posibles preguntas Xullo 2024 de Xestión de Infraestruturas con 20 preguntas. 10 puntos, 45 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/gl/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Xullo 2024\",\"item\":\"https://pe.pablopl.dev/gl/equisi/exam/2024-07\"}],\"url\":\"https://pe.pablopl.dev/gl/equisi/exam/2024-07\"}]}"
   },
   {
     "url": "seo/gl/equisi/exam/daypo-modulo-i.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/equisi/exam/daypo-modulo-i",
-    "title": "Daypo Módulo I de Xestión de Infraestruturas: simulador",
-    "description": "Simula o exame Daypo Módulo I de Xestión de Infraestruturas con 130 preguntas. 130 puntos, 120 minutos, respostas modelo e autocorrección.",
+    "title": "Daypo Módulo I de Xestión de Infraestruturas: práctica cronometrada",
+    "description": "Practica a recompilación cronometrada Daypo Módulo I de Xestión de Infraestruturas con 130 preguntas. 130 puntos, 120 minutos, respostas modelo e autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/equisi/exam/daypo-modulo-i",
     "ogImage": "https://pe.pablopl.dev/og/equisi.png",
@@ -10975,15 +10975,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equisi/exam/daypo-modulo-i"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Módulo I de Xestión de Infraestruturas: simulador\",\"url\":\"https://pe.pablopl.dev/gl/equisi/exam/daypo-modulo-i\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Daypo Módulo I de Xestión de Infraestruturas con 130 preguntas. 130 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/gl/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Módulo I\",\"item\":\"https://pe.pablopl.dev/gl/equisi/exam/daypo-modulo-i\"}],\"url\":\"https://pe.pablopl.dev/gl/equisi/exam/daypo-modulo-i\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Módulo I de Xestión de Infraestruturas: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/gl/equisi/exam/daypo-modulo-i\",\"inLanguage\":\"gl\",\"description\":\"Practica a recompilación cronometrada Daypo Módulo I de Xestión de Infraestruturas con 130 preguntas. 130 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/gl/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Módulo I\",\"item\":\"https://pe.pablopl.dev/gl/equisi/exam/daypo-modulo-i\"}],\"url\":\"https://pe.pablopl.dev/gl/equisi/exam/daypo-modulo-i\"}]}"
   },
   {
     "url": "seo/gl/equisi/exam/daypo-modulo-ii.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/equisi/exam/daypo-modulo-ii",
-    "title": "Daypo Módulo II de Xestión de Infraestruturas: simulador",
-    "description": "Simula o exame Daypo Módulo II de Xestión de Infraestruturas con 109 preguntas. 109 puntos, 120 minutos, respostas modelo e autocorrección.",
+    "title": "Daypo Módulo II de Xestión de Infraestruturas: práctica cronometrada",
+    "description": "Practica a recompilación cronometrada Daypo Módulo II de Xestión de Infraestruturas con 109 preguntas. 109 puntos, 120 minutos, respostas modelo e autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/equisi/exam/daypo-modulo-ii",
     "ogImage": "https://pe.pablopl.dev/og/equisi.png",
@@ -11007,15 +11007,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equisi/exam/daypo-modulo-ii"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Módulo II de Xestión de Infraestruturas: simulador\",\"url\":\"https://pe.pablopl.dev/gl/equisi/exam/daypo-modulo-ii\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Daypo Módulo II de Xestión de Infraestruturas con 109 preguntas. 109 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/gl/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Módulo II\",\"item\":\"https://pe.pablopl.dev/gl/equisi/exam/daypo-modulo-ii\"}],\"url\":\"https://pe.pablopl.dev/gl/equisi/exam/daypo-modulo-ii\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Módulo II de Xestión de Infraestruturas: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/gl/equisi/exam/daypo-modulo-ii\",\"inLanguage\":\"gl\",\"description\":\"Practica a recompilación cronometrada Daypo Módulo II de Xestión de Infraestruturas con 109 preguntas. 109 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/gl/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Módulo II\",\"item\":\"https://pe.pablopl.dev/gl/equisi/exam/daypo-modulo-ii\"}],\"url\":\"https://pe.pablopl.dev/gl/equisi/exam/daypo-modulo-ii\"}]}"
   },
   {
     "url": "seo/gl/equisi/exam/megarecopilacion.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/equisi/exam/megarecopilacion",
-    "title": "Megarecopilación Test XI de Xestión de Infraestruturas: simulador",
-    "description": "Simula o exame Megarecopilación Test XI de Xestión de Infraestruturas con 122 preguntas. 122 puntos, 90 minutos, respostas modelo e autocorrección.",
+    "title": "Megarecopilación Test XI de Xestión de Infraestruturas: práctica cronometrada",
+    "description": "Practica a recompilación cronometrada Megarecopilación Test XI de Xestión de Infraestruturas con 122 preguntas. 122 puntos, 90 minutos, respostas modelo e autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/equisi/exam/megarecopilacion",
     "ogImage": "https://pe.pablopl.dev/og/equisi.png",
@@ -11039,15 +11039,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equisi/exam/megarecopilacion"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Megarecopilación Test XI de Xestión de Infraestruturas: simulador\",\"url\":\"https://pe.pablopl.dev/gl/equisi/exam/megarecopilacion\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Megarecopilación Test XI de Xestión de Infraestruturas con 122 preguntas. 122 puntos, 90 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/gl/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Megarecopilación Test XI\",\"item\":\"https://pe.pablopl.dev/gl/equisi/exam/megarecopilacion\"}],\"url\":\"https://pe.pablopl.dev/gl/equisi/exam/megarecopilacion\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Megarecopilación Test XI de Xestión de Infraestruturas: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/gl/equisi/exam/megarecopilacion\",\"inLanguage\":\"gl\",\"description\":\"Practica a recompilación cronometrada Megarecopilación Test XI de Xestión de Infraestruturas con 122 preguntas. 122 puntos, 90 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/gl/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Megarecopilación Test XI\",\"item\":\"https://pe.pablopl.dev/gl/equisi/exam/megarecopilacion\"}],\"url\":\"https://pe.pablopl.dev/gl/equisi/exam/megarecopilacion\"}]}"
   },
   {
     "url": "seo/gl/equispe.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/equispe",
-    "title": "Xestión de Proxectos: \"exames\" e preguntas resoltas",
-    "description": "Practica 175 preguntas de Xestión de Proxectos de 5 \"exames\" anteriores con respostas modelo e autocorrección. 202323, Universidade da Coruña.",
+    "title": "Xestión de Proxectos: recompilacións e preguntas resoltas",
+    "description": "Practica 175 preguntas de Xestión de Proxectos de 5 recompilacións de práctica con respostas modelo e autocorrección. 202323, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/equispe",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -11071,7 +11071,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Xestión de Proxectos: \\\"exames\\\" e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/equispe\",\"inLanguage\":\"gl\",\"description\":\"Practica 175 preguntas de Xestión de Proxectos de 5 \\\"exames\\\" anteriores con respostas modelo e autocorrección. 202323, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/gl/equispe\"}],\"url\":\"https://pe.pablopl.dev/gl/equispe\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Xestión de Proxectos: recompilacións e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/equispe\",\"inLanguage\":\"gl\",\"description\":\"Practica 175 preguntas de Xestión de Proxectos de 5 recompilacións de práctica con respostas modelo e autocorrección. 202323, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/gl/equispe\"}],\"url\":\"https://pe.pablopl.dev/gl/equispe\"}]}"
   },
   {
     "url": "seo/gl/equispe/practice/teoria.html",
@@ -11079,7 +11079,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/equispe/practice/teoria",
     "title": "Teoría: preguntas de Xestión de Proxectos | Pásame Exámenes",
-    "description": "Practica 107 preguntas de Teoría de \"exames\" anteriores de Xestión de Proxectos, con respostas modelo e autocorrección. 202323, Universidade da Coruña.",
+    "description": "Practica 107 preguntas de Teoría de recompilacións de Xestión de Proxectos, con respostas modelo e autocorrección. 202323, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/equispe/practice/teoria",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -11103,7 +11103,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe/practice/teoria"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Teoría: preguntas de Xestión de Proxectos | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/equispe/practice/teoria\",\"inLanguage\":\"gl\",\"description\":\"Practica 107 preguntas de Teoría de \\\"exames\\\" anteriores de Xestión de Proxectos, con respostas modelo e autocorrección. 202323, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Teoría\"},{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/gl/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Teoría\",\"item\":\"https://pe.pablopl.dev/gl/equispe/practice/teoria\"}],\"url\":\"https://pe.pablopl.dev/gl/equispe/practice/teoria\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Teoría: preguntas de Xestión de Proxectos | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/equispe/practice/teoria\",\"inLanguage\":\"gl\",\"description\":\"Practica 107 preguntas de Teoría de recompilacións de Xestión de Proxectos, con respostas modelo e autocorrección. 202323, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Teoría\"},{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/gl/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Teoría\",\"item\":\"https://pe.pablopl.dev/gl/equispe/practice/teoria\"}],\"url\":\"https://pe.pablopl.dev/gl/equispe/practice/teoria\"}]}"
   },
   {
     "url": "seo/gl/equispe/practice/practica.html",
@@ -11111,7 +11111,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/equispe/practice/practica",
     "title": "Práctica: preguntas de Xestión de Proxectos | Pásame Exámenes",
-    "description": "Practica 68 preguntas de Práctica de \"exames\" anteriores de Xestión de Proxectos, con respostas modelo e autocorrección. 202323, Universidade da Coruña.",
+    "description": "Practica 68 preguntas de Práctica de recompilacións de Xestión de Proxectos, con respostas modelo e autocorrección. 202323, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/equispe/practice/practica",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -11135,15 +11135,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe/practice/practica"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Práctica: preguntas de Xestión de Proxectos | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/equispe/practice/practica\",\"inLanguage\":\"gl\",\"description\":\"Practica 68 preguntas de Práctica de \\\"exames\\\" anteriores de Xestión de Proxectos, con respostas modelo e autocorrección. 202323, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Práctica\"},{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/gl/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Práctica\",\"item\":\"https://pe.pablopl.dev/gl/equispe/practice/practica\"}],\"url\":\"https://pe.pablopl.dev/gl/equispe/practice/practica\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Práctica: preguntas de Xestión de Proxectos | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/equispe/practice/practica\",\"inLanguage\":\"gl\",\"description\":\"Practica 68 preguntas de Práctica de recompilacións de Xestión de Proxectos, con respostas modelo e autocorrección. 202323, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Práctica\"},{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/gl/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Práctica\",\"item\":\"https://pe.pablopl.dev/gl/equispe/practice/practica\"}],\"url\":\"https://pe.pablopl.dev/gl/equispe/practice/practica\"}]}"
   },
   {
     "url": "seo/gl/equispe/exam/2024-01.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/equispe/exam/2024-01",
-    "title": "Posibles preguntas Xaneiro 2024 de Xestión de Proxectos: simulador",
-    "description": "Simula o exame Posibles preguntas Xaneiro 2024 de Xestión de Proxectos con 7 preguntas. 10 puntos, 120 minutos, respostas modelo e autocorrección.",
+    "title": "Posibles preguntas Xaneiro 2024 de Xestión de Proxectos: práctica cronometrada",
+    "description": "Practica a recompilación cronometrada Posibles preguntas Xaneiro 2024 de Xestión de Proxectos con 7 preguntas. 10 puntos, 120 minutos, respostas modelo e autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/equispe/exam/2024-01",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -11167,15 +11167,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe/exam/2024-01"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Xaneiro 2024 de Xestión de Proxectos: simulador\",\"url\":\"https://pe.pablopl.dev/gl/equispe/exam/2024-01\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Posibles preguntas Xaneiro 2024 de Xestión de Proxectos con 7 preguntas. 10 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/gl/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Xaneiro 2024\",\"item\":\"https://pe.pablopl.dev/gl/equispe/exam/2024-01\"}],\"url\":\"https://pe.pablopl.dev/gl/equispe/exam/2024-01\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Xaneiro 2024 de Xestión de Proxectos: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/gl/equispe/exam/2024-01\",\"inLanguage\":\"gl\",\"description\":\"Practica a recompilación cronometrada Posibles preguntas Xaneiro 2024 de Xestión de Proxectos con 7 preguntas. 10 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/gl/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Xaneiro 2024\",\"item\":\"https://pe.pablopl.dev/gl/equispe/exam/2024-01\"}],\"url\":\"https://pe.pablopl.dev/gl/equispe/exam/2024-01\"}]}"
   },
   {
     "url": "seo/gl/equispe/exam/2026-01.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/equispe/exam/2026-01",
-    "title": "Posibles preguntas Xaneiro 2026 de Xestión de Proxectos: simulador",
-    "description": "Simula o exame Posibles preguntas Xaneiro 2026 de Xestión de Proxectos con 13 preguntas. 25 puntos, 180 minutos, respostas modelo e autocorrección.",
+    "title": "Posibles preguntas Xaneiro 2026 de Xestión de Proxectos: práctica cronometrada",
+    "description": "Practica a recompilación cronometrada Posibles preguntas Xaneiro 2026 de Xestión de Proxectos con 13 preguntas. 25 puntos, 180 minutos, respostas modelo e autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/equispe/exam/2026-01",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -11199,15 +11199,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe/exam/2026-01"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Xaneiro 2026 de Xestión de Proxectos: simulador\",\"url\":\"https://pe.pablopl.dev/gl/equispe/exam/2026-01\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Posibles preguntas Xaneiro 2026 de Xestión de Proxectos con 13 preguntas. 25 puntos, 180 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/gl/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Xaneiro 2026\",\"item\":\"https://pe.pablopl.dev/gl/equispe/exam/2026-01\"}],\"url\":\"https://pe.pablopl.dev/gl/equispe/exam/2026-01\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Xaneiro 2026 de Xestión de Proxectos: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/gl/equispe/exam/2026-01\",\"inLanguage\":\"gl\",\"description\":\"Practica a recompilación cronometrada Posibles preguntas Xaneiro 2026 de Xestión de Proxectos con 13 preguntas. 25 puntos, 180 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/gl/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Xaneiro 2026\",\"item\":\"https://pe.pablopl.dev/gl/equispe/exam/2026-01\"}],\"url\":\"https://pe.pablopl.dev/gl/equispe/exam/2026-01\"}]}"
   },
   {
     "url": "seo/gl/equispe/exam/daypo-tipo-udc.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/equispe/exam/daypo-tipo-udc",
-    "title": "Daypo Tipo UDC de Xestión de Proxectos: simulador",
-    "description": "Simula o exame Daypo Tipo UDC de Xestión de Proxectos con 63 preguntas. 63 puntos, 90 minutos, respostas modelo e autocorrección.",
+    "title": "Daypo Tipo UDC de Xestión de Proxectos: práctica cronometrada",
+    "description": "Practica a recompilación cronometrada Daypo Tipo UDC de Xestión de Proxectos con 63 preguntas. 63 puntos, 90 minutos, respostas modelo e autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/equispe/exam/daypo-tipo-udc",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -11231,15 +11231,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe/exam/daypo-tipo-udc"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Tipo UDC de Xestión de Proxectos: simulador\",\"url\":\"https://pe.pablopl.dev/gl/equispe/exam/daypo-tipo-udc\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Daypo Tipo UDC de Xestión de Proxectos con 63 preguntas. 63 puntos, 90 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/gl/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Tipo UDC\",\"item\":\"https://pe.pablopl.dev/gl/equispe/exam/daypo-tipo-udc\"}],\"url\":\"https://pe.pablopl.dev/gl/equispe/exam/daypo-tipo-udc\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Tipo UDC de Xestión de Proxectos: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/gl/equispe/exam/daypo-tipo-udc\",\"inLanguage\":\"gl\",\"description\":\"Practica a recompilación cronometrada Daypo Tipo UDC de Xestión de Proxectos con 63 preguntas. 63 puntos, 90 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/gl/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Tipo UDC\",\"item\":\"https://pe.pablopl.dev/gl/equispe/exam/daypo-tipo-udc\"}],\"url\":\"https://pe.pablopl.dev/gl/equispe/exam/daypo-tipo-udc\"}]}"
   },
   {
     "url": "seo/gl/equispe/exam/daypo-teoria.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/equispe/exam/daypo-teoria",
-    "title": "Daypo Teoría de Xestión de Proxectos: simulador",
-    "description": "Simula o exame Daypo Teoría de Xestión de Proxectos con 34 preguntas. 34 puntos, 60 minutos, respostas modelo e autocorrección.",
+    "title": "Daypo Teoría de Xestión de Proxectos: práctica cronometrada",
+    "description": "Practica a recompilación cronometrada Daypo Teoría de Xestión de Proxectos con 34 preguntas. 34 puntos, 60 minutos, respostas modelo e autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/equispe/exam/daypo-teoria",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -11263,15 +11263,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe/exam/daypo-teoria"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Teoría de Xestión de Proxectos: simulador\",\"url\":\"https://pe.pablopl.dev/gl/equispe/exam/daypo-teoria\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Daypo Teoría de Xestión de Proxectos con 34 preguntas. 34 puntos, 60 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/gl/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Teoría\",\"item\":\"https://pe.pablopl.dev/gl/equispe/exam/daypo-teoria\"}],\"url\":\"https://pe.pablopl.dev/gl/equispe/exam/daypo-teoria\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Teoría de Xestión de Proxectos: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/gl/equispe/exam/daypo-teoria\",\"inLanguage\":\"gl\",\"description\":\"Practica a recompilación cronometrada Daypo Teoría de Xestión de Proxectos con 34 preguntas. 34 puntos, 60 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/gl/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Teoría\",\"item\":\"https://pe.pablopl.dev/gl/equispe/exam/daypo-teoria\"}],\"url\":\"https://pe.pablopl.dev/gl/equispe/exam/daypo-teoria\"}]}"
   },
   {
     "url": "seo/gl/equispe/exam/daypo-practica.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/equispe/exam/daypo-practica",
-    "title": "Daypo Práctica de Xestión de Proxectos: simulador",
-    "description": "Simula o exame Daypo Práctica de Xestión de Proxectos con 58 preguntas. 58 puntos, 90 minutos, respostas modelo e autocorrección.",
+    "title": "Daypo Práctica de Xestión de Proxectos: práctica cronometrada",
+    "description": "Practica a recompilación cronometrada Daypo Práctica de Xestión de Proxectos con 58 preguntas. 58 puntos, 90 minutos, respostas modelo e autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/equispe/exam/daypo-practica",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -11295,15 +11295,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe/exam/daypo-practica"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Práctica de Xestión de Proxectos: simulador\",\"url\":\"https://pe.pablopl.dev/gl/equispe/exam/daypo-practica\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Daypo Práctica de Xestión de Proxectos con 58 preguntas. 58 puntos, 90 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/gl/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Práctica\",\"item\":\"https://pe.pablopl.dev/gl/equispe/exam/daypo-practica\"}],\"url\":\"https://pe.pablopl.dev/gl/equispe/exam/daypo-practica\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Práctica de Xestión de Proxectos: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/gl/equispe/exam/daypo-practica\",\"inLanguage\":\"gl\",\"description\":\"Practica a recompilación cronometrada Daypo Práctica de Xestión de Proxectos con 58 preguntas. 58 puntos, 90 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/gl/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Práctica\",\"item\":\"https://pe.pablopl.dev/gl/equispe/exam/daypo-practica\"}],\"url\":\"https://pe.pablopl.dev/gl/equispe/exam/daypo-practica\"}]}"
   },
   {
     "url": "seo/gl/esei.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/esei",
-    "title": "Sistemas Intelixentes: \"exames\" e preguntas resoltas",
-    "description": "Practica 234 preguntas de Sistemas Intelixentes de 5 \"exames\" anteriores con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
+    "title": "Sistemas Intelixentes: recompilacións e preguntas resoltas",
+    "description": "Practica 234 preguntas de Sistemas Intelixentes de 5 recompilacións de práctica con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/esei",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -11327,7 +11327,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Sistemas Intelixentes: \\\"exames\\\" e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/esei\",\"inLanguage\":\"gl\",\"description\":\"Practica 234 preguntas de Sistemas Intelixentes de 5 \\\"exames\\\" anteriores con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"}],\"url\":\"https://pe.pablopl.dev/gl/esei\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Sistemas Intelixentes: recompilacións e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/esei\",\"inLanguage\":\"gl\",\"description\":\"Practica 234 preguntas de Sistemas Intelixentes de 5 recompilacións de práctica con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"}],\"url\":\"https://pe.pablopl.dev/gl/esei\"}]}"
   },
   {
     "url": "seo/gl/esei/practice/t1.html",
@@ -11335,7 +11335,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/esei/practice/t1",
     "title": "Tema 1: Introducción: preguntas de Sistemas Intelixentes",
-    "description": "Practica 4 preguntas de Tema 1: Introducción de \"exames\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 4 preguntas de Tema 1: Introducción de recompilacións de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/esei/practice/t1",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -11359,7 +11359,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t1"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 1: Introducción: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t1\",\"inLanguage\":\"gl\",\"description\":\"Practica 4 preguntas de Tema 1: Introducción de \\\"exames\\\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 1: Introducción\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 1: Introducción\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t1\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t1\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 1: Introducción: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t1\",\"inLanguage\":\"gl\",\"description\":\"Practica 4 preguntas de Tema 1: Introducción de recompilacións de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 1: Introducción\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 1: Introducción\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t1\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t1\"}]}"
   },
   {
     "url": "seo/gl/esei/practice/t2.html",
@@ -11367,7 +11367,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/esei/practice/t2",
     "title": "Tema 2: Búsqueda: preguntas de Sistemas Intelixentes",
-    "description": "Practica 24 preguntas de Tema 2: Búsqueda de \"exames\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 24 preguntas de Tema 2: Búsqueda de recompilacións de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/esei/practice/t2",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -11391,7 +11391,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t2"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 2: Búsqueda: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t2\",\"inLanguage\":\"gl\",\"description\":\"Practica 24 preguntas de Tema 2: Búsqueda de \\\"exames\\\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 2: Búsqueda\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 2: Búsqueda\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t2\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t2\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 2: Búsqueda: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t2\",\"inLanguage\":\"gl\",\"description\":\"Practica 24 preguntas de Tema 2: Búsqueda de recompilacións de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 2: Búsqueda\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 2: Búsqueda\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t2\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t2\"}]}"
   },
   {
     "url": "seo/gl/esei/practice/t3.html",
@@ -11399,7 +11399,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/esei/practice/t3",
     "title": "Tema 3: Representación: preguntas de Sistemas Intelixentes",
-    "description": "Practica 17 preguntas de Tema 3: Representación de \"exames\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 17 preguntas de Tema 3: Representación de recompilacións de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/esei/practice/t3",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -11423,7 +11423,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t3"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 3: Representación: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t3\",\"inLanguage\":\"gl\",\"description\":\"Practica 17 preguntas de Tema 3: Representación de \\\"exames\\\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 3: Representación\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 3: Representación\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t3\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t3\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 3: Representación: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t3\",\"inLanguage\":\"gl\",\"description\":\"Practica 17 preguntas de Tema 3: Representación de recompilacións de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 3: Representación\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 3: Representación\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t3\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t3\"}]}"
   },
   {
     "url": "seo/gl/esei/practice/t4.html",
@@ -11431,7 +11431,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/esei/practice/t4",
     "title": "Tema 4: Razonamiento: preguntas de Sistemas Intelixentes",
-    "description": "Practica 12 preguntas de Tema 4: Razonamiento de \"exames\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 12 preguntas de Tema 4: Razonamiento de recompilacións de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/esei/practice/t4",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -11455,7 +11455,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t4"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 4: Razonamiento: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t4\",\"inLanguage\":\"gl\",\"description\":\"Practica 12 preguntas de Tema 4: Razonamiento de \\\"exames\\\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 4: Razonamiento\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 4: Razonamiento\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t4\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t4\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 4: Razonamiento: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t4\",\"inLanguage\":\"gl\",\"description\":\"Practica 12 preguntas de Tema 4: Razonamiento de recompilacións de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 4: Razonamiento\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 4: Razonamiento\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t4\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t4\"}]}"
   },
   {
     "url": "seo/gl/esei/practice/t5.html",
@@ -11463,7 +11463,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/esei/practice/t5",
     "title": "Tema 5: Planificación: preguntas de Sistemas Intelixentes",
-    "description": "Practica 2 preguntas de Tema 5: Planificación de \"exames\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 2 preguntas de Tema 5: Planificación de recompilacións de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/esei/practice/t5",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -11487,7 +11487,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t5"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 5: Planificación: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t5\",\"inLanguage\":\"gl\",\"description\":\"Practica 2 preguntas de Tema 5: Planificación de \\\"exames\\\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 5: Planificación\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 5: Planificación\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t5\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t5\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 5: Planificación: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t5\",\"inLanguage\":\"gl\",\"description\":\"Practica 2 preguntas de Tema 5: Planificación de recompilacións de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 5: Planificación\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 5: Planificación\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t5\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t5\"}]}"
   },
   {
     "url": "seo/gl/esei/practice/t6.html",
@@ -11495,7 +11495,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/esei/practice/t6",
     "title": "Tema 6: Introducción a los sistemas subsimbólicos: preguntas de Sistemas Intelixentes",
-    "description": "Practica 18 preguntas de Tema 6: Introducción a los sistemas subsimbólicos de \"exames\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 18 preguntas de Tema 6: Introducción a los sistemas subsimbólicos de recompilacións de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/esei/practice/t6",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -11519,7 +11519,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t6"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 6: Introducción a los sistemas subsimbólicos: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t6\",\"inLanguage\":\"gl\",\"description\":\"Practica 18 preguntas de Tema 6: Introducción a los sistemas subsimbólicos de \\\"exames\\\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 6: Introducción a los sistemas subsimbólicos\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 6: Introducción a los sistemas subsimbólicos\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t6\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t6\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 6: Introducción a los sistemas subsimbólicos: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t6\",\"inLanguage\":\"gl\",\"description\":\"Practica 18 preguntas de Tema 6: Introducción a los sistemas subsimbólicos de recompilacións de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 6: Introducción a los sistemas subsimbólicos\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 6: Introducción a los sistemas subsimbólicos\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t6\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t6\"}]}"
   },
   {
     "url": "seo/gl/esei/practice/t7.html",
@@ -11527,7 +11527,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/esei/practice/t7",
     "title": "Tema 7: Redes Neuronales Artificiales: modelos y características: preguntas de Sistemas Intelixentes",
-    "description": "Practica 40 preguntas de Tema 7: Redes Neuronales Artificiales: modelos y características de \"exames\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 40 preguntas de Tema 7: Redes Neuronales Artificiales: modelos y características de recompilacións de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/esei/practice/t7",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -11551,7 +11551,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t7"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 7: Redes Neuronales Artificiales: modelos y características: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t7\",\"inLanguage\":\"gl\",\"description\":\"Practica 40 preguntas de Tema 7: Redes Neuronales Artificiales: modelos y características de \\\"exames\\\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 7: Redes Neuronales Artificiales: modelos y características\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 7: Redes Neuronales Artificiales: modelos y características\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t7\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t7\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 7: Redes Neuronales Artificiales: modelos y características: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t7\",\"inLanguage\":\"gl\",\"description\":\"Practica 40 preguntas de Tema 7: Redes Neuronales Artificiales: modelos y características de recompilacións de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 7: Redes Neuronales Artificiales: modelos y características\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 7: Redes Neuronales Artificiales: modelos y características\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t7\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t7\"}]}"
   },
   {
     "url": "seo/gl/esei/practice/t8.html",
@@ -11559,7 +11559,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/esei/practice/t8",
     "title": "Tema 8: Entrenamiento de Redes Neuronales Artificiales: preguntas de Sistemas Intelixentes",
-    "description": "Practica 20 preguntas de Tema 8: Entrenamiento de Redes Neuronales Artificiales de \"exames\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 20 preguntas de Tema 8: Entrenamiento de Redes Neuronales Artificiales de recompilacións de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/esei/practice/t8",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -11583,7 +11583,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t8"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 8: Entrenamiento de Redes Neuronales Artificiales: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t8\",\"inLanguage\":\"gl\",\"description\":\"Practica 20 preguntas de Tema 8: Entrenamiento de Redes Neuronales Artificiales de \\\"exames\\\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 8: Entrenamiento de Redes Neuronales Artificiales\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 8: Entrenamiento de Redes Neuronales Artificiales\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t8\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t8\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 8: Entrenamiento de Redes Neuronales Artificiales: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t8\",\"inLanguage\":\"gl\",\"description\":\"Practica 20 preguntas de Tema 8: Entrenamiento de Redes Neuronales Artificiales de recompilacións de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 8: Entrenamiento de Redes Neuronales Artificiales\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 8: Entrenamiento de Redes Neuronales Artificiales\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t8\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t8\"}]}"
   },
   {
     "url": "seo/gl/esei/practice/t9.html",
@@ -11591,7 +11591,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/esei/practice/t9",
     "title": "Tema 9: Sistemas autoorganizativos: preguntas de Sistemas Intelixentes",
-    "description": "Practica 59 preguntas de Tema 9: Sistemas autoorganizativos de \"exames\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 59 preguntas de Tema 9: Sistemas autoorganizativos de recompilacións de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/esei/practice/t9",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -11615,7 +11615,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t9"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 9: Sistemas autoorganizativos: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t9\",\"inLanguage\":\"gl\",\"description\":\"Practica 59 preguntas de Tema 9: Sistemas autoorganizativos de \\\"exames\\\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 9: Sistemas autoorganizativos\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 9: Sistemas autoorganizativos\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t9\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t9\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 9: Sistemas autoorganizativos: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t9\",\"inLanguage\":\"gl\",\"description\":\"Practica 59 preguntas de Tema 9: Sistemas autoorganizativos de recompilacións de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 9: Sistemas autoorganizativos\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 9: Sistemas autoorganizativos\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t9\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t9\"}]}"
   },
   {
     "url": "seo/gl/esei/practice/t10.html",
@@ -11623,7 +11623,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/esei/practice/t10",
     "title": "Tema 10: Computación Evolutiva: preguntas de Sistemas Intelixentes",
-    "description": "Practica 38 preguntas de Tema 10: Computación Evolutiva de \"exames\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 38 preguntas de Tema 10: Computación Evolutiva de recompilacións de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/esei/practice/t10",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -11647,15 +11647,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t10"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 10: Computación Evolutiva: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t10\",\"inLanguage\":\"gl\",\"description\":\"Practica 38 preguntas de Tema 10: Computación Evolutiva de \\\"exames\\\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 10: Computación Evolutiva\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 10: Computación Evolutiva\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t10\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t10\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 10: Computación Evolutiva: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t10\",\"inLanguage\":\"gl\",\"description\":\"Practica 38 preguntas de Tema 10: Computación Evolutiva de recompilacións de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 10: Computación Evolutiva\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 10: Computación Evolutiva\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t10\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t10\"}]}"
   },
   {
     "url": "seo/gl/esei/exam/2023.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/esei/exam/2023",
-    "title": "Posibles preguntas 2023 de Sistemas Intelixentes: simulador",
-    "description": "Simula o exame Posibles preguntas 2023 de Sistemas Intelixentes con 45 preguntas. 45 puntos, 120 minutos, respostas modelo e autocorrección.",
+    "title": "Posibles preguntas 2023 de Sistemas Intelixentes: práctica cronometrada",
+    "description": "Practica a recompilación cronometrada Posibles preguntas 2023 de Sistemas Intelixentes con 45 preguntas. 45 puntos, 120 minutos, respostas modelo e autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/esei/exam/2023",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -11679,15 +11679,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/exam/2023"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas 2023 de Sistemas Intelixentes: simulador\",\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2023\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Posibles preguntas 2023 de Sistemas Intelixentes con 45 preguntas. 45 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas 2023\",\"item\":\"https://pe.pablopl.dev/gl/esei/exam/2023\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2023\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas 2023 de Sistemas Intelixentes: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2023\",\"inLanguage\":\"gl\",\"description\":\"Practica a recompilación cronometrada Posibles preguntas 2023 de Sistemas Intelixentes con 45 preguntas. 45 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas 2023\",\"item\":\"https://pe.pablopl.dev/gl/esei/exam/2023\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2023\"}]}"
   },
   {
     "url": "seo/gl/esei/exam/2024.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/esei/exam/2024",
-    "title": "Posibles preguntas 2024 de Sistemas Intelixentes: simulador",
-    "description": "Simula o exame Posibles preguntas 2024 de Sistemas Intelixentes con 44 preguntas. 44 puntos, 120 minutos, respostas modelo e autocorrección.",
+    "title": "Posibles preguntas 2024 de Sistemas Intelixentes: práctica cronometrada",
+    "description": "Practica a recompilación cronometrada Posibles preguntas 2024 de Sistemas Intelixentes con 44 preguntas. 44 puntos, 120 minutos, respostas modelo e autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/esei/exam/2024",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -11711,15 +11711,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/exam/2024"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas 2024 de Sistemas Intelixentes: simulador\",\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2024\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Posibles preguntas 2024 de Sistemas Intelixentes con 44 preguntas. 44 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas 2024\",\"item\":\"https://pe.pablopl.dev/gl/esei/exam/2024\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2024\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas 2024 de Sistemas Intelixentes: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2024\",\"inLanguage\":\"gl\",\"description\":\"Practica a recompilación cronometrada Posibles preguntas 2024 de Sistemas Intelixentes con 44 preguntas. 44 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas 2024\",\"item\":\"https://pe.pablopl.dev/gl/esei/exam/2024\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2024\"}]}"
   },
   {
     "url": "seo/gl/esei/exam/2025-05.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/esei/exam/2025-05",
-    "title": "Posibles preguntas Mayo 2025 de Sistemas Intelixentes: simulador",
-    "description": "Simula o exame Posibles preguntas Mayo 2025 de Sistemas Intelixentes con 42 preguntas. 42 puntos, 120 minutos, respostas modelo e autocorrección.",
+    "title": "Posibles preguntas Mayo 2025 de Sistemas Intelixentes: práctica cronometrada",
+    "description": "Practica a recompilación cronometrada Posibles preguntas Mayo 2025 de Sistemas Intelixentes con 42 preguntas. 42 puntos, 120 minutos, respostas modelo e autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/esei/exam/2025-05",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -11743,15 +11743,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/exam/2025-05"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Mayo 2025 de Sistemas Intelixentes: simulador\",\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2025-05\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Posibles preguntas Mayo 2025 de Sistemas Intelixentes con 42 preguntas. 42 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Mayo 2025\",\"item\":\"https://pe.pablopl.dev/gl/esei/exam/2025-05\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2025-05\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Mayo 2025 de Sistemas Intelixentes: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2025-05\",\"inLanguage\":\"gl\",\"description\":\"Practica a recompilación cronometrada Posibles preguntas Mayo 2025 de Sistemas Intelixentes con 42 preguntas. 42 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Mayo 2025\",\"item\":\"https://pe.pablopl.dev/gl/esei/exam/2025-05\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2025-05\"}]}"
   },
   {
     "url": "seo/gl/esei/exam/2025-07.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/esei/exam/2025-07",
-    "title": "Posibles preguntas Julio 2025 de Sistemas Intelixentes: simulador",
-    "description": "Simula o exame Posibles preguntas Julio 2025 de Sistemas Intelixentes con 47 preguntas. 47 puntos, 120 minutos, respostas modelo e autocorrección.",
+    "title": "Posibles preguntas Julio 2025 de Sistemas Intelixentes: práctica cronometrada",
+    "description": "Practica a recompilación cronometrada Posibles preguntas Julio 2025 de Sistemas Intelixentes con 47 preguntas. 47 puntos, 120 minutos, respostas modelo e autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/esei/exam/2025-07",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -11775,15 +11775,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/exam/2025-07"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Julio 2025 de Sistemas Intelixentes: simulador\",\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2025-07\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Posibles preguntas Julio 2025 de Sistemas Intelixentes con 47 preguntas. 47 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Julio 2025\",\"item\":\"https://pe.pablopl.dev/gl/esei/exam/2025-07\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2025-07\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Julio 2025 de Sistemas Intelixentes: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2025-07\",\"inLanguage\":\"gl\",\"description\":\"Practica a recompilación cronometrada Posibles preguntas Julio 2025 de Sistemas Intelixentes con 47 preguntas. 47 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Julio 2025\",\"item\":\"https://pe.pablopl.dev/gl/esei/exam/2025-07\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2025-07\"}]}"
   },
   {
     "url": "seo/gl/esei/exam/2026-06.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/esei/exam/2026-06",
-    "title": "Posibles preguntas Junio 2026 de Sistemas Intelixentes: simulador",
-    "description": "Simula o exame Posibles preguntas Junio 2026 de Sistemas Intelixentes con 56 preguntas. 56 puntos, 120 minutos, respostas modelo e autocorrección.",
+    "title": "Posibles preguntas Junio 2026 de Sistemas Intelixentes: práctica cronometrada",
+    "description": "Practica a recompilación cronometrada Posibles preguntas Junio 2026 de Sistemas Intelixentes con 56 preguntas. 56 puntos, 120 minutos, respostas modelo e autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/esei/exam/2026-06",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -11807,15 +11807,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/exam/2026-06"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Junio 2026 de Sistemas Intelixentes: simulador\",\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2026-06\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Posibles preguntas Junio 2026 de Sistemas Intelixentes con 56 preguntas. 56 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Junio 2026\",\"item\":\"https://pe.pablopl.dev/gl/esei/exam/2026-06\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2026-06\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Junio 2026 de Sistemas Intelixentes: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2026-06\",\"inLanguage\":\"gl\",\"description\":\"Practica a recompilación cronometrada Posibles preguntas Junio 2026 de Sistemas Intelixentes con 56 preguntas. 56 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Junio 2026\",\"item\":\"https://pe.pablopl.dev/gl/esei/exam/2026-06\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2026-06\"}]}"
   },
   {
     "url": "seo/gl/eseo.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/eseo",
-    "title": "Sistemas Operativos: \"exames\" e preguntas resoltas",
-    "description": "Practica 119 preguntas de Sistemas Operativos de 9 \"exames\" anteriores con respostas modelo e autocorrección. 202318, Universidade da Coruña.",
+    "title": "Sistemas Operativos: exames e preguntas resoltas",
+    "description": "Practica 119 preguntas de Sistemas Operativos de 9 exames con respostas modelo e autocorrección. 202318, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/eseo",
     "ogImage": "https://pe.pablopl.dev/og/eseo.png",
@@ -11839,7 +11839,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/eseo"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Sistemas Operativos: \\\"exames\\\" e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/eseo\",\"inLanguage\":\"gl\",\"description\":\"Practica 119 preguntas de Sistemas Operativos de 9 \\\"exames\\\" anteriores con respostas modelo e autocorrección. 202318, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/gl/eseo\"}],\"url\":\"https://pe.pablopl.dev/gl/eseo\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Sistemas Operativos: exames e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/eseo\",\"inLanguage\":\"gl\",\"description\":\"Practica 119 preguntas de Sistemas Operativos de 9 exames con respostas modelo e autocorrección. 202318, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/gl/eseo\"}],\"url\":\"https://pe.pablopl.dev/gl/eseo\"}]}"
   },
   {
     "url": "seo/gl/eseo/practice/sistema-ficheros.html",
@@ -11847,7 +11847,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/eseo/practice/sistema-ficheros",
     "title": "Sistema de Ficheros: preguntas de Sistemas Operativos",
-    "description": "Practica 36 preguntas de Sistema de Ficheros de \"exames\" anteriores de Sistemas Operativos, con respostas modelo e autocorrección. 202318, Universidade da Coruña.",
+    "description": "Practica 36 preguntas de Sistema de Ficheros de exames de Sistemas Operativos, con respostas modelo e autocorrección. 202318, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/eseo/practice/sistema-ficheros",
     "ogImage": "https://pe.pablopl.dev/og/eseo.png",
@@ -11871,7 +11871,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/eseo/practice/sistema-ficheros"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Sistema de Ficheros: preguntas de Sistemas Operativos\",\"url\":\"https://pe.pablopl.dev/gl/eseo/practice/sistema-ficheros\",\"inLanguage\":\"gl\",\"description\":\"Practica 36 preguntas de Sistema de Ficheros de \\\"exames\\\" anteriores de Sistemas Operativos, con respostas modelo e autocorrección. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Sistema de Ficheros\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/gl/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Sistema de Ficheros\",\"item\":\"https://pe.pablopl.dev/gl/eseo/practice/sistema-ficheros\"}],\"url\":\"https://pe.pablopl.dev/gl/eseo/practice/sistema-ficheros\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Sistema de Ficheros: preguntas de Sistemas Operativos\",\"url\":\"https://pe.pablopl.dev/gl/eseo/practice/sistema-ficheros\",\"inLanguage\":\"gl\",\"description\":\"Practica 36 preguntas de Sistema de Ficheros de exames de Sistemas Operativos, con respostas modelo e autocorrección. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Sistema de Ficheros\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/gl/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Sistema de Ficheros\",\"item\":\"https://pe.pablopl.dev/gl/eseo/practice/sistema-ficheros\"}],\"url\":\"https://pe.pablopl.dev/gl/eseo/practice/sistema-ficheros\"}]}"
   },
   {
     "url": "seo/gl/eseo/practice/memoria.html",
@@ -11879,7 +11879,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/eseo/practice/memoria",
     "title": "Gestión de Memoria: preguntas de Sistemas Operativos",
-    "description": "Practica 25 preguntas de Gestión de Memoria de \"exames\" anteriores de Sistemas Operativos, con respostas modelo e autocorrección. 202318, Universidade da Coruña.",
+    "description": "Practica 25 preguntas de Gestión de Memoria de exames de Sistemas Operativos, con respostas modelo e autocorrección. 202318, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/eseo/practice/memoria",
     "ogImage": "https://pe.pablopl.dev/og/eseo.png",
@@ -11903,7 +11903,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/eseo/practice/memoria"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Gestión de Memoria: preguntas de Sistemas Operativos\",\"url\":\"https://pe.pablopl.dev/gl/eseo/practice/memoria\",\"inLanguage\":\"gl\",\"description\":\"Practica 25 preguntas de Gestión de Memoria de \\\"exames\\\" anteriores de Sistemas Operativos, con respostas modelo e autocorrección. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Gestión de Memoria\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/gl/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Gestión de Memoria\",\"item\":\"https://pe.pablopl.dev/gl/eseo/practice/memoria\"}],\"url\":\"https://pe.pablopl.dev/gl/eseo/practice/memoria\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Gestión de Memoria: preguntas de Sistemas Operativos\",\"url\":\"https://pe.pablopl.dev/gl/eseo/practice/memoria\",\"inLanguage\":\"gl\",\"description\":\"Practica 25 preguntas de Gestión de Memoria de exames de Sistemas Operativos, con respostas modelo e autocorrección. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Gestión de Memoria\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/gl/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Gestión de Memoria\",\"item\":\"https://pe.pablopl.dev/gl/eseo/practice/memoria\"}],\"url\":\"https://pe.pablopl.dev/gl/eseo/practice/memoria\"}]}"
   },
   {
     "url": "seo/gl/eseo/practice/procesos.html",
@@ -11911,7 +11911,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/eseo/practice/procesos",
     "title": "Procesos e Hilos: preguntas de Sistemas Operativos",
-    "description": "Practica 30 preguntas de Procesos e Hilos de \"exames\" anteriores de Sistemas Operativos, con respostas modelo e autocorrección. 202318, Universidade da Coruña.",
+    "description": "Practica 30 preguntas de Procesos e Hilos de exames de Sistemas Operativos, con respostas modelo e autocorrección. 202318, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/eseo/practice/procesos",
     "ogImage": "https://pe.pablopl.dev/og/eseo.png",
@@ -11935,7 +11935,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/eseo/practice/procesos"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Procesos e Hilos: preguntas de Sistemas Operativos\",\"url\":\"https://pe.pablopl.dev/gl/eseo/practice/procesos\",\"inLanguage\":\"gl\",\"description\":\"Practica 30 preguntas de Procesos e Hilos de \\\"exames\\\" anteriores de Sistemas Operativos, con respostas modelo e autocorrección. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Procesos e Hilos\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/gl/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Procesos e Hilos\",\"item\":\"https://pe.pablopl.dev/gl/eseo/practice/procesos\"}],\"url\":\"https://pe.pablopl.dev/gl/eseo/practice/procesos\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Procesos e Hilos: preguntas de Sistemas Operativos\",\"url\":\"https://pe.pablopl.dev/gl/eseo/practice/procesos\",\"inLanguage\":\"gl\",\"description\":\"Practica 30 preguntas de Procesos e Hilos de exames de Sistemas Operativos, con respostas modelo e autocorrección. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Procesos e Hilos\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/gl/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Procesos e Hilos\",\"item\":\"https://pe.pablopl.dev/gl/eseo/practice/procesos\"}],\"url\":\"https://pe.pablopl.dev/gl/eseo/practice/procesos\"}]}"
   },
   {
     "url": "seo/gl/eseo/practice/entrada-salida.html",
@@ -11943,7 +11943,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/eseo/practice/entrada-salida",
     "title": "Entrada/Salida: preguntas de Sistemas Operativos",
-    "description": "Practica 28 preguntas de Entrada/Salida de \"exames\" anteriores de Sistemas Operativos, con respostas modelo e autocorrección. 202318, Universidade da Coruña.",
+    "description": "Practica 28 preguntas de Entrada/Salida de exames de Sistemas Operativos, con respostas modelo e autocorrección. 202318, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/eseo/practice/entrada-salida",
     "ogImage": "https://pe.pablopl.dev/og/eseo.png",
@@ -11967,7 +11967,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/eseo/practice/entrada-salida"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Entrada/Salida: preguntas de Sistemas Operativos\",\"url\":\"https://pe.pablopl.dev/gl/eseo/practice/entrada-salida\",\"inLanguage\":\"gl\",\"description\":\"Practica 28 preguntas de Entrada/Salida de \\\"exames\\\" anteriores de Sistemas Operativos, con respostas modelo e autocorrección. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Entrada/Salida\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/gl/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Entrada/Salida\",\"item\":\"https://pe.pablopl.dev/gl/eseo/practice/entrada-salida\"}],\"url\":\"https://pe.pablopl.dev/gl/eseo/practice/entrada-salida\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Entrada/Salida: preguntas de Sistemas Operativos\",\"url\":\"https://pe.pablopl.dev/gl/eseo/practice/entrada-salida\",\"inLanguage\":\"gl\",\"description\":\"Practica 28 preguntas de Entrada/Salida de exames de Sistemas Operativos, con respostas modelo e autocorrección. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Entrada/Salida\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/gl/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Entrada/Salida\",\"item\":\"https://pe.pablopl.dev/gl/eseo/practice/entrada-salida\"}],\"url\":\"https://pe.pablopl.dev/gl/eseo/practice/entrada-salida\"}]}"
   },
   {
     "url": "seo/gl/eseo/exam/2020-01.html",
@@ -12262,8 +12262,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/iesede",
-    "title": "Internet y Sistemas Distribuidos: \"exames\" e preguntas resoltas",
-    "description": "Practica 18 preguntas de Internet y Sistemas Distribuidos de 1 \"exames\" anteriores con respostas modelo e autocorrección. 200188, Universidade da Coruña.",
+    "title": "Internet y Sistemas Distribuidos: recompilacións e preguntas resoltas",
+    "description": "Practica 18 preguntas de Internet y Sistemas Distribuidos de 1 recompilacións de práctica con respostas modelo e autocorrección. 200188, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/iesede",
     "ogImage": "https://pe.pablopl.dev/og/iesede.png",
@@ -12287,7 +12287,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/iesede"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Internet y Sistemas Distribuidos: \\\"exames\\\" e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/iesede\",\"inLanguage\":\"gl\",\"description\":\"Practica 18 preguntas de Internet y Sistemas Distribuidos de 1 \\\"exames\\\" anteriores con respostas modelo e autocorrección. 200188, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Internet y Sistemas Distribuidos\",\"courseCode\":\"200188\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Internet y Sistemas Distribuidos\",\"item\":\"https://pe.pablopl.dev/gl/iesede\"}],\"url\":\"https://pe.pablopl.dev/gl/iesede\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Internet y Sistemas Distribuidos: recompilacións e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/iesede\",\"inLanguage\":\"gl\",\"description\":\"Practica 18 preguntas de Internet y Sistemas Distribuidos de 1 recompilacións de práctica con respostas modelo e autocorrección. 200188, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Internet y Sistemas Distribuidos\",\"courseCode\":\"200188\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Internet y Sistemas Distribuidos\",\"item\":\"https://pe.pablopl.dev/gl/iesede\"}],\"url\":\"https://pe.pablopl.dev/gl/iesede\"}]}"
   },
   {
     "url": "seo/gl/iesede/practice/general.html",
@@ -12295,7 +12295,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/iesede/practice/general",
     "title": "General: preguntas de Internet y Sistemas Distribuidos",
-    "description": "Practica 18 preguntas de General de \"exames\" anteriores de Internet y Sistemas Distribuidos, con respostas modelo e autocorrección. 200188, Universidade da Coruña.",
+    "description": "Practica 18 preguntas de General de recompilacións de Internet y Sistemas Distribuidos, con respostas modelo e autocorrección. 200188, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/iesede/practice/general",
     "ogImage": "https://pe.pablopl.dev/og/iesede.png",
@@ -12319,15 +12319,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/iesede/practice/general"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"General: preguntas de Internet y Sistemas Distribuidos\",\"url\":\"https://pe.pablopl.dev/gl/iesede/practice/general\",\"inLanguage\":\"gl\",\"description\":\"Practica 18 preguntas de General de \\\"exames\\\" anteriores de Internet y Sistemas Distribuidos, con respostas modelo e autocorrección. 200188, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"General\"},{\"@type\":\"Course\",\"name\":\"Internet y Sistemas Distribuidos\",\"courseCode\":\"200188\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Internet y Sistemas Distribuidos\",\"item\":\"https://pe.pablopl.dev/gl/iesede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"General\",\"item\":\"https://pe.pablopl.dev/gl/iesede/practice/general\"}],\"url\":\"https://pe.pablopl.dev/gl/iesede/practice/general\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"General: preguntas de Internet y Sistemas Distribuidos\",\"url\":\"https://pe.pablopl.dev/gl/iesede/practice/general\",\"inLanguage\":\"gl\",\"description\":\"Practica 18 preguntas de General de recompilacións de Internet y Sistemas Distribuidos, con respostas modelo e autocorrección. 200188, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"General\"},{\"@type\":\"Course\",\"name\":\"Internet y Sistemas Distribuidos\",\"courseCode\":\"200188\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Internet y Sistemas Distribuidos\",\"item\":\"https://pe.pablopl.dev/gl/iesede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"General\",\"item\":\"https://pe.pablopl.dev/gl/iesede/practice/general\"}],\"url\":\"https://pe.pablopl.dev/gl/iesede/practice/general\"}]}"
   },
   {
     "url": "seo/gl/iesede/exam/examen_recopilatorio.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/iesede/exam/examen_recopilatorio",
-    "title": "Recopilación de Internet y Sistemas Distribuidos: simulador",
-    "description": "Simula o exame Recopilación de Internet y Sistemas Distribuidos con 18 preguntas. 18 puntos, 120 minutos, respostas modelo e autocorrección.",
+    "title": "Recopilación de Internet y Sistemas Distribuidos: práctica cronometrada",
+    "description": "Practica a recompilación cronometrada Recopilación de Internet y Sistemas Distribuidos con 18 preguntas. 18 puntos, 120 minutos, respostas modelo e autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/iesede/exam/examen_recopilatorio",
     "ogImage": "https://pe.pablopl.dev/og/iesede.png",
@@ -12351,15 +12351,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/iesede/exam/examen_recopilatorio"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Recopilación de Internet y Sistemas Distribuidos: simulador\",\"url\":\"https://pe.pablopl.dev/gl/iesede/exam/examen_recopilatorio\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Recopilación de Internet y Sistemas Distribuidos con 18 preguntas. 18 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Internet y Sistemas Distribuidos\",\"courseCode\":\"200188\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Internet y Sistemas Distribuidos\",\"item\":\"https://pe.pablopl.dev/gl/iesede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Recopilación\",\"item\":\"https://pe.pablopl.dev/gl/iesede/exam/examen_recopilatorio\"}],\"url\":\"https://pe.pablopl.dev/gl/iesede/exam/examen_recopilatorio\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Recopilación de Internet y Sistemas Distribuidos: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/gl/iesede/exam/examen_recopilatorio\",\"inLanguage\":\"gl\",\"description\":\"Practica a recompilación cronometrada Recopilación de Internet y Sistemas Distribuidos con 18 preguntas. 18 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Internet y Sistemas Distribuidos\",\"courseCode\":\"200188\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Internet y Sistemas Distribuidos\",\"item\":\"https://pe.pablopl.dev/gl/iesede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Recopilación\",\"item\":\"https://pe.pablopl.dev/gl/iesede/exam/examen_recopilatorio\"}],\"url\":\"https://pe.pablopl.dev/gl/iesede/exam/examen_recopilatorio\"}]}"
   },
   {
     "url": "seo/gl/peese.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/peese",
-    "title": "Proceso Software: \"exames\" e preguntas resoltas",
-    "description": "Practica 17 preguntas de Proceso Software de 1 \"exames\" anteriores con respostas modelo e autocorrección. 202321, Universidade da Coruña.",
+    "title": "Proceso Software: recompilacións e preguntas resoltas",
+    "description": "Practica 17 preguntas de Proceso Software de 1 recompilacións de práctica con respostas modelo e autocorrección. 202321, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/peese",
     "ogImage": "https://pe.pablopl.dev/og/peese.png",
@@ -12383,7 +12383,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/peese"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Proceso Software: \\\"exames\\\" e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/peese\",\"inLanguage\":\"gl\",\"description\":\"Practica 17 preguntas de Proceso Software de 1 \\\"exames\\\" anteriores con respostas modelo e autocorrección. 202321, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Proceso Software\",\"courseCode\":\"202321\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Proceso Software\",\"item\":\"https://pe.pablopl.dev/gl/peese\"}],\"url\":\"https://pe.pablopl.dev/gl/peese\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Proceso Software: recompilacións e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/peese\",\"inLanguage\":\"gl\",\"description\":\"Practica 17 preguntas de Proceso Software de 1 recompilacións de práctica con respostas modelo e autocorrección. 202321, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Proceso Software\",\"courseCode\":\"202321\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Proceso Software\",\"item\":\"https://pe.pablopl.dev/gl/peese\"}],\"url\":\"https://pe.pablopl.dev/gl/peese\"}]}"
   },
   {
     "url": "seo/gl/peese/practice/teoria.html",
@@ -12391,7 +12391,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/peese/practice/teoria",
     "title": "Teoría: preguntas de Proceso Software | Pásame Exámenes",
-    "description": "Practica 17 preguntas de Teoría de \"exames\" anteriores de Proceso Software, con respostas modelo e autocorrección. 202321, Universidade da Coruña.",
+    "description": "Practica 17 preguntas de Teoría de recompilacións de Proceso Software, con respostas modelo e autocorrección. 202321, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/peese/practice/teoria",
     "ogImage": "https://pe.pablopl.dev/og/peese.png",
@@ -12415,15 +12415,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/peese/practice/teoria"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Teoría: preguntas de Proceso Software | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/peese/practice/teoria\",\"inLanguage\":\"gl\",\"description\":\"Practica 17 preguntas de Teoría de \\\"exames\\\" anteriores de Proceso Software, con respostas modelo e autocorrección. 202321, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Teoría\"},{\"@type\":\"Course\",\"name\":\"Proceso Software\",\"courseCode\":\"202321\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Proceso Software\",\"item\":\"https://pe.pablopl.dev/gl/peese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Teoría\",\"item\":\"https://pe.pablopl.dev/gl/peese/practice/teoria\"}],\"url\":\"https://pe.pablopl.dev/gl/peese/practice/teoria\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Teoría: preguntas de Proceso Software | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/peese/practice/teoria\",\"inLanguage\":\"gl\",\"description\":\"Practica 17 preguntas de Teoría de recompilacións de Proceso Software, con respostas modelo e autocorrección. 202321, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Teoría\"},{\"@type\":\"Course\",\"name\":\"Proceso Software\",\"courseCode\":\"202321\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Proceso Software\",\"item\":\"https://pe.pablopl.dev/gl/peese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Teoría\",\"item\":\"https://pe.pablopl.dev/gl/peese/practice/teoria\"}],\"url\":\"https://pe.pablopl.dev/gl/peese/practice/teoria\"}]}"
   },
   {
     "url": "seo/gl/peese/exam/2026-05.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/peese/exam/2026-05",
-    "title": "Posibles preguntas Mayo 2026 de Proceso Software: simulador",
-    "description": "Simula o exame Posibles preguntas Mayo 2026 de Proceso Software con 17 preguntas. 8.5 puntos, 120 minutos, respostas modelo e autocorrección.",
+    "title": "Posibles preguntas Mayo 2026 de Proceso Software: práctica cronometrada",
+    "description": "Practica a recompilación cronometrada Posibles preguntas Mayo 2026 de Proceso Software con 17 preguntas. 8.5 puntos, 120 minutos, respostas modelo e autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/peese/exam/2026-05",
     "ogImage": "https://pe.pablopl.dev/og/peese.png",
@@ -12447,15 +12447,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/peese/exam/2026-05"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Mayo 2026 de Proceso Software: simulador\",\"url\":\"https://pe.pablopl.dev/gl/peese/exam/2026-05\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Posibles preguntas Mayo 2026 de Proceso Software con 17 preguntas. 8.5 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Proceso Software\",\"courseCode\":\"202321\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Proceso Software\",\"item\":\"https://pe.pablopl.dev/gl/peese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Mayo 2026\",\"item\":\"https://pe.pablopl.dev/gl/peese/exam/2026-05\"}],\"url\":\"https://pe.pablopl.dev/gl/peese/exam/2026-05\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Mayo 2026 de Proceso Software: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/gl/peese/exam/2026-05\",\"inLanguage\":\"gl\",\"description\":\"Practica a recompilación cronometrada Posibles preguntas Mayo 2026 de Proceso Software con 17 preguntas. 8.5 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Proceso Software\",\"courseCode\":\"202321\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Proceso Software\",\"item\":\"https://pe.pablopl.dev/gl/peese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Mayo 2026\",\"item\":\"https://pe.pablopl.dev/gl/peese/exam/2026-05\"}],\"url\":\"https://pe.pablopl.dev/gl/peese/exam/2026-05\"}]}"
   },
   {
     "url": "seo/gl/pei.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/pei",
-    "title": "Programación Integrativa: \"exames\" e preguntas resoltas",
-    "description": "Practica 54 preguntas de Programación Integrativa de 1 \"exames\" anteriores con respostas modelo e autocorrección. 200214, Universidade da Coruña.",
+    "title": "Programación Integrativa: recompilacións e preguntas resoltas",
+    "description": "Practica 54 preguntas de Programación Integrativa de 1 recompilacións de práctica con respostas modelo e autocorrección. 200214, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/pei",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -12479,7 +12479,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Programación Integrativa: \\\"exames\\\" e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/pei\",\"inLanguage\":\"gl\",\"description\":\"Practica 54 preguntas de Programación Integrativa de 1 \\\"exames\\\" anteriores con respostas modelo e autocorrección. 200214, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/gl/pei\"}],\"url\":\"https://pe.pablopl.dev/gl/pei\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Programación Integrativa: recompilacións e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/pei\",\"inLanguage\":\"gl\",\"description\":\"Practica 54 preguntas de Programación Integrativa de 1 recompilacións de práctica con respostas modelo e autocorrección. 200214, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/gl/pei\"}],\"url\":\"https://pe.pablopl.dev/gl/pei\"}]}"
   },
   {
     "url": "seo/gl/pei/practice/pandas.html",
@@ -12487,7 +12487,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/pei/practice/pandas",
     "title": "Pandas y Datos Estructurados: preguntas de Programación Integrativa",
-    "description": "Practica 8 preguntas de Pandas y Datos Estructurados de \"exames\" anteriores de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.",
+    "description": "Practica 8 preguntas de Pandas y Datos Estructurados de recompilacións de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/pei/practice/pandas",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -12511,7 +12511,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei/practice/pandas"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Pandas y Datos Estructurados: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/gl/pei/practice/pandas\",\"inLanguage\":\"gl\",\"description\":\"Practica 8 preguntas de Pandas y Datos Estructurados de \\\"exames\\\" anteriores de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Pandas y Datos Estructurados\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/gl/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Pandas y Datos Estructurados\",\"item\":\"https://pe.pablopl.dev/gl/pei/practice/pandas\"}],\"url\":\"https://pe.pablopl.dev/gl/pei/practice/pandas\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Pandas y Datos Estructurados: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/gl/pei/practice/pandas\",\"inLanguage\":\"gl\",\"description\":\"Practica 8 preguntas de Pandas y Datos Estructurados de recompilacións de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Pandas y Datos Estructurados\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/gl/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Pandas y Datos Estructurados\",\"item\":\"https://pe.pablopl.dev/gl/pei/practice/pandas\"}],\"url\":\"https://pe.pablopl.dev/gl/pei/practice/pandas\"}]}"
   },
   {
     "url": "seo/gl/pei/practice/poo.html",
@@ -12519,7 +12519,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/pei/practice/poo",
     "title": "POO en Python: preguntas de Programación Integrativa",
-    "description": "Practica 8 preguntas de POO en Python de \"exames\" anteriores de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.",
+    "description": "Practica 8 preguntas de POO en Python de recompilacións de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/pei/practice/poo",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -12543,7 +12543,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei/practice/poo"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"POO en Python: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/gl/pei/practice/poo\",\"inLanguage\":\"gl\",\"description\":\"Practica 8 preguntas de POO en Python de \\\"exames\\\" anteriores de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"POO en Python\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/gl/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"POO en Python\",\"item\":\"https://pe.pablopl.dev/gl/pei/practice/poo\"}],\"url\":\"https://pe.pablopl.dev/gl/pei/practice/poo\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"POO en Python: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/gl/pei/practice/poo\",\"inLanguage\":\"gl\",\"description\":\"Practica 8 preguntas de POO en Python de recompilacións de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"POO en Python\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/gl/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"POO en Python\",\"item\":\"https://pe.pablopl.dev/gl/pei/practice/poo\"}],\"url\":\"https://pe.pablopl.dev/gl/pei/practice/poo\"}]}"
   },
   {
     "url": "seo/gl/pei/practice/scripting.html",
@@ -12551,7 +12551,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/pei/practice/scripting",
     "title": "Scripting y Regex: preguntas de Programación Integrativa",
-    "description": "Practica 15 preguntas de Scripting y Regex de \"exames\" anteriores de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.",
+    "description": "Practica 15 preguntas de Scripting y Regex de recompilacións de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/pei/practice/scripting",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -12575,7 +12575,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei/practice/scripting"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Scripting y Regex: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/gl/pei/practice/scripting\",\"inLanguage\":\"gl\",\"description\":\"Practica 15 preguntas de Scripting y Regex de \\\"exames\\\" anteriores de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Scripting y Regex\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/gl/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Scripting y Regex\",\"item\":\"https://pe.pablopl.dev/gl/pei/practice/scripting\"}],\"url\":\"https://pe.pablopl.dev/gl/pei/practice/scripting\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Scripting y Regex: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/gl/pei/practice/scripting\",\"inLanguage\":\"gl\",\"description\":\"Practica 15 preguntas de Scripting y Regex de recompilacións de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Scripting y Regex\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/gl/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Scripting y Regex\",\"item\":\"https://pe.pablopl.dev/gl/pei/practice/scripting\"}],\"url\":\"https://pe.pablopl.dev/gl/pei/practice/scripting\"}]}"
   },
   {
     "url": "seo/gl/pei/practice/django-apis.html",
@@ -12583,7 +12583,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/pei/practice/django-apis",
     "title": "Django, APIs e Integración: preguntas de Programación Integrativa",
-    "description": "Practica 14 preguntas de Django, APIs e Integración de \"exames\" anteriores de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.",
+    "description": "Practica 14 preguntas de Django, APIs e Integración de recompilacións de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/pei/practice/django-apis",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -12607,7 +12607,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei/practice/django-apis"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Django, APIs e Integración: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/gl/pei/practice/django-apis\",\"inLanguage\":\"gl\",\"description\":\"Practica 14 preguntas de Django, APIs e Integración de \\\"exames\\\" anteriores de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Django, APIs e Integración\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/gl/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Django, APIs e Integración\",\"item\":\"https://pe.pablopl.dev/gl/pei/practice/django-apis\"}],\"url\":\"https://pe.pablopl.dev/gl/pei/practice/django-apis\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Django, APIs e Integración: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/gl/pei/practice/django-apis\",\"inLanguage\":\"gl\",\"description\":\"Practica 14 preguntas de Django, APIs e Integración de recompilacións de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Django, APIs e Integración\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/gl/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Django, APIs e Integración\",\"item\":\"https://pe.pablopl.dev/gl/pei/practice/django-apis\"}],\"url\":\"https://pe.pablopl.dev/gl/pei/practice/django-apis\"}]}"
   },
   {
     "url": "seo/gl/pei/practice/conceptos.html",
@@ -12615,7 +12615,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/pei/practice/conceptos",
     "title": "Conceptos y Test: preguntas de Programación Integrativa",
-    "description": "Practica 9 preguntas de Conceptos y Test de \"exames\" anteriores de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.",
+    "description": "Practica 9 preguntas de Conceptos y Test de recompilacións de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/pei/practice/conceptos",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -12639,15 +12639,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei/practice/conceptos"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Conceptos y Test: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/gl/pei/practice/conceptos\",\"inLanguage\":\"gl\",\"description\":\"Practica 9 preguntas de Conceptos y Test de \\\"exames\\\" anteriores de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Conceptos y Test\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/gl/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Conceptos y Test\",\"item\":\"https://pe.pablopl.dev/gl/pei/practice/conceptos\"}],\"url\":\"https://pe.pablopl.dev/gl/pei/practice/conceptos\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Conceptos y Test: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/gl/pei/practice/conceptos\",\"inLanguage\":\"gl\",\"description\":\"Practica 9 preguntas de Conceptos y Test de recompilacións de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Conceptos y Test\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/gl/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Conceptos y Test\",\"item\":\"https://pe.pablopl.dev/gl/pei/practice/conceptos\"}],\"url\":\"https://pe.pablopl.dev/gl/pei/practice/conceptos\"}]}"
   },
   {
     "url": "seo/gl/pei/exam/recopilacion.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/pei/exam/recopilacion",
-    "title": "Recopilación de Programación Integrativa: simulador",
-    "description": "Simula o exame Recopilación de Programación Integrativa con 54 preguntas. 30 puntos, 120 minutos, respostas modelo e autocorrección.",
+    "title": "Recopilación de Programación Integrativa: práctica cronometrada",
+    "description": "Practica a recompilación cronometrada Recopilación de Programación Integrativa con 54 preguntas. 30 puntos, 120 minutos, respostas modelo e autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/pei/exam/recopilacion",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -12671,15 +12671,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei/exam/recopilacion"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Recopilación de Programación Integrativa: simulador\",\"url\":\"https://pe.pablopl.dev/gl/pei/exam/recopilacion\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Recopilación de Programación Integrativa con 54 preguntas. 30 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/gl/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Recopilación\",\"item\":\"https://pe.pablopl.dev/gl/pei/exam/recopilacion\"}],\"url\":\"https://pe.pablopl.dev/gl/pei/exam/recopilacion\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Recopilación de Programación Integrativa: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/gl/pei/exam/recopilacion\",\"inLanguage\":\"gl\",\"description\":\"Practica a recompilación cronometrada Recopilación de Programación Integrativa con 54 preguntas. 30 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/gl/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Recopilación\",\"item\":\"https://pe.pablopl.dev/gl/pei/exam/recopilacion\"}],\"url\":\"https://pe.pablopl.dev/gl/pei/exam/recopilacion\"}]}"
   },
   {
     "url": "seo/gl/redes.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/redes",
-    "title": "Redes: \"exames\" e preguntas resoltas | Pásame Exámenes",
-    "description": "Practica 460 preguntas de Redes de 3 \"exames\" anteriores con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
+    "title": "Redes: recompilacións e preguntas resoltas | Pásame Exámenes",
+    "description": "Practica 460 preguntas de Redes de 3 recompilacións de práctica con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/redes",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -12703,7 +12703,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Redes: \\\"exames\\\" e preguntas resoltas | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/redes\",\"inLanguage\":\"gl\",\"description\":\"Practica 460 preguntas de Redes de 3 \\\"exames\\\" anteriores con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"}],\"url\":\"https://pe.pablopl.dev/gl/redes\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Redes: recompilacións e preguntas resoltas | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/redes\",\"inLanguage\":\"gl\",\"description\":\"Practica 460 preguntas de Redes de 3 recompilacións de práctica con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"}],\"url\":\"https://pe.pablopl.dev/gl/redes\"}]}"
   },
   {
     "url": "seo/gl/redes/practice/tema-1.html",
@@ -12711,7 +12711,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/redes/practice/tema-1",
     "title": "Tema 1. Redes de ordenadores e Internet: preguntas de Redes",
-    "description": "Practica 54 preguntas de Tema 1. Redes de ordenadores e Internet de \"exames\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 54 preguntas de Tema 1. Redes de ordenadores e Internet de recompilacións de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/redes/practice/tema-1",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -12735,7 +12735,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-1"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 1. Redes de ordenadores e Internet: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-1\",\"inLanguage\":\"gl\",\"description\":\"Practica 54 preguntas de Tema 1. Redes de ordenadores e Internet de \\\"exames\\\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 1. Redes de ordenadores e Internet\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 1. Redes de ordenadores e Internet\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-1\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-1\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 1. Redes de ordenadores e Internet: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-1\",\"inLanguage\":\"gl\",\"description\":\"Practica 54 preguntas de Tema 1. Redes de ordenadores e Internet de recompilacións de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 1. Redes de ordenadores e Internet\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 1. Redes de ordenadores e Internet\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-1\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-1\"}]}"
   },
   {
     "url": "seo/gl/redes/practice/tema-2.html",
@@ -12743,7 +12743,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/redes/practice/tema-2",
     "title": "Tema 2. Introducción a TCP/IP: preguntas de Redes",
-    "description": "Practica 19 preguntas de Tema 2. Introducción a TCP/IP de \"exames\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 19 preguntas de Tema 2. Introducción a TCP/IP de recompilacións de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/redes/practice/tema-2",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -12767,7 +12767,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-2"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 2. Introducción a TCP/IP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-2\",\"inLanguage\":\"gl\",\"description\":\"Practica 19 preguntas de Tema 2. Introducción a TCP/IP de \\\"exames\\\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 2. Introducción a TCP/IP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 2. Introducción a TCP/IP\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-2\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-2\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 2. Introducción a TCP/IP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-2\",\"inLanguage\":\"gl\",\"description\":\"Practica 19 preguntas de Tema 2. Introducción a TCP/IP de recompilacións de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 2. Introducción a TCP/IP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 2. Introducción a TCP/IP\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-2\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-2\"}]}"
   },
   {
     "url": "seo/gl/redes/practice/tema-3-4.html",
@@ -12775,7 +12775,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/redes/practice/tema-3-4",
     "title": "Tema 3-4. Protocolos nivel de aplicación: preguntas de Redes",
-    "description": "Practica 77 preguntas de Tema 3-4. Protocolos nivel de aplicación de \"exames\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 77 preguntas de Tema 3-4. Protocolos nivel de aplicación de recompilacións de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/redes/practice/tema-3-4",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -12799,7 +12799,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-3-4"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 3-4. Protocolos nivel de aplicación: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-3-4\",\"inLanguage\":\"gl\",\"description\":\"Practica 77 preguntas de Tema 3-4. Protocolos nivel de aplicación de \\\"exames\\\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 3-4. Protocolos nivel de aplicación\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 3-4. Protocolos nivel de aplicación\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-3-4\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-3-4\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 3-4. Protocolos nivel de aplicación: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-3-4\",\"inLanguage\":\"gl\",\"description\":\"Practica 77 preguntas de Tema 3-4. Protocolos nivel de aplicación de recompilacións de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 3-4. Protocolos nivel de aplicación\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 3-4. Protocolos nivel de aplicación\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-3-4\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-3-4\"}]}"
   },
   {
     "url": "seo/gl/redes/practice/tema-5.html",
@@ -12807,7 +12807,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/redes/practice/tema-5",
     "title": "Tema 5. Protocolos de transporte UDP y TCP: preguntas de Redes",
-    "description": "Practica 51 preguntas de Tema 5. Protocolos de transporte UDP y TCP de \"exames\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 51 preguntas de Tema 5. Protocolos de transporte UDP y TCP de recompilacións de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/redes/practice/tema-5",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -12831,7 +12831,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-5"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 5. Protocolos de transporte UDP y TCP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-5\",\"inLanguage\":\"gl\",\"description\":\"Practica 51 preguntas de Tema 5. Protocolos de transporte UDP y TCP de \\\"exames\\\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 5. Protocolos de transporte UDP y TCP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 5. Protocolos de transporte UDP y TCP\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-5\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-5\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 5. Protocolos de transporte UDP y TCP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-5\",\"inLanguage\":\"gl\",\"description\":\"Practica 51 preguntas de Tema 5. Protocolos de transporte UDP y TCP de recompilacións de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 5. Protocolos de transporte UDP y TCP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 5. Protocolos de transporte UDP y TCP\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-5\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-5\"}]}"
   },
   {
     "url": "seo/gl/redes/practice/tema-6.html",
@@ -12839,7 +12839,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/redes/practice/tema-6",
     "title": "Tema 6. Intercambio de datos TCP: preguntas de Redes",
-    "description": "Practica 48 preguntas de Tema 6. Intercambio de datos TCP de \"exames\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 48 preguntas de Tema 6. Intercambio de datos TCP de recompilacións de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/redes/practice/tema-6",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -12863,7 +12863,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-6"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 6. Intercambio de datos TCP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-6\",\"inLanguage\":\"gl\",\"description\":\"Practica 48 preguntas de Tema 6. Intercambio de datos TCP de \\\"exames\\\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 6. Intercambio de datos TCP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 6. Intercambio de datos TCP\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-6\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-6\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 6. Intercambio de datos TCP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-6\",\"inLanguage\":\"gl\",\"description\":\"Practica 48 preguntas de Tema 6. Intercambio de datos TCP de recompilacións de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 6. Intercambio de datos TCP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 6. Intercambio de datos TCP\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-6\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-6\"}]}"
   },
   {
     "url": "seo/gl/redes/practice/tema-7.html",
@@ -12871,7 +12871,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/redes/practice/tema-7",
     "title": "Tema 7. Nivel de red: protocolo IP: preguntas de Redes",
-    "description": "Practica 81 preguntas de Tema 7. Nivel de red: protocolo IP de \"exames\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 81 preguntas de Tema 7. Nivel de red: protocolo IP de recompilacións de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/redes/practice/tema-7",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -12895,7 +12895,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-7"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 7. Nivel de red: protocolo IP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-7\",\"inLanguage\":\"gl\",\"description\":\"Practica 81 preguntas de Tema 7. Nivel de red: protocolo IP de \\\"exames\\\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 7. Nivel de red: protocolo IP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 7. Nivel de red: protocolo IP\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-7\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-7\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 7. Nivel de red: protocolo IP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-7\",\"inLanguage\":\"gl\",\"description\":\"Practica 81 preguntas de Tema 7. Nivel de red: protocolo IP de recompilacións de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 7. Nivel de red: protocolo IP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 7. Nivel de red: protocolo IP\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-7\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-7\"}]}"
   },
   {
     "url": "seo/gl/redes/practice/tema-8.html",
@@ -12903,7 +12903,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/redes/practice/tema-8",
     "title": "Tema 8. Enrutamiento: preguntas de Redes | Pásame Exámenes",
-    "description": "Practica 22 preguntas de Tema 8. Enrutamiento de \"exames\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 22 preguntas de Tema 8. Enrutamiento de recompilacións de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/redes/practice/tema-8",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -12927,7 +12927,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-8"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 8. Enrutamiento: preguntas de Redes | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-8\",\"inLanguage\":\"gl\",\"description\":\"Practica 22 preguntas de Tema 8. Enrutamiento de \\\"exames\\\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 8. Enrutamiento\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 8. Enrutamiento\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-8\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-8\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 8. Enrutamiento: preguntas de Redes | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-8\",\"inLanguage\":\"gl\",\"description\":\"Practica 22 preguntas de Tema 8. Enrutamiento de recompilacións de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 8. Enrutamiento\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 8. Enrutamiento\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-8\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-8\"}]}"
   },
   {
     "url": "seo/gl/redes/practice/tema-9.html",
@@ -12935,7 +12935,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/redes/practice/tema-9",
     "title": "Tema 9. ICMP y fragmentación IP: preguntas de Redes",
-    "description": "Practica 24 preguntas de Tema 9. ICMP y fragmentación IP de \"exames\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 24 preguntas de Tema 9. ICMP y fragmentación IP de recompilacións de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/redes/practice/tema-9",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -12959,7 +12959,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-9"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 9. ICMP y fragmentación IP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-9\",\"inLanguage\":\"gl\",\"description\":\"Practica 24 preguntas de Tema 9. ICMP y fragmentación IP de \\\"exames\\\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 9. ICMP y fragmentación IP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 9. ICMP y fragmentación IP\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-9\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-9\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 9. ICMP y fragmentación IP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-9\",\"inLanguage\":\"gl\",\"description\":\"Practica 24 preguntas de Tema 9. ICMP y fragmentación IP de recompilacións de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 9. ICMP y fragmentación IP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 9. ICMP y fragmentación IP\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-9\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-9\"}]}"
   },
   {
     "url": "seo/gl/redes/practice/tema-10.html",
@@ -12967,7 +12967,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/redes/practice/tema-10",
     "title": "Tema 10. Protocolo IPv6: preguntas de Redes | Pásame Exámenes",
-    "description": "Practica 11 preguntas de Tema 10. Protocolo IPv6 de \"exames\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 11 preguntas de Tema 10. Protocolo IPv6 de recompilacións de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/redes/practice/tema-10",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -12991,7 +12991,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-10"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 10. Protocolo IPv6: preguntas de Redes | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-10\",\"inLanguage\":\"gl\",\"description\":\"Practica 11 preguntas de Tema 10. Protocolo IPv6 de \\\"exames\\\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 10. Protocolo IPv6\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 10. Protocolo IPv6\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-10\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-10\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 10. Protocolo IPv6: preguntas de Redes | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-10\",\"inLanguage\":\"gl\",\"description\":\"Practica 11 preguntas de Tema 10. Protocolo IPv6 de recompilacións de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 10. Protocolo IPv6\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 10. Protocolo IPv6\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-10\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-10\"}]}"
   },
   {
     "url": "seo/gl/redes/practice/tema-11.html",
@@ -12999,7 +12999,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/redes/practice/tema-11",
     "title": "Tema 11. TCP/IP y nivel de enlace: preguntas de Redes",
-    "description": "Practica 24 preguntas de Tema 11. TCP/IP y nivel de enlace de \"exames\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 24 preguntas de Tema 11. TCP/IP y nivel de enlace de recompilacións de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/redes/practice/tema-11",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -13023,7 +13023,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-11"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 11. TCP/IP y nivel de enlace: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-11\",\"inLanguage\":\"gl\",\"description\":\"Practica 24 preguntas de Tema 11. TCP/IP y nivel de enlace de \\\"exames\\\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 11. TCP/IP y nivel de enlace\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 11. TCP/IP y nivel de enlace\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-11\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-11\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 11. TCP/IP y nivel de enlace: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-11\",\"inLanguage\":\"gl\",\"description\":\"Practica 24 preguntas de Tema 11. TCP/IP y nivel de enlace de recompilacións de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 11. TCP/IP y nivel de enlace\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 11. TCP/IP y nivel de enlace\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-11\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-11\"}]}"
   },
   {
     "url": "seo/gl/redes/practice/tema-12.html",
@@ -13031,7 +13031,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/redes/practice/tema-12",
     "title": "Tema 12. Tecnologías del nivel de enlace: preguntas de Redes",
-    "description": "Practica 49 preguntas de Tema 12. Tecnologías del nivel de enlace de \"exames\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 49 preguntas de Tema 12. Tecnologías del nivel de enlace de recompilacións de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/redes/practice/tema-12",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -13055,15 +13055,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-12"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 12. Tecnologías del nivel de enlace: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-12\",\"inLanguage\":\"gl\",\"description\":\"Practica 49 preguntas de Tema 12. Tecnologías del nivel de enlace de \\\"exames\\\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 12. Tecnologías del nivel de enlace\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 12. Tecnologías del nivel de enlace\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-12\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-12\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 12. Tecnologías del nivel de enlace: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-12\",\"inLanguage\":\"gl\",\"description\":\"Practica 49 preguntas de Tema 12. Tecnologías del nivel de enlace de recompilacións de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 12. Tecnologías del nivel de enlace\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 12. Tecnologías del nivel de enlace\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-12\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-12\"}]}"
   },
   {
     "url": "seo/gl/redes/exam/daypo-recopilatorio-lara.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/redes/exam/daypo-recopilatorio-lara",
-    "title": "Daypo Recopilatorio (des. 2008) de Redes: simulador",
-    "description": "Simula o exame Daypo Recopilatorio (des. 2008) de Redes con 125 preguntas. 125 puntos, 120 minutos, respostas modelo e autocorrección.",
+    "title": "Daypo Recopilatorio (des. 2008) de Redes: práctica cronometrada",
+    "description": "Practica a recompilación cronometrada Daypo Recopilatorio (des. 2008) de Redes con 125 preguntas. 125 puntos, 120 minutos, respostas modelo e autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/redes/exam/daypo-recopilatorio-lara",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -13087,15 +13087,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/exam/daypo-recopilatorio-lara"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Recopilatorio (des. 2008) de Redes: simulador\",\"url\":\"https://pe.pablopl.dev/gl/redes/exam/daypo-recopilatorio-lara\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Daypo Recopilatorio (des. 2008) de Redes con 125 preguntas. 125 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Recopilatorio (des. 2008)\",\"item\":\"https://pe.pablopl.dev/gl/redes/exam/daypo-recopilatorio-lara\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/exam/daypo-recopilatorio-lara\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Recopilatorio (des. 2008) de Redes: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/gl/redes/exam/daypo-recopilatorio-lara\",\"inLanguage\":\"gl\",\"description\":\"Practica a recompilación cronometrada Daypo Recopilatorio (des. 2008) de Redes con 125 preguntas. 125 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Recopilatorio (des. 2008)\",\"item\":\"https://pe.pablopl.dev/gl/redes/exam/daypo-recopilatorio-lara\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/exam/daypo-recopilatorio-lara\"}]}"
   },
   {
     "url": "seo/gl/redes/exam/daypo-recopilatorio-udc.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/redes/exam/daypo-recopilatorio-udc",
-    "title": "Daypo Recopilatorio (UDC) de Redes: simulador",
-    "description": "Simula o exame Daypo Recopilatorio (UDC) de Redes con 298 preguntas. 298 puntos, 240 minutos, respostas modelo e autocorrección.",
+    "title": "Daypo Recopilatorio (UDC) de Redes: práctica cronometrada",
+    "description": "Practica a recompilación cronometrada Daypo Recopilatorio (UDC) de Redes con 298 preguntas. 298 puntos, 240 minutos, respostas modelo e autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/redes/exam/daypo-recopilatorio-udc",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -13119,15 +13119,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/exam/daypo-recopilatorio-udc"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Recopilatorio (UDC) de Redes: simulador\",\"url\":\"https://pe.pablopl.dev/gl/redes/exam/daypo-recopilatorio-udc\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Daypo Recopilatorio (UDC) de Redes con 298 preguntas. 298 puntos, 240 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Recopilatorio (UDC)\",\"item\":\"https://pe.pablopl.dev/gl/redes/exam/daypo-recopilatorio-udc\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/exam/daypo-recopilatorio-udc\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Daypo Recopilatorio (UDC) de Redes: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/gl/redes/exam/daypo-recopilatorio-udc\",\"inLanguage\":\"gl\",\"description\":\"Practica a recompilación cronometrada Daypo Recopilatorio (UDC) de Redes con 298 preguntas. 298 puntos, 240 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Daypo Recopilatorio (UDC)\",\"item\":\"https://pe.pablopl.dev/gl/redes/exam/daypo-recopilatorio-udc\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/exam/daypo-recopilatorio-udc\"}]}"
   },
   {
     "url": "seo/gl/redes/exam/2025-05.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/redes/exam/2025-05",
-    "title": "Posibles preguntas Mayo 2025 de Redes: simulador",
-    "description": "Simula o exame Posibles preguntas Mayo 2025 de Redes con 37 preguntas. 37 puntos, 120 minutos, respostas modelo e autocorrección.",
+    "title": "Posibles preguntas Mayo 2025 de Redes: práctica cronometrada",
+    "description": "Practica a recompilación cronometrada Posibles preguntas Mayo 2025 de Redes con 37 preguntas. 37 puntos, 120 minutos, respostas modelo e autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/redes/exam/2025-05",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -13151,6 +13151,6 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/exam/2025-05"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Mayo 2025 de Redes: simulador\",\"url\":\"https://pe.pablopl.dev/gl/redes/exam/2025-05\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Posibles preguntas Mayo 2025 de Redes con 37 preguntas. 37 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Mayo 2025\",\"item\":\"https://pe.pablopl.dev/gl/redes/exam/2025-05\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/exam/2025-05\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Mayo 2025 de Redes: práctica cronometrada\",\"url\":\"https://pe.pablopl.dev/gl/redes/exam/2025-05\",\"inLanguage\":\"gl\",\"description\":\"Practica a recompilación cronometrada Posibles preguntas Mayo 2025 de Redes con 37 preguntas. 37 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Mayo 2025\",\"item\":\"https://pe.pablopl.dev/gl/redes/exam/2025-05\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/exam/2025-05\"}]}"
   }
 ] as const satisfies readonly PageMetaData[];

--- a/src/seo/pageMetaMap.generated.ts
+++ b/src/seo/pageMetaMap.generated.ts
@@ -38,8 +38,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/bede",
-    "title": "Bases de Datos: past exams and solved questions",
-    "description": "Practice 98 Bases de Datos questions from 1 past exams with model answers and self-grading. 202315, Universidade da Coruña.",
+    "title": "Bases de Datos: past \"exams\" and solved questions",
+    "description": "Practice 98 Bases de Datos questions from 1 past \"exams\" with model answers and self-grading. 202315, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/bede",
     "ogImage": "https://pe.pablopl.dev/og/bede.png",
@@ -63,7 +63,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/bede"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Bases de Datos: past exams and solved questions\",\"url\":\"https://pe.pablopl.dev/en/bede\",\"inLanguage\":\"en\",\"description\":\"Practice 98 Bases de Datos questions from 1 past exams with model answers and self-grading. 202315, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/en/bede\"}],\"url\":\"https://pe.pablopl.dev/en/bede\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Bases de Datos: past \\\"exams\\\" and solved questions\",\"url\":\"https://pe.pablopl.dev/en/bede\",\"inLanguage\":\"en\",\"description\":\"Practice 98 Bases de Datos questions from 1 past \\\"exams\\\" with model answers and self-grading. 202315, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/en/bede\"}],\"url\":\"https://pe.pablopl.dev/en/bede\"}]}"
   },
   {
     "url": "seo/en/bede/practice/recuperacion-concurrencia.html",
@@ -71,7 +71,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/bede/practice/recuperacion-concurrencia",
     "title": "Recuperación y Concurrencia: Bases de Datos exam questions",
-    "description": "Practice 48 Recuperación y Concurrencia questions from past Bases de Datos exams with model answers and self-grading. 202315, Universidade da Coruña.",
+    "description": "Practice 48 Recuperación y Concurrencia questions from past Bases de Datos \"exams\" with model answers and self-grading. 202315, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/bede/practice/recuperacion-concurrencia",
     "ogImage": "https://pe.pablopl.dev/og/bede.png",
@@ -95,7 +95,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/bede/practice/recuperacion-concurrencia"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Recuperación y Concurrencia: Bases de Datos exam questions\",\"url\":\"https://pe.pablopl.dev/en/bede/practice/recuperacion-concurrencia\",\"inLanguage\":\"en\",\"description\":\"Practice 48 Recuperación y Concurrencia questions from past Bases de Datos exams with model answers and self-grading. 202315, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Recuperación y Concurrencia\"},{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/en/bede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Recuperación y Concurrencia\",\"item\":\"https://pe.pablopl.dev/en/bede/practice/recuperacion-concurrencia\"}],\"url\":\"https://pe.pablopl.dev/en/bede/practice/recuperacion-concurrencia\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Recuperación y Concurrencia: Bases de Datos exam questions\",\"url\":\"https://pe.pablopl.dev/en/bede/practice/recuperacion-concurrencia\",\"inLanguage\":\"en\",\"description\":\"Practice 48 Recuperación y Concurrencia questions from past Bases de Datos \\\"exams\\\" with model answers and self-grading. 202315, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Recuperación y Concurrencia\"},{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/en/bede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Recuperación y Concurrencia\",\"item\":\"https://pe.pablopl.dev/en/bede/practice/recuperacion-concurrencia\"}],\"url\":\"https://pe.pablopl.dev/en/bede/practice/recuperacion-concurrencia\"}]}"
   },
   {
     "url": "seo/en/bede/practice/ficheros.html",
@@ -103,7 +103,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/bede/practice/ficheros",
     "title": "Ficheros: Bases de Datos exam questions | Pásame Exámenes",
-    "description": "Practice 50 Ficheros questions from past Bases de Datos exams with model answers and self-grading. 202315, Universidade da Coruña.",
+    "description": "Practice 50 Ficheros questions from past Bases de Datos \"exams\" with model answers and self-grading. 202315, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/bede/practice/ficheros",
     "ogImage": "https://pe.pablopl.dev/og/bede.png",
@@ -127,7 +127,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/bede/practice/ficheros"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Ficheros: Bases de Datos exam questions | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/en/bede/practice/ficheros\",\"inLanguage\":\"en\",\"description\":\"Practice 50 Ficheros questions from past Bases de Datos exams with model answers and self-grading. 202315, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Ficheros\"},{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/en/bede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Ficheros\",\"item\":\"https://pe.pablopl.dev/en/bede/practice/ficheros\"}],\"url\":\"https://pe.pablopl.dev/en/bede/practice/ficheros\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Ficheros: Bases de Datos exam questions | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/en/bede/practice/ficheros\",\"inLanguage\":\"en\",\"description\":\"Practice 50 Ficheros questions from past Bases de Datos \\\"exams\\\" with model answers and self-grading. 202315, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Ficheros\"},{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/en/bede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Ficheros\",\"item\":\"https://pe.pablopl.dev/en/bede/practice/ficheros\"}],\"url\":\"https://pe.pablopl.dev/en/bede/practice/ficheros\"}]}"
   },
   {
     "url": "seo/en/bede/exam/daypo-preguntas.html",
@@ -166,8 +166,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/cepe",
-    "title": "Concorrencia e Paralelismo: past exams and solved questions",
-    "description": "Practice 76 Concorrencia e Paralelismo questions from 16 past exams with model answers and self-grading. 202320, Universidade da Coruña.",
+    "title": "Concorrencia e Paralelismo: past \"exams\" and solved questions",
+    "description": "Practice 76 Concorrencia e Paralelismo questions from 16 past \"exams\" with model answers and self-grading. 202320, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/cepe",
     "ogImage": "https://pe.pablopl.dev/og/cepe.png",
@@ -191,7 +191,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/cepe"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Concorrencia e Paralelismo: past exams and solved questions\",\"url\":\"https://pe.pablopl.dev/en/cepe\",\"inLanguage\":\"en\",\"description\":\"Practice 76 Concorrencia e Paralelismo questions from 16 past exams with model answers and self-grading. 202320, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/en/cepe\"}],\"url\":\"https://pe.pablopl.dev/en/cepe\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Concorrencia e Paralelismo: past \\\"exams\\\" and solved questions\",\"url\":\"https://pe.pablopl.dev/en/cepe\",\"inLanguage\":\"en\",\"description\":\"Practice 76 Concorrencia e Paralelismo questions from 16 past \\\"exams\\\" with model answers and self-grading. 202320, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/en/cepe\"}],\"url\":\"https://pe.pablopl.dev/en/cepe\"}]}"
   },
   {
     "url": "seo/en/cepe/practice/concurrencia-mutex.html",
@@ -199,7 +199,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/cepe/practice/concurrencia-mutex",
     "title": "Mutex y Condiciones: Concorrencia e Paralelismo exam questions",
-    "description": "Practice 32 Mutex y Condiciones questions from past Concorrencia e Paralelismo exams with model answers and self-grading. 202320, Universidade da Coruña.",
+    "description": "Practice 32 Mutex y Condiciones questions from past Concorrencia e Paralelismo \"exams\" with model answers and self-grading. 202320, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/cepe/practice/concurrencia-mutex",
     "ogImage": "https://pe.pablopl.dev/og/cepe.png",
@@ -223,7 +223,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/cepe/practice/concurrencia-mutex"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Mutex y Condiciones: Concorrencia e Paralelismo exam questions\",\"url\":\"https://pe.pablopl.dev/en/cepe/practice/concurrencia-mutex\",\"inLanguage\":\"en\",\"description\":\"Practice 32 Mutex y Condiciones questions from past Concorrencia e Paralelismo exams with model answers and self-grading. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Mutex y Condiciones\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/en/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Mutex y Condiciones\",\"item\":\"https://pe.pablopl.dev/en/cepe/practice/concurrencia-mutex\"}],\"url\":\"https://pe.pablopl.dev/en/cepe/practice/concurrencia-mutex\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Mutex y Condiciones: Concorrencia e Paralelismo exam questions\",\"url\":\"https://pe.pablopl.dev/en/cepe/practice/concurrencia-mutex\",\"inLanguage\":\"en\",\"description\":\"Practice 32 Mutex y Condiciones questions from past Concorrencia e Paralelismo \\\"exams\\\" with model answers and self-grading. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Mutex y Condiciones\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/en/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Mutex y Condiciones\",\"item\":\"https://pe.pablopl.dev/en/cepe/practice/concurrencia-mutex\"}],\"url\":\"https://pe.pablopl.dev/en/cepe/practice/concurrencia-mutex\"}]}"
   },
   {
     "url": "seo/en/cepe/practice/concurrencia-erlang.html",
@@ -231,7 +231,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/cepe/practice/concurrencia-erlang",
     "title": "Erlang: Concorrencia e Paralelismo exam questions",
-    "description": "Practice 12 Erlang questions from past Concorrencia e Paralelismo exams with model answers and self-grading. 202320, Universidade da Coruña.",
+    "description": "Practice 12 Erlang questions from past Concorrencia e Paralelismo \"exams\" with model answers and self-grading. 202320, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/cepe/practice/concurrencia-erlang",
     "ogImage": "https://pe.pablopl.dev/og/cepe.png",
@@ -255,7 +255,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/cepe/practice/concurrencia-erlang"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Erlang: Concorrencia e Paralelismo exam questions\",\"url\":\"https://pe.pablopl.dev/en/cepe/practice/concurrencia-erlang\",\"inLanguage\":\"en\",\"description\":\"Practice 12 Erlang questions from past Concorrencia e Paralelismo exams with model answers and self-grading. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Erlang\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/en/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Erlang\",\"item\":\"https://pe.pablopl.dev/en/cepe/practice/concurrencia-erlang\"}],\"url\":\"https://pe.pablopl.dev/en/cepe/practice/concurrencia-erlang\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Erlang: Concorrencia e Paralelismo exam questions\",\"url\":\"https://pe.pablopl.dev/en/cepe/practice/concurrencia-erlang\",\"inLanguage\":\"en\",\"description\":\"Practice 12 Erlang questions from past Concorrencia e Paralelismo \\\"exams\\\" with model answers and self-grading. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Erlang\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/en/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Erlang\",\"item\":\"https://pe.pablopl.dev/en/cepe/practice/concurrencia-erlang\"}],\"url\":\"https://pe.pablopl.dev/en/cepe/practice/concurrencia-erlang\"}]}"
   },
   {
     "url": "seo/en/cepe/practice/paralelismo-teoria.html",
@@ -263,7 +263,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/cepe/practice/paralelismo-teoria",
     "title": "Preguntas Teóricas: Concorrencia e Paralelismo exam questions",
-    "description": "Practice 19 Preguntas Teóricas questions from past Concorrencia e Paralelismo exams with model answers and self-grading. 202320, Universidade da Coruña.",
+    "description": "Practice 19 Preguntas Teóricas questions from past Concorrencia e Paralelismo \"exams\" with model answers and self-grading. 202320, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/cepe/practice/paralelismo-teoria",
     "ogImage": "https://pe.pablopl.dev/og/cepe.png",
@@ -287,7 +287,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/cepe/practice/paralelismo-teoria"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Preguntas Teóricas: Concorrencia e Paralelismo exam questions\",\"url\":\"https://pe.pablopl.dev/en/cepe/practice/paralelismo-teoria\",\"inLanguage\":\"en\",\"description\":\"Practice 19 Preguntas Teóricas questions from past Concorrencia e Paralelismo exams with model answers and self-grading. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Preguntas Teóricas\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/en/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Preguntas Teóricas\",\"item\":\"https://pe.pablopl.dev/en/cepe/practice/paralelismo-teoria\"}],\"url\":\"https://pe.pablopl.dev/en/cepe/practice/paralelismo-teoria\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Preguntas Teóricas: Concorrencia e Paralelismo exam questions\",\"url\":\"https://pe.pablopl.dev/en/cepe/practice/paralelismo-teoria\",\"inLanguage\":\"en\",\"description\":\"Practice 19 Preguntas Teóricas questions from past Concorrencia e Paralelismo \\\"exams\\\" with model answers and self-grading. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Preguntas Teóricas\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/en/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Preguntas Teóricas\",\"item\":\"https://pe.pablopl.dev/en/cepe/practice/paralelismo-teoria\"}],\"url\":\"https://pe.pablopl.dev/en/cepe/practice/paralelismo-teoria\"}]}"
   },
   {
     "url": "seo/en/cepe/practice/paralelismo-mpi.html",
@@ -295,7 +295,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/cepe/practice/paralelismo-mpi",
     "title": "Ejercicios de MPI: Concorrencia e Paralelismo exam questions",
-    "description": "Practice 13 Ejercicios de MPI questions from past Concorrencia e Paralelismo exams with model answers and self-grading. 202320, Universidade da Coruña.",
+    "description": "Practice 13 Ejercicios de MPI questions from past Concorrencia e Paralelismo \"exams\" with model answers and self-grading. 202320, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/cepe/practice/paralelismo-mpi",
     "ogImage": "https://pe.pablopl.dev/og/cepe.png",
@@ -319,7 +319,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/cepe/practice/paralelismo-mpi"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Ejercicios de MPI: Concorrencia e Paralelismo exam questions\",\"url\":\"https://pe.pablopl.dev/en/cepe/practice/paralelismo-mpi\",\"inLanguage\":\"en\",\"description\":\"Practice 13 Ejercicios de MPI questions from past Concorrencia e Paralelismo exams with model answers and self-grading. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Ejercicios de MPI\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/en/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Ejercicios de MPI\",\"item\":\"https://pe.pablopl.dev/en/cepe/practice/paralelismo-mpi\"}],\"url\":\"https://pe.pablopl.dev/en/cepe/practice/paralelismo-mpi\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Ejercicios de MPI: Concorrencia e Paralelismo exam questions\",\"url\":\"https://pe.pablopl.dev/en/cepe/practice/paralelismo-mpi\",\"inLanguage\":\"en\",\"description\":\"Practice 13 Ejercicios de MPI questions from past Concorrencia e Paralelismo \\\"exams\\\" with model answers and self-grading. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Ejercicios de MPI\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/en/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Ejercicios de MPI\",\"item\":\"https://pe.pablopl.dev/en/cepe/practice/paralelismo-mpi\"}],\"url\":\"https://pe.pablopl.dev/en/cepe/practice/paralelismo-mpi\"}]}"
   },
   {
     "url": "seo/en/cepe/exam/2018-06.html",
@@ -838,8 +838,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/deese",
-    "title": "Deseño de Software: past exams and solved questions",
-    "description": "Practice 55 Deseño de Software questions from 2 past exams with model answers and self-grading. 202317, Universidade da Coruña.",
+    "title": "Deseño de Software: past \"exams\" and solved questions",
+    "description": "Practice 55 Deseño de Software questions from 2 past \"exams\" with model answers and self-grading. 202317, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/deese",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -863,7 +863,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Deseño de Software: past exams and solved questions\",\"url\":\"https://pe.pablopl.dev/en/deese\",\"inLanguage\":\"en\",\"description\":\"Practice 55 Deseño de Software questions from 2 past exams with model answers and self-grading. 202317, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/en/deese\"}],\"url\":\"https://pe.pablopl.dev/en/deese\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Deseño de Software: past \\\"exams\\\" and solved questions\",\"url\":\"https://pe.pablopl.dev/en/deese\",\"inLanguage\":\"en\",\"description\":\"Practice 55 Deseño de Software questions from 2 past \\\"exams\\\" with model answers and self-grading. 202317, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/en/deese\"}],\"url\":\"https://pe.pablopl.dev/en/deese\"}]}"
   },
   {
     "url": "seo/en/deese/practice/intro-y-objetos.html",
@@ -871,7 +871,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/deese/practice/intro-y-objetos",
     "title": "Introducción y Elementos Básicos de la OO: Deseño de Software exam questions",
-    "description": "Practice 12 Introducción y Elementos Básicos de la OO questions from past Deseño de Software exams with model answers and self-grading. 202317, Universidade da Coruña.",
+    "description": "Practice 12 Introducción y Elementos Básicos de la OO questions from past Deseño de Software \"exams\" with model answers and self-grading. 202317, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/deese/practice/intro-y-objetos",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -895,7 +895,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/practice/intro-y-objetos"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Introducción y Elementos Básicos de la OO: Deseño de Software exam questions\",\"url\":\"https://pe.pablopl.dev/en/deese/practice/intro-y-objetos\",\"inLanguage\":\"en\",\"description\":\"Practice 12 Introducción y Elementos Básicos de la OO questions from past Deseño de Software exams with model answers and self-grading. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Introducción y Elementos Básicos de la OO\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/en/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Introducción y Elementos Básicos de la OO\",\"item\":\"https://pe.pablopl.dev/en/deese/practice/intro-y-objetos\"}],\"url\":\"https://pe.pablopl.dev/en/deese/practice/intro-y-objetos\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Introducción y Elementos Básicos de la OO: Deseño de Software exam questions\",\"url\":\"https://pe.pablopl.dev/en/deese/practice/intro-y-objetos\",\"inLanguage\":\"en\",\"description\":\"Practice 12 Introducción y Elementos Básicos de la OO questions from past Deseño de Software \\\"exams\\\" with model answers and self-grading. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Introducción y Elementos Básicos de la OO\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/en/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Introducción y Elementos Básicos de la OO\",\"item\":\"https://pe.pablopl.dev/en/deese/practice/intro-y-objetos\"}],\"url\":\"https://pe.pablopl.dev/en/deese/practice/intro-y-objetos\"}]}"
   },
   {
     "url": "seo/en/deese/practice/propiedades-oo.html",
@@ -903,7 +903,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/deese/practice/propiedades-oo",
     "title": "Propiedades Básicas de la OO: Deseño de Software exam questions",
-    "description": "Practice 11 Propiedades Básicas de la OO questions from past Deseño de Software exams with model answers and self-grading. 202317, Universidade da Coruña.",
+    "description": "Practice 11 Propiedades Básicas de la OO questions from past Deseño de Software \"exams\" with model answers and self-grading. 202317, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/deese/practice/propiedades-oo",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -927,7 +927,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/practice/propiedades-oo"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Propiedades Básicas de la OO: Deseño de Software exam questions\",\"url\":\"https://pe.pablopl.dev/en/deese/practice/propiedades-oo\",\"inLanguage\":\"en\",\"description\":\"Practice 11 Propiedades Básicas de la OO questions from past Deseño de Software exams with model answers and self-grading. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Propiedades Básicas de la OO\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/en/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Propiedades Básicas de la OO\",\"item\":\"https://pe.pablopl.dev/en/deese/practice/propiedades-oo\"}],\"url\":\"https://pe.pablopl.dev/en/deese/practice/propiedades-oo\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Propiedades Básicas de la OO: Deseño de Software exam questions\",\"url\":\"https://pe.pablopl.dev/en/deese/practice/propiedades-oo\",\"inLanguage\":\"en\",\"description\":\"Practice 11 Propiedades Básicas de la OO questions from past Deseño de Software \\\"exams\\\" with model answers and self-grading. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Propiedades Básicas de la OO\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/en/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Propiedades Básicas de la OO\",\"item\":\"https://pe.pablopl.dev/en/deese/practice/propiedades-oo\"}],\"url\":\"https://pe.pablopl.dev/en/deese/practice/propiedades-oo\"}]}"
   },
   {
     "url": "seo/en/deese/practice/uml.html",
@@ -935,7 +935,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/deese/practice/uml",
     "title": "UML: Deseño de Software exam questions | Pásame Exámenes",
-    "description": "Practice 10 UML questions from past Deseño de Software exams with model answers and self-grading. 202317, Universidade da Coruña.",
+    "description": "Practice 10 UML questions from past Deseño de Software \"exams\" with model answers and self-grading. 202317, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/deese/practice/uml",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -959,7 +959,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/practice/uml"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"UML: Deseño de Software exam questions | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/en/deese/practice/uml\",\"inLanguage\":\"en\",\"description\":\"Practice 10 UML questions from past Deseño de Software exams with model answers and self-grading. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"UML\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/en/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"UML\",\"item\":\"https://pe.pablopl.dev/en/deese/practice/uml\"}],\"url\":\"https://pe.pablopl.dev/en/deese/practice/uml\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"UML: Deseño de Software exam questions | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/en/deese/practice/uml\",\"inLanguage\":\"en\",\"description\":\"Practice 10 UML questions from past Deseño de Software \\\"exams\\\" with model answers and self-grading. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"UML\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/en/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"UML\",\"item\":\"https://pe.pablopl.dev/en/deese/practice/uml\"}],\"url\":\"https://pe.pablopl.dev/en/deese/practice/uml\"}]}"
   },
   {
     "url": "seo/en/deese/practice/principios-diseno.html",
@@ -967,7 +967,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/deese/practice/principios-diseno",
     "title": "Principios de Diseño: Deseño de Software exam questions",
-    "description": "Practice 12 Principios de Diseño questions from past Deseño de Software exams with model answers and self-grading. 202317, Universidade da Coruña.",
+    "description": "Practice 12 Principios de Diseño questions from past Deseño de Software \"exams\" with model answers and self-grading. 202317, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/deese/practice/principios-diseno",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -991,7 +991,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/practice/principios-diseno"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Principios de Diseño: Deseño de Software exam questions\",\"url\":\"https://pe.pablopl.dev/en/deese/practice/principios-diseno\",\"inLanguage\":\"en\",\"description\":\"Practice 12 Principios de Diseño questions from past Deseño de Software exams with model answers and self-grading. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Principios de Diseño\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/en/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Principios de Diseño\",\"item\":\"https://pe.pablopl.dev/en/deese/practice/principios-diseno\"}],\"url\":\"https://pe.pablopl.dev/en/deese/practice/principios-diseno\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Principios de Diseño: Deseño de Software exam questions\",\"url\":\"https://pe.pablopl.dev/en/deese/practice/principios-diseno\",\"inLanguage\":\"en\",\"description\":\"Practice 12 Principios de Diseño questions from past Deseño de Software \\\"exams\\\" with model answers and self-grading. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Principios de Diseño\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/en/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Principios de Diseño\",\"item\":\"https://pe.pablopl.dev/en/deese/practice/principios-diseno\"}],\"url\":\"https://pe.pablopl.dev/en/deese/practice/principios-diseno\"}]}"
   },
   {
     "url": "seo/en/deese/practice/patrones-diseno.html",
@@ -999,7 +999,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/deese/practice/patrones-diseno",
     "title": "Patrones de Diseño: Deseño de Software exam questions",
-    "description": "Practice 10 Patrones de Diseño questions from past Deseño de Software exams with model answers and self-grading. 202317, Universidade da Coruña.",
+    "description": "Practice 10 Patrones de Diseño questions from past Deseño de Software \"exams\" with model answers and self-grading. 202317, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/deese/practice/patrones-diseno",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -1023,15 +1023,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/practice/patrones-diseno"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Patrones de Diseño: Deseño de Software exam questions\",\"url\":\"https://pe.pablopl.dev/en/deese/practice/patrones-diseno\",\"inLanguage\":\"en\",\"description\":\"Practice 10 Patrones de Diseño questions from past Deseño de Software exams with model answers and self-grading. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Patrones de Diseño\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/en/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Patrones de Diseño\",\"item\":\"https://pe.pablopl.dev/en/deese/practice/patrones-diseno\"}],\"url\":\"https://pe.pablopl.dev/en/deese/practice/patrones-diseno\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Patrones de Diseño: Deseño de Software exam questions\",\"url\":\"https://pe.pablopl.dev/en/deese/practice/patrones-diseno\",\"inLanguage\":\"en\",\"description\":\"Practice 10 Patrones de Diseño questions from past Deseño de Software \\\"exams\\\" with model answers and self-grading. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Patrones de Diseño\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/en/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Patrones de Diseño\",\"item\":\"https://pe.pablopl.dev/en/deese/practice/patrones-diseno\"}],\"url\":\"https://pe.pablopl.dev/en/deese/practice/patrones-diseno\"}]}"
   },
   {
     "url": "seo/en/deese/exam/2020-01.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/deese/exam/2020-01",
-    "title": "Enero 2020 Deseño de Software: exam simulator",
-    "description": "Simulate the Enero 2020 Deseño de Software exam with 30 questions. 30 points, 150 minutes, model answers and self-grading.",
+    "title": "Posibles preguntas Enero 2020 Deseño de Software: exam simulator",
+    "description": "Simulate the Posibles preguntas Enero 2020 Deseño de Software exam with 30 questions. 30 points, 150 minutes, model answers and self-grading.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/deese/exam/2020-01",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -1055,15 +1055,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/exam/2020-01"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Enero 2020 Deseño de Software: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/deese/exam/2020-01\",\"inLanguage\":\"en\",\"description\":\"Simulate the Enero 2020 Deseño de Software exam with 30 questions. 30 points, 150 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/en/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Enero 2020\",\"item\":\"https://pe.pablopl.dev/en/deese/exam/2020-01\"}],\"url\":\"https://pe.pablopl.dev/en/deese/exam/2020-01\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Enero 2020 Deseño de Software: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/deese/exam/2020-01\",\"inLanguage\":\"en\",\"description\":\"Simulate the Posibles preguntas Enero 2020 Deseño de Software exam with 30 questions. 30 points, 150 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/en/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Enero 2020\",\"item\":\"https://pe.pablopl.dev/en/deese/exam/2020-01\"}],\"url\":\"https://pe.pablopl.dev/en/deese/exam/2020-01\"}]}"
   },
   {
     "url": "seo/en/deese/exam/2022-01.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/deese/exam/2022-01",
-    "title": "Enero 2022 Deseño de Software: exam simulator",
-    "description": "Simulate the Enero 2022 Deseño de Software exam with 25 questions. 25 points, 150 minutes, model answers and self-grading.",
+    "title": "Posibles preguntas Enero 2022 Deseño de Software: exam simulator",
+    "description": "Simulate the Posibles preguntas Enero 2022 Deseño de Software exam with 25 questions. 25 points, 150 minutes, model answers and self-grading.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/deese/exam/2022-01",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -1087,15 +1087,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/exam/2022-01"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Enero 2022 Deseño de Software: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/deese/exam/2022-01\",\"inLanguage\":\"en\",\"description\":\"Simulate the Enero 2022 Deseño de Software exam with 25 questions. 25 points, 150 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/en/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Enero 2022\",\"item\":\"https://pe.pablopl.dev/en/deese/exam/2022-01\"}],\"url\":\"https://pe.pablopl.dev/en/deese/exam/2022-01\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Enero 2022 Deseño de Software: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/deese/exam/2022-01\",\"inLanguage\":\"en\",\"description\":\"Simulate the Posibles preguntas Enero 2022 Deseño de Software exam with 25 questions. 25 points, 150 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/en/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Enero 2022\",\"item\":\"https://pe.pablopl.dev/en/deese/exam/2022-01\"}],\"url\":\"https://pe.pablopl.dev/en/deese/exam/2022-01\"}]}"
   },
   {
     "url": "seo/en/ece.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/ece",
-    "title": "Estrutura de Computadores: past exams and solved questions",
-    "description": "Practice 51 Estrutura de Computadores questions from 11 past exams with model answers and self-grading. 202314, Universidade da Coruña.",
+    "title": "Estrutura de Computadores: past \"exams\" and solved questions",
+    "description": "Practice 51 Estrutura de Computadores questions from 11 past \"exams\" with model answers and self-grading. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/ece",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -1119,7 +1119,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Estrutura de Computadores: past exams and solved questions\",\"url\":\"https://pe.pablopl.dev/en/ece\",\"inLanguage\":\"en\",\"description\":\"Practice 51 Estrutura de Computadores questions from 11 past exams with model answers and self-grading. 202314, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/en/ece\"}],\"url\":\"https://pe.pablopl.dev/en/ece\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Estrutura de Computadores: past \\\"exams\\\" and solved questions\",\"url\":\"https://pe.pablopl.dev/en/ece\",\"inLanguage\":\"en\",\"description\":\"Practice 51 Estrutura de Computadores questions from 11 past \\\"exams\\\" with model answers and self-grading. 202314, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/en/ece\"}],\"url\":\"https://pe.pablopl.dev/en/ece\"}]}"
   },
   {
     "url": "seo/en/ece/practice/rendimiento.html",
@@ -1127,7 +1127,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/ece/practice/rendimiento",
     "title": "Rendimiento: Estrutura de Computadores exam questions",
-    "description": "Practice 7 Rendimiento questions from past Estrutura de Computadores exams with model answers and self-grading. 202314, Universidade da Coruña.",
+    "description": "Practice 7 Rendimiento questions from past Estrutura de Computadores \"exams\" with model answers and self-grading. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/ece/practice/rendimiento",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -1151,7 +1151,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece/practice/rendimiento"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Rendimiento: Estrutura de Computadores exam questions\",\"url\":\"https://pe.pablopl.dev/en/ece/practice/rendimiento\",\"inLanguage\":\"en\",\"description\":\"Practice 7 Rendimiento questions from past Estrutura de Computadores exams with model answers and self-grading. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Rendimiento\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/en/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Rendimiento\",\"item\":\"https://pe.pablopl.dev/en/ece/practice/rendimiento\"}],\"url\":\"https://pe.pablopl.dev/en/ece/practice/rendimiento\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Rendimiento: Estrutura de Computadores exam questions\",\"url\":\"https://pe.pablopl.dev/en/ece/practice/rendimiento\",\"inLanguage\":\"en\",\"description\":\"Practice 7 Rendimiento questions from past Estrutura de Computadores \\\"exams\\\" with model answers and self-grading. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Rendimiento\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/en/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Rendimiento\",\"item\":\"https://pe.pablopl.dev/en/ece/practice/rendimiento\"}],\"url\":\"https://pe.pablopl.dev/en/ece/practice/rendimiento\"}]}"
   },
   {
     "url": "seo/en/ece/practice/segmentacion.html",
@@ -1159,7 +1159,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/ece/practice/segmentacion",
     "title": "Segmentación: Estrutura de Computadores exam questions",
-    "description": "Practice 7 Segmentación questions from past Estrutura de Computadores exams with model answers and self-grading. 202314, Universidade da Coruña.",
+    "description": "Practice 7 Segmentación questions from past Estrutura de Computadores \"exams\" with model answers and self-grading. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/ece/practice/segmentacion",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -1183,7 +1183,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece/practice/segmentacion"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Segmentación: Estrutura de Computadores exam questions\",\"url\":\"https://pe.pablopl.dev/en/ece/practice/segmentacion\",\"inLanguage\":\"en\",\"description\":\"Practice 7 Segmentación questions from past Estrutura de Computadores exams with model answers and self-grading. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Segmentación\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/en/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Segmentación\",\"item\":\"https://pe.pablopl.dev/en/ece/practice/segmentacion\"}],\"url\":\"https://pe.pablopl.dev/en/ece/practice/segmentacion\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Segmentación: Estrutura de Computadores exam questions\",\"url\":\"https://pe.pablopl.dev/en/ece/practice/segmentacion\",\"inLanguage\":\"en\",\"description\":\"Practice 7 Segmentación questions from past Estrutura de Computadores \\\"exams\\\" with model answers and self-grading. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Segmentación\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/en/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Segmentación\",\"item\":\"https://pe.pablopl.dev/en/ece/practice/segmentacion\"}],\"url\":\"https://pe.pablopl.dev/en/ece/practice/segmentacion\"}]}"
   },
   {
     "url": "seo/en/ece/practice/cache.html",
@@ -1191,7 +1191,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/ece/practice/cache",
     "title": "Memoria caché: Estrutura de Computadores exam questions",
-    "description": "Practice 7 Memoria caché questions from past Estrutura de Computadores exams with model answers and self-grading. 202314, Universidade da Coruña.",
+    "description": "Practice 7 Memoria caché questions from past Estrutura de Computadores \"exams\" with model answers and self-grading. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/ece/practice/cache",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -1215,7 +1215,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece/practice/cache"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Memoria caché: Estrutura de Computadores exam questions\",\"url\":\"https://pe.pablopl.dev/en/ece/practice/cache\",\"inLanguage\":\"en\",\"description\":\"Practice 7 Memoria caché questions from past Estrutura de Computadores exams with model answers and self-grading. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Memoria caché\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/en/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Memoria caché\",\"item\":\"https://pe.pablopl.dev/en/ece/practice/cache\"}],\"url\":\"https://pe.pablopl.dev/en/ece/practice/cache\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Memoria caché: Estrutura de Computadores exam questions\",\"url\":\"https://pe.pablopl.dev/en/ece/practice/cache\",\"inLanguage\":\"en\",\"description\":\"Practice 7 Memoria caché questions from past Estrutura de Computadores \\\"exams\\\" with model answers and self-grading. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Memoria caché\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/en/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Memoria caché\",\"item\":\"https://pe.pablopl.dev/en/ece/practice/cache\"}],\"url\":\"https://pe.pablopl.dev/en/ece/practice/cache\"}]}"
   },
   {
     "url": "seo/en/ece/practice/memoria-virtual.html",
@@ -1223,7 +1223,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/ece/practice/memoria-virtual",
     "title": "Memoria virtual: Estrutura de Computadores exam questions",
-    "description": "Practice 11 Memoria virtual questions from past Estrutura de Computadores exams with model answers and self-grading. 202314, Universidade da Coruña.",
+    "description": "Practice 11 Memoria virtual questions from past Estrutura de Computadores \"exams\" with model answers and self-grading. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/ece/practice/memoria-virtual",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -1247,7 +1247,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece/practice/memoria-virtual"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Memoria virtual: Estrutura de Computadores exam questions\",\"url\":\"https://pe.pablopl.dev/en/ece/practice/memoria-virtual\",\"inLanguage\":\"en\",\"description\":\"Practice 11 Memoria virtual questions from past Estrutura de Computadores exams with model answers and self-grading. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Memoria virtual\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/en/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Memoria virtual\",\"item\":\"https://pe.pablopl.dev/en/ece/practice/memoria-virtual\"}],\"url\":\"https://pe.pablopl.dev/en/ece/practice/memoria-virtual\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Memoria virtual: Estrutura de Computadores exam questions\",\"url\":\"https://pe.pablopl.dev/en/ece/practice/memoria-virtual\",\"inLanguage\":\"en\",\"description\":\"Practice 11 Memoria virtual questions from past Estrutura de Computadores \\\"exams\\\" with model answers and self-grading. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Memoria virtual\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/en/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Memoria virtual\",\"item\":\"https://pe.pablopl.dev/en/ece/practice/memoria-virtual\"}],\"url\":\"https://pe.pablopl.dev/en/ece/practice/memoria-virtual\"}]}"
   },
   {
     "url": "seo/en/ece/practice/buses.html",
@@ -1255,7 +1255,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/ece/practice/buses",
     "title": "Buses y E/S: Estrutura de Computadores exam questions",
-    "description": "Practice 11 Buses y E/S questions from past Estrutura de Computadores exams with model answers and self-grading. 202314, Universidade da Coruña.",
+    "description": "Practice 11 Buses y E/S questions from past Estrutura de Computadores \"exams\" with model answers and self-grading. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/ece/practice/buses",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -1279,7 +1279,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece/practice/buses"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Buses y E/S: Estrutura de Computadores exam questions\",\"url\":\"https://pe.pablopl.dev/en/ece/practice/buses\",\"inLanguage\":\"en\",\"description\":\"Practice 11 Buses y E/S questions from past Estrutura de Computadores exams with model answers and self-grading. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Buses y E/S\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/en/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Buses y E/S\",\"item\":\"https://pe.pablopl.dev/en/ece/practice/buses\"}],\"url\":\"https://pe.pablopl.dev/en/ece/practice/buses\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Buses y E/S: Estrutura de Computadores exam questions\",\"url\":\"https://pe.pablopl.dev/en/ece/practice/buses\",\"inLanguage\":\"en\",\"description\":\"Practice 11 Buses y E/S questions from past Estrutura de Computadores \\\"exams\\\" with model answers and self-grading. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Buses y E/S\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/en/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Buses y E/S\",\"item\":\"https://pe.pablopl.dev/en/ece/practice/buses\"}],\"url\":\"https://pe.pablopl.dev/en/ece/practice/buses\"}]}"
   },
   {
     "url": "seo/en/ece/practice/raid.html",
@@ -1287,7 +1287,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/ece/practice/raid",
     "title": "RAID y almacenamiento: Estrutura de Computadores exam questions",
-    "description": "Practice 8 RAID y almacenamiento questions from past Estrutura de Computadores exams with model answers and self-grading. 202314, Universidade da Coruña.",
+    "description": "Practice 8 RAID y almacenamiento questions from past Estrutura de Computadores \"exams\" with model answers and self-grading. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/ece/practice/raid",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -1311,7 +1311,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece/practice/raid"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"RAID y almacenamiento: Estrutura de Computadores exam questions\",\"url\":\"https://pe.pablopl.dev/en/ece/practice/raid\",\"inLanguage\":\"en\",\"description\":\"Practice 8 RAID y almacenamiento questions from past Estrutura de Computadores exams with model answers and self-grading. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"RAID y almacenamiento\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/en/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"RAID y almacenamiento\",\"item\":\"https://pe.pablopl.dev/en/ece/practice/raid\"}],\"url\":\"https://pe.pablopl.dev/en/ece/practice/raid\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"RAID y almacenamiento: Estrutura de Computadores exam questions\",\"url\":\"https://pe.pablopl.dev/en/ece/practice/raid\",\"inLanguage\":\"en\",\"description\":\"Practice 8 RAID y almacenamiento questions from past Estrutura de Computadores \\\"exams\\\" with model answers and self-grading. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"RAID y almacenamiento\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/en/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"RAID y almacenamiento\",\"item\":\"https://pe.pablopl.dev/en/ece/practice/raid\"}],\"url\":\"https://pe.pablopl.dev/en/ece/practice/raid\"}]}"
   },
   {
     "url": "seo/en/ece/exam/2021-01.html",
@@ -1670,8 +1670,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/emeele",
-    "title": "Introduction to Machine Learning: past exams and solved questions",
-    "description": "Practice 47 Introduction to Machine Learning questions from 2 past exams with model answers and self-grading. 2DV516, Linnaeus University.",
+    "title": "Introduction to Machine Learning: past \"exams\" and solved questions",
+    "description": "Practice 47 Introduction to Machine Learning questions from 2 past \"exams\" with model answers and self-grading. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/emeele",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -1695,7 +1695,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Introduction to Machine Learning: past exams and solved questions\",\"url\":\"https://pe.pablopl.dev/en/emeele\",\"inLanguage\":\"en\",\"description\":\"Practice 47 Introduction to Machine Learning questions from 2 past exams with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Linnaeus University\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"}],\"url\":\"https://pe.pablopl.dev/en/emeele\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Introduction to Machine Learning: past \\\"exams\\\" and solved questions\",\"url\":\"https://pe.pablopl.dev/en/emeele\",\"inLanguage\":\"en\",\"description\":\"Practice 47 Introduction to Machine Learning questions from 2 past \\\"exams\\\" with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Linnaeus University\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"}],\"url\":\"https://pe.pablopl.dev/en/emeele\"}]}"
   },
   {
     "url": "seo/en/emeele/practice/kNN.html",
@@ -1703,7 +1703,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/emeele/practice/kNN",
     "title": "k-Nearest Neighbors: Introduction to Machine Learning exam questions",
-    "description": "Practice 6 k-Nearest Neighbors questions from past Introduction to Machine Learning exams with model answers and self-grading. 2DV516, Linnaeus University.",
+    "description": "Practice 6 k-Nearest Neighbors questions from past Introduction to Machine Learning \"exams\" with model answers and self-grading. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/emeele/practice/kNN",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -1727,7 +1727,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/kNN"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"k-Nearest Neighbors: Introduction to Machine Learning exam questions\",\"url\":\"https://pe.pablopl.dev/en/emeele/practice/kNN\",\"inLanguage\":\"en\",\"description\":\"Practice 6 k-Nearest Neighbors questions from past Introduction to Machine Learning exams with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"k-Nearest Neighbors\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"k-Nearest Neighbors\",\"item\":\"https://pe.pablopl.dev/en/emeele/practice/kNN\"}],\"url\":\"https://pe.pablopl.dev/en/emeele/practice/kNN\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"k-Nearest Neighbors: Introduction to Machine Learning exam questions\",\"url\":\"https://pe.pablopl.dev/en/emeele/practice/kNN\",\"inLanguage\":\"en\",\"description\":\"Practice 6 k-Nearest Neighbors questions from past Introduction to Machine Learning \\\"exams\\\" with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"k-Nearest Neighbors\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"k-Nearest Neighbors\",\"item\":\"https://pe.pablopl.dev/en/emeele/practice/kNN\"}],\"url\":\"https://pe.pablopl.dev/en/emeele/practice/kNN\"}]}"
   },
   {
     "url": "seo/en/emeele/practice/Bias-Variance.html",
@@ -1735,7 +1735,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/emeele/practice/Bias-Variance",
     "title": "Bias-Variance Tradeoff: Introduction to Machine Learning exam questions",
-    "description": "Practice 5 Bias-Variance Tradeoff questions from past Introduction to Machine Learning exams with model answers and self-grading. 2DV516, Linnaeus University.",
+    "description": "Practice 5 Bias-Variance Tradeoff questions from past Introduction to Machine Learning \"exams\" with model answers and self-grading. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/emeele/practice/Bias-Variance",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -1759,7 +1759,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Bias-Variance"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Bias-Variance Tradeoff: Introduction to Machine Learning exam questions\",\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Bias-Variance\",\"inLanguage\":\"en\",\"description\":\"Practice 5 Bias-Variance Tradeoff questions from past Introduction to Machine Learning exams with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Bias-Variance Tradeoff\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Bias-Variance Tradeoff\",\"item\":\"https://pe.pablopl.dev/en/emeele/practice/Bias-Variance\"}],\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Bias-Variance\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Bias-Variance Tradeoff: Introduction to Machine Learning exam questions\",\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Bias-Variance\",\"inLanguage\":\"en\",\"description\":\"Practice 5 Bias-Variance Tradeoff questions from past Introduction to Machine Learning \\\"exams\\\" with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Bias-Variance Tradeoff\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Bias-Variance Tradeoff\",\"item\":\"https://pe.pablopl.dev/en/emeele/practice/Bias-Variance\"}],\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Bias-Variance\"}]}"
   },
   {
     "url": "seo/en/emeele/practice/Linear%20%26%20Logistic%20Regression.html",
@@ -1767,7 +1767,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/emeele/practice/Linear & Logistic Regression",
     "title": "Linear & Logistic Regression: Introduction to Machine Learning exam questions",
-    "description": "Practice 5 Linear & Logistic Regression questions from past Introduction to Machine Learning exams with model answers and self-grading. 2DV516, Linnaeus University.",
+    "description": "Practice 5 Linear & Logistic Regression questions from past Introduction to Machine Learning \"exams\" with model answers and self-grading. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/emeele/practice/Linear%20%26%20Logistic%20Regression",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -1791,7 +1791,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Linear%20%26%20Logistic%20Regression"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Linear & Logistic Regression: Introduction to Machine Learning exam questions\",\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Linear%20%26%20Logistic%20Regression\",\"inLanguage\":\"en\",\"description\":\"Practice 5 Linear & Logistic Regression questions from past Introduction to Machine Learning exams with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Linear & Logistic Regression\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Linear & Logistic Regression\",\"item\":\"https://pe.pablopl.dev/en/emeele/practice/Linear%20%26%20Logistic%20Regression\"}],\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Linear%20%26%20Logistic%20Regression\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Linear & Logistic Regression: Introduction to Machine Learning exam questions\",\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Linear%20%26%20Logistic%20Regression\",\"inLanguage\":\"en\",\"description\":\"Practice 5 Linear & Logistic Regression questions from past Introduction to Machine Learning \\\"exams\\\" with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Linear & Logistic Regression\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Linear & Logistic Regression\",\"item\":\"https://pe.pablopl.dev/en/emeele/practice/Linear%20%26%20Logistic%20Regression\"}],\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Linear%20%26%20Logistic%20Regression\"}]}"
   },
   {
     "url": "seo/en/emeele/practice/Model%20Selection%20%26%20Regularization.html",
@@ -1799,7 +1799,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/emeele/practice/Model Selection & Regularization",
     "title": "Model Selection & Regularization: Introduction to Machine Learning exam questions",
-    "description": "Practice 5 Model Selection & Regularization questions from past Introduction to Machine Learning exams with model answers and self-grading. 2DV516, Linnaeus University.",
+    "description": "Practice 5 Model Selection & Regularization questions from past Introduction to Machine Learning \"exams\" with model answers and self-grading. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/emeele/practice/Model%20Selection%20%26%20Regularization",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -1823,7 +1823,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Model%20Selection%20%26%20Regularization"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Model Selection & Regularization: Introduction to Machine Learning exam questions\",\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Model%20Selection%20%26%20Regularization\",\"inLanguage\":\"en\",\"description\":\"Practice 5 Model Selection & Regularization questions from past Introduction to Machine Learning exams with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Model Selection & Regularization\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Model Selection & Regularization\",\"item\":\"https://pe.pablopl.dev/en/emeele/practice/Model%20Selection%20%26%20Regularization\"}],\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Model%20Selection%20%26%20Regularization\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Model Selection & Regularization: Introduction to Machine Learning exam questions\",\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Model%20Selection%20%26%20Regularization\",\"inLanguage\":\"en\",\"description\":\"Practice 5 Model Selection & Regularization questions from past Introduction to Machine Learning \\\"exams\\\" with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Model Selection & Regularization\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Model Selection & Regularization\",\"item\":\"https://pe.pablopl.dev/en/emeele/practice/Model%20Selection%20%26%20Regularization\"}],\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Model%20Selection%20%26%20Regularization\"}]}"
   },
   {
     "url": "seo/en/emeele/practice/Neural%20Networks.html",
@@ -1831,7 +1831,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/emeele/practice/Neural Networks",
     "title": "Neural Networks: Introduction to Machine Learning exam questions",
-    "description": "Practice 6 Neural Networks questions from past Introduction to Machine Learning exams with model answers and self-grading. 2DV516, Linnaeus University.",
+    "description": "Practice 6 Neural Networks questions from past Introduction to Machine Learning \"exams\" with model answers and self-grading. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/emeele/practice/Neural%20Networks",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -1855,7 +1855,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Neural%20Networks"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Neural Networks: Introduction to Machine Learning exam questions\",\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Neural%20Networks\",\"inLanguage\":\"en\",\"description\":\"Practice 6 Neural Networks questions from past Introduction to Machine Learning exams with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Neural Networks\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Neural Networks\",\"item\":\"https://pe.pablopl.dev/en/emeele/practice/Neural%20Networks\"}],\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Neural%20Networks\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Neural Networks: Introduction to Machine Learning exam questions\",\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Neural%20Networks\",\"inLanguage\":\"en\",\"description\":\"Practice 6 Neural Networks questions from past Introduction to Machine Learning \\\"exams\\\" with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Neural Networks\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Neural Networks\",\"item\":\"https://pe.pablopl.dev/en/emeele/practice/Neural%20Networks\"}],\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Neural%20Networks\"}]}"
   },
   {
     "url": "seo/en/emeele/practice/Decision%20Trees%20%26%20Ensembles.html",
@@ -1863,7 +1863,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/emeele/practice/Decision Trees & Ensembles",
     "title": "Decision Trees & Ensembles: Introduction to Machine Learning exam questions",
-    "description": "Practice 4 Decision Trees & Ensembles questions from past Introduction to Machine Learning exams with model answers and self-grading. 2DV516, Linnaeus University.",
+    "description": "Practice 4 Decision Trees & Ensembles questions from past Introduction to Machine Learning \"exams\" with model answers and self-grading. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/emeele/practice/Decision%20Trees%20%26%20Ensembles",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -1887,7 +1887,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Decision%20Trees%20%26%20Ensembles"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Decision Trees & Ensembles: Introduction to Machine Learning exam questions\",\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Decision%20Trees%20%26%20Ensembles\",\"inLanguage\":\"en\",\"description\":\"Practice 4 Decision Trees & Ensembles questions from past Introduction to Machine Learning exams with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Decision Trees & Ensembles\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Decision Trees & Ensembles\",\"item\":\"https://pe.pablopl.dev/en/emeele/practice/Decision%20Trees%20%26%20Ensembles\"}],\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Decision%20Trees%20%26%20Ensembles\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Decision Trees & Ensembles: Introduction to Machine Learning exam questions\",\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Decision%20Trees%20%26%20Ensembles\",\"inLanguage\":\"en\",\"description\":\"Practice 4 Decision Trees & Ensembles questions from past Introduction to Machine Learning \\\"exams\\\" with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Decision Trees & Ensembles\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Decision Trees & Ensembles\",\"item\":\"https://pe.pablopl.dev/en/emeele/practice/Decision%20Trees%20%26%20Ensembles\"}],\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Decision%20Trees%20%26%20Ensembles\"}]}"
   },
   {
     "url": "seo/en/emeele/practice/Support%20Vector%20Machines.html",
@@ -1895,7 +1895,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/emeele/practice/Support Vector Machines",
     "title": "Support Vector Machines: Introduction to Machine Learning exam questions",
-    "description": "Practice 6 Support Vector Machines questions from past Introduction to Machine Learning exams with model answers and self-grading. 2DV516, Linnaeus University.",
+    "description": "Practice 6 Support Vector Machines questions from past Introduction to Machine Learning \"exams\" with model answers and self-grading. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/emeele/practice/Support%20Vector%20Machines",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -1919,7 +1919,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Support%20Vector%20Machines"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Support Vector Machines: Introduction to Machine Learning exam questions\",\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Support%20Vector%20Machines\",\"inLanguage\":\"en\",\"description\":\"Practice 6 Support Vector Machines questions from past Introduction to Machine Learning exams with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Support Vector Machines\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Support Vector Machines\",\"item\":\"https://pe.pablopl.dev/en/emeele/practice/Support%20Vector%20Machines\"}],\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Support%20Vector%20Machines\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Support Vector Machines: Introduction to Machine Learning exam questions\",\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Support%20Vector%20Machines\",\"inLanguage\":\"en\",\"description\":\"Practice 6 Support Vector Machines questions from past Introduction to Machine Learning \\\"exams\\\" with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Support Vector Machines\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Support Vector Machines\",\"item\":\"https://pe.pablopl.dev/en/emeele/practice/Support%20Vector%20Machines\"}],\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Support%20Vector%20Machines\"}]}"
   },
   {
     "url": "seo/en/emeele/practice/Clustering.html",
@@ -1927,7 +1927,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/emeele/practice/Clustering",
     "title": "Clustering: Introduction to Machine Learning exam questions",
-    "description": "Practice 6 Clustering questions from past Introduction to Machine Learning exams with model answers and self-grading. 2DV516, Linnaeus University.",
+    "description": "Practice 6 Clustering questions from past Introduction to Machine Learning \"exams\" with model answers and self-grading. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/emeele/practice/Clustering",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -1951,7 +1951,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Clustering"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Clustering: Introduction to Machine Learning exam questions\",\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Clustering\",\"inLanguage\":\"en\",\"description\":\"Practice 6 Clustering questions from past Introduction to Machine Learning exams with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Clustering\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Clustering\",\"item\":\"https://pe.pablopl.dev/en/emeele/practice/Clustering\"}],\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Clustering\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Clustering: Introduction to Machine Learning exam questions\",\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Clustering\",\"inLanguage\":\"en\",\"description\":\"Practice 6 Clustering questions from past Introduction to Machine Learning \\\"exams\\\" with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Clustering\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Clustering\",\"item\":\"https://pe.pablopl.dev/en/emeele/practice/Clustering\"}],\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Clustering\"}]}"
   },
   {
     "url": "seo/en/emeele/practice/Dimensionality%20Reduction.html",
@@ -1959,7 +1959,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/emeele/practice/Dimensionality Reduction",
     "title": "Dimensionality Reduction: Introduction to Machine Learning exam questions",
-    "description": "Practice 4 Dimensionality Reduction questions from past Introduction to Machine Learning exams with model answers and self-grading. 2DV516, Linnaeus University.",
+    "description": "Practice 4 Dimensionality Reduction questions from past Introduction to Machine Learning \"exams\" with model answers and self-grading. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/emeele/practice/Dimensionality%20Reduction",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -1983,7 +1983,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Dimensionality%20Reduction"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Dimensionality Reduction: Introduction to Machine Learning exam questions\",\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Dimensionality%20Reduction\",\"inLanguage\":\"en\",\"description\":\"Practice 4 Dimensionality Reduction questions from past Introduction to Machine Learning exams with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Dimensionality Reduction\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Dimensionality Reduction\",\"item\":\"https://pe.pablopl.dev/en/emeele/practice/Dimensionality%20Reduction\"}],\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Dimensionality%20Reduction\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Dimensionality Reduction: Introduction to Machine Learning exam questions\",\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Dimensionality%20Reduction\",\"inLanguage\":\"en\",\"description\":\"Practice 4 Dimensionality Reduction questions from past Introduction to Machine Learning \\\"exams\\\" with model answers and self-grading. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Dimensionality Reduction\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/en/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Dimensionality Reduction\",\"item\":\"https://pe.pablopl.dev/en/emeele/practice/Dimensionality%20Reduction\"}],\"url\":\"https://pe.pablopl.dev/en/emeele/practice/Dimensionality%20Reduction\"}]}"
   },
   {
     "url": "seo/en/emeele/exam/2024.html",
@@ -2054,8 +2054,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/equisi",
-    "title": "Xestión de Infraestruturas: past exams and solved questions",
-    "description": "Practice 381 Xestión de Infraestruturas questions from 4 past exams with model answers and self-grading. 200190, Universidade da Coruña.",
+    "title": "Xestión de Infraestruturas: past \"exams\" and solved questions",
+    "description": "Practice 381 Xestión de Infraestruturas questions from 4 past \"exams\" with model answers and self-grading. 200190, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/equisi",
     "ogImage": "https://pe.pablopl.dev/og/equisi.png",
@@ -2079,7 +2079,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equisi"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Xestión de Infraestruturas: past exams and solved questions\",\"url\":\"https://pe.pablopl.dev/en/equisi\",\"inLanguage\":\"en\",\"description\":\"Practice 381 Xestión de Infraestruturas questions from 4 past exams with model answers and self-grading. 200190, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/en/equisi\"}],\"url\":\"https://pe.pablopl.dev/en/equisi\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Xestión de Infraestruturas: past \\\"exams\\\" and solved questions\",\"url\":\"https://pe.pablopl.dev/en/equisi\",\"inLanguage\":\"en\",\"description\":\"Practice 381 Xestión de Infraestruturas questions from 4 past \\\"exams\\\" with model answers and self-grading. 200190, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/en/equisi\"}],\"url\":\"https://pe.pablopl.dev/en/equisi\"}]}"
   },
   {
     "url": "seo/en/equisi/practice/modulo-i.html",
@@ -2087,7 +2087,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/equisi/practice/modulo-i",
     "title": "Módulo I: Sinais e Comunicacións: Xestión de Infraestruturas exam questions",
-    "description": "Practice 130 Módulo I: Sinais e Comunicacións questions from past Xestión de Infraestruturas exams with model answers and self-grading. 200190, Universidade da Coruña.",
+    "description": "Practice 130 Módulo I: Sinais e Comunicacións questions from past Xestión de Infraestruturas \"exams\" with model answers and self-grading. 200190, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/equisi/practice/modulo-i",
     "ogImage": "https://pe.pablopl.dev/og/equisi.png",
@@ -2111,7 +2111,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equisi/practice/modulo-i"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Módulo I: Sinais e Comunicacións: Xestión de Infraestruturas exam questions\",\"url\":\"https://pe.pablopl.dev/en/equisi/practice/modulo-i\",\"inLanguage\":\"en\",\"description\":\"Practice 130 Módulo I: Sinais e Comunicacións questions from past Xestión de Infraestruturas exams with model answers and self-grading. 200190, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Módulo I: Sinais e Comunicacións\"},{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/en/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Módulo I: Sinais e Comunicacións\",\"item\":\"https://pe.pablopl.dev/en/equisi/practice/modulo-i\"}],\"url\":\"https://pe.pablopl.dev/en/equisi/practice/modulo-i\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Módulo I: Sinais e Comunicacións: Xestión de Infraestruturas exam questions\",\"url\":\"https://pe.pablopl.dev/en/equisi/practice/modulo-i\",\"inLanguage\":\"en\",\"description\":\"Practice 130 Módulo I: Sinais e Comunicacións questions from past Xestión de Infraestruturas \\\"exams\\\" with model answers and self-grading. 200190, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Módulo I: Sinais e Comunicacións\"},{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/en/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Módulo I: Sinais e Comunicacións\",\"item\":\"https://pe.pablopl.dev/en/equisi/practice/modulo-i\"}],\"url\":\"https://pe.pablopl.dev/en/equisi/practice/modulo-i\"}]}"
   },
   {
     "url": "seo/en/equisi/practice/modulo-ii.html",
@@ -2119,7 +2119,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/equisi/practice/modulo-ii",
     "title": "Módulo II: Infraestruturas TI: Xestión de Infraestruturas exam questions",
-    "description": "Practice 251 Módulo II: Infraestruturas TI questions from past Xestión de Infraestruturas exams with model answers and self-grading. 200190, Universidade da Coruña.",
+    "description": "Practice 251 Módulo II: Infraestruturas TI questions from past Xestión de Infraestruturas \"exams\" with model answers and self-grading. 200190, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/equisi/practice/modulo-ii",
     "ogImage": "https://pe.pablopl.dev/og/equisi.png",
@@ -2143,15 +2143,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equisi/practice/modulo-ii"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Módulo II: Infraestruturas TI: Xestión de Infraestruturas exam questions\",\"url\":\"https://pe.pablopl.dev/en/equisi/practice/modulo-ii\",\"inLanguage\":\"en\",\"description\":\"Practice 251 Módulo II: Infraestruturas TI questions from past Xestión de Infraestruturas exams with model answers and self-grading. 200190, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Módulo II: Infraestruturas TI\"},{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/en/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Módulo II: Infraestruturas TI\",\"item\":\"https://pe.pablopl.dev/en/equisi/practice/modulo-ii\"}],\"url\":\"https://pe.pablopl.dev/en/equisi/practice/modulo-ii\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Módulo II: Infraestruturas TI: Xestión de Infraestruturas exam questions\",\"url\":\"https://pe.pablopl.dev/en/equisi/practice/modulo-ii\",\"inLanguage\":\"en\",\"description\":\"Practice 251 Módulo II: Infraestruturas TI questions from past Xestión de Infraestruturas \\\"exams\\\" with model answers and self-grading. 200190, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Módulo II: Infraestruturas TI\"},{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/en/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Módulo II: Infraestruturas TI\",\"item\":\"https://pe.pablopl.dev/en/equisi/practice/modulo-ii\"}],\"url\":\"https://pe.pablopl.dev/en/equisi/practice/modulo-ii\"}]}"
   },
   {
     "url": "seo/en/equisi/exam/2024-07.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/equisi/exam/2024-07",
-    "title": "Xullo 2024 Xestión de Infraestruturas: exam simulator",
-    "description": "Simulate the Xullo 2024 Xestión de Infraestruturas exam with 20 questions. 10 points, 45 minutes, model answers and self-grading.",
+    "title": "Posibles preguntas Xullo 2024 Xestión de Infraestruturas: exam simulator",
+    "description": "Simulate the Posibles preguntas Xullo 2024 Xestión de Infraestruturas exam with 20 questions. 10 points, 45 minutes, model answers and self-grading.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/equisi/exam/2024-07",
     "ogImage": "https://pe.pablopl.dev/og/equisi.png",
@@ -2175,7 +2175,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equisi/exam/2024-07"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Xullo 2024 Xestión de Infraestruturas: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/equisi/exam/2024-07\",\"inLanguage\":\"en\",\"description\":\"Simulate the Xullo 2024 Xestión de Infraestruturas exam with 20 questions. 10 points, 45 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/en/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Xullo 2024\",\"item\":\"https://pe.pablopl.dev/en/equisi/exam/2024-07\"}],\"url\":\"https://pe.pablopl.dev/en/equisi/exam/2024-07\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Xullo 2024 Xestión de Infraestruturas: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/equisi/exam/2024-07\",\"inLanguage\":\"en\",\"description\":\"Simulate the Posibles preguntas Xullo 2024 Xestión de Infraestruturas exam with 20 questions. 10 points, 45 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/en/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Xullo 2024\",\"item\":\"https://pe.pablopl.dev/en/equisi/exam/2024-07\"}],\"url\":\"https://pe.pablopl.dev/en/equisi/exam/2024-07\"}]}"
   },
   {
     "url": "seo/en/equisi/exam/daypo-modulo-i.html",
@@ -2278,8 +2278,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/equispe",
-    "title": "Xestión de Proxectos: past exams and solved questions",
-    "description": "Practice 175 Xestión de Proxectos questions from 5 past exams with model answers and self-grading. 202323, Universidade da Coruña.",
+    "title": "Xestión de Proxectos: past \"exams\" and solved questions",
+    "description": "Practice 175 Xestión de Proxectos questions from 5 past \"exams\" with model answers and self-grading. 202323, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/equispe",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -2303,7 +2303,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Xestión de Proxectos: past exams and solved questions\",\"url\":\"https://pe.pablopl.dev/en/equispe\",\"inLanguage\":\"en\",\"description\":\"Practice 175 Xestión de Proxectos questions from 5 past exams with model answers and self-grading. 202323, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/en/equispe\"}],\"url\":\"https://pe.pablopl.dev/en/equispe\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Xestión de Proxectos: past \\\"exams\\\" and solved questions\",\"url\":\"https://pe.pablopl.dev/en/equispe\",\"inLanguage\":\"en\",\"description\":\"Practice 175 Xestión de Proxectos questions from 5 past \\\"exams\\\" with model answers and self-grading. 202323, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/en/equispe\"}],\"url\":\"https://pe.pablopl.dev/en/equispe\"}]}"
   },
   {
     "url": "seo/en/equispe/practice/teoria.html",
@@ -2311,7 +2311,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/equispe/practice/teoria",
     "title": "Teoría: Xestión de Proxectos exam questions | Pásame Exámenes",
-    "description": "Practice 107 Teoría questions from past Xestión de Proxectos exams with model answers and self-grading. 202323, Universidade da Coruña.",
+    "description": "Practice 107 Teoría questions from past Xestión de Proxectos \"exams\" with model answers and self-grading. 202323, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/equispe/practice/teoria",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -2335,7 +2335,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe/practice/teoria"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Teoría: Xestión de Proxectos exam questions | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/en/equispe/practice/teoria\",\"inLanguage\":\"en\",\"description\":\"Practice 107 Teoría questions from past Xestión de Proxectos exams with model answers and self-grading. 202323, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Teoría\"},{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/en/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Teoría\",\"item\":\"https://pe.pablopl.dev/en/equispe/practice/teoria\"}],\"url\":\"https://pe.pablopl.dev/en/equispe/practice/teoria\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Teoría: Xestión de Proxectos exam questions | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/en/equispe/practice/teoria\",\"inLanguage\":\"en\",\"description\":\"Practice 107 Teoría questions from past Xestión de Proxectos \\\"exams\\\" with model answers and self-grading. 202323, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Teoría\"},{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/en/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Teoría\",\"item\":\"https://pe.pablopl.dev/en/equispe/practice/teoria\"}],\"url\":\"https://pe.pablopl.dev/en/equispe/practice/teoria\"}]}"
   },
   {
     "url": "seo/en/equispe/practice/practica.html",
@@ -2343,7 +2343,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/equispe/practice/practica",
     "title": "Práctica: Xestión de Proxectos exam questions",
-    "description": "Practice 68 Práctica questions from past Xestión de Proxectos exams with model answers and self-grading. 202323, Universidade da Coruña.",
+    "description": "Practice 68 Práctica questions from past Xestión de Proxectos \"exams\" with model answers and self-grading. 202323, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/equispe/practice/practica",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -2367,15 +2367,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe/practice/practica"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Práctica: Xestión de Proxectos exam questions\",\"url\":\"https://pe.pablopl.dev/en/equispe/practice/practica\",\"inLanguage\":\"en\",\"description\":\"Practice 68 Práctica questions from past Xestión de Proxectos exams with model answers and self-grading. 202323, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Práctica\"},{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/en/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Práctica\",\"item\":\"https://pe.pablopl.dev/en/equispe/practice/practica\"}],\"url\":\"https://pe.pablopl.dev/en/equispe/practice/practica\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Práctica: Xestión de Proxectos exam questions\",\"url\":\"https://pe.pablopl.dev/en/equispe/practice/practica\",\"inLanguage\":\"en\",\"description\":\"Practice 68 Práctica questions from past Xestión de Proxectos \\\"exams\\\" with model answers and self-grading. 202323, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Práctica\"},{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/en/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Práctica\",\"item\":\"https://pe.pablopl.dev/en/equispe/practice/practica\"}],\"url\":\"https://pe.pablopl.dev/en/equispe/practice/practica\"}]}"
   },
   {
     "url": "seo/en/equispe/exam/2024-01.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/equispe/exam/2024-01",
-    "title": "Xaneiro 2024 Xestión de Proxectos: exam simulator",
-    "description": "Simulate the Xaneiro 2024 Xestión de Proxectos exam with 7 questions. 10 points, 120 minutes, model answers and self-grading.",
+    "title": "Posibles preguntas Xaneiro 2024 Xestión de Proxectos: exam simulator",
+    "description": "Simulate the Posibles preguntas Xaneiro 2024 Xestión de Proxectos exam with 7 questions. 10 points, 120 minutes, model answers and self-grading.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/equispe/exam/2024-01",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -2399,15 +2399,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe/exam/2024-01"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Xaneiro 2024 Xestión de Proxectos: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/equispe/exam/2024-01\",\"inLanguage\":\"en\",\"description\":\"Simulate the Xaneiro 2024 Xestión de Proxectos exam with 7 questions. 10 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/en/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Xaneiro 2024\",\"item\":\"https://pe.pablopl.dev/en/equispe/exam/2024-01\"}],\"url\":\"https://pe.pablopl.dev/en/equispe/exam/2024-01\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Xaneiro 2024 Xestión de Proxectos: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/equispe/exam/2024-01\",\"inLanguage\":\"en\",\"description\":\"Simulate the Posibles preguntas Xaneiro 2024 Xestión de Proxectos exam with 7 questions. 10 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/en/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Xaneiro 2024\",\"item\":\"https://pe.pablopl.dev/en/equispe/exam/2024-01\"}],\"url\":\"https://pe.pablopl.dev/en/equispe/exam/2024-01\"}]}"
   },
   {
     "url": "seo/en/equispe/exam/2026-01.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/equispe/exam/2026-01",
-    "title": "Xaneiro 2026 Xestión de Proxectos: exam simulator",
-    "description": "Simulate the Xaneiro 2026 Xestión de Proxectos exam with 13 questions. 25 points, 180 minutes, model answers and self-grading.",
+    "title": "Posibles preguntas Xaneiro 2026 Xestión de Proxectos: exam simulator",
+    "description": "Simulate the Posibles preguntas Xaneiro 2026 Xestión de Proxectos exam with 13 questions. 25 points, 180 minutes, model answers and self-grading.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/equispe/exam/2026-01",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -2431,7 +2431,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe/exam/2026-01"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Xaneiro 2026 Xestión de Proxectos: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/equispe/exam/2026-01\",\"inLanguage\":\"en\",\"description\":\"Simulate the Xaneiro 2026 Xestión de Proxectos exam with 13 questions. 25 points, 180 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/en/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Xaneiro 2026\",\"item\":\"https://pe.pablopl.dev/en/equispe/exam/2026-01\"}],\"url\":\"https://pe.pablopl.dev/en/equispe/exam/2026-01\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Xaneiro 2026 Xestión de Proxectos: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/equispe/exam/2026-01\",\"inLanguage\":\"en\",\"description\":\"Simulate the Posibles preguntas Xaneiro 2026 Xestión de Proxectos exam with 13 questions. 25 points, 180 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/en/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Xaneiro 2026\",\"item\":\"https://pe.pablopl.dev/en/equispe/exam/2026-01\"}],\"url\":\"https://pe.pablopl.dev/en/equispe/exam/2026-01\"}]}"
   },
   {
     "url": "seo/en/equispe/exam/daypo-tipo-udc.html",
@@ -2534,8 +2534,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/esei",
-    "title": "Sistemas Intelixentes: past exams and solved questions",
-    "description": "Practice 234 Sistemas Intelixentes questions from 5 past exams with model answers and self-grading. 202322, Universidade da Coruña.",
+    "title": "Sistemas Intelixentes: past \"exams\" and solved questions",
+    "description": "Practice 234 Sistemas Intelixentes questions from 5 past \"exams\" with model answers and self-grading. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/esei",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -2559,7 +2559,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Sistemas Intelixentes: past exams and solved questions\",\"url\":\"https://pe.pablopl.dev/en/esei\",\"inLanguage\":\"en\",\"description\":\"Practice 234 Sistemas Intelixentes questions from 5 past exams with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"}],\"url\":\"https://pe.pablopl.dev/en/esei\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Sistemas Intelixentes: past \\\"exams\\\" and solved questions\",\"url\":\"https://pe.pablopl.dev/en/esei\",\"inLanguage\":\"en\",\"description\":\"Practice 234 Sistemas Intelixentes questions from 5 past \\\"exams\\\" with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"}],\"url\":\"https://pe.pablopl.dev/en/esei\"}]}"
   },
   {
     "url": "seo/en/esei/practice/t1.html",
@@ -2567,7 +2567,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/esei/practice/t1",
     "title": "Tema 1: Introducción: Sistemas Intelixentes exam questions",
-    "description": "Practice 4 Tema 1: Introducción questions from past Sistemas Intelixentes exams with model answers and self-grading. 202322, Universidade da Coruña.",
+    "description": "Practice 4 Tema 1: Introducción questions from past Sistemas Intelixentes \"exams\" with model answers and self-grading. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/esei/practice/t1",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -2591,7 +2591,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t1"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 1: Introducción: Sistemas Intelixentes exam questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t1\",\"inLanguage\":\"en\",\"description\":\"Practice 4 Tema 1: Introducción questions from past Sistemas Intelixentes exams with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 1: Introducción\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 1: Introducción\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t1\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t1\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 1: Introducción: Sistemas Intelixentes exam questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t1\",\"inLanguage\":\"en\",\"description\":\"Practice 4 Tema 1: Introducción questions from past Sistemas Intelixentes \\\"exams\\\" with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 1: Introducción\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 1: Introducción\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t1\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t1\"}]}"
   },
   {
     "url": "seo/en/esei/practice/t2.html",
@@ -2599,7 +2599,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/esei/practice/t2",
     "title": "Tema 2: Búsqueda: Sistemas Intelixentes exam questions",
-    "description": "Practice 24 Tema 2: Búsqueda questions from past Sistemas Intelixentes exams with model answers and self-grading. 202322, Universidade da Coruña.",
+    "description": "Practice 24 Tema 2: Búsqueda questions from past Sistemas Intelixentes \"exams\" with model answers and self-grading. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/esei/practice/t2",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -2623,7 +2623,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t2"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 2: Búsqueda: Sistemas Intelixentes exam questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t2\",\"inLanguage\":\"en\",\"description\":\"Practice 24 Tema 2: Búsqueda questions from past Sistemas Intelixentes exams with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 2: Búsqueda\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 2: Búsqueda\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t2\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t2\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 2: Búsqueda: Sistemas Intelixentes exam questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t2\",\"inLanguage\":\"en\",\"description\":\"Practice 24 Tema 2: Búsqueda questions from past Sistemas Intelixentes \\\"exams\\\" with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 2: Búsqueda\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 2: Búsqueda\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t2\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t2\"}]}"
   },
   {
     "url": "seo/en/esei/practice/t3.html",
@@ -2631,7 +2631,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/esei/practice/t3",
     "title": "Tema 3: Representación: Sistemas Intelixentes exam questions",
-    "description": "Practice 17 Tema 3: Representación questions from past Sistemas Intelixentes exams with model answers and self-grading. 202322, Universidade da Coruña.",
+    "description": "Practice 17 Tema 3: Representación questions from past Sistemas Intelixentes \"exams\" with model answers and self-grading. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/esei/practice/t3",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -2655,7 +2655,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t3"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 3: Representación: Sistemas Intelixentes exam questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t3\",\"inLanguage\":\"en\",\"description\":\"Practice 17 Tema 3: Representación questions from past Sistemas Intelixentes exams with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 3: Representación\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 3: Representación\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t3\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t3\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 3: Representación: Sistemas Intelixentes exam questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t3\",\"inLanguage\":\"en\",\"description\":\"Practice 17 Tema 3: Representación questions from past Sistemas Intelixentes \\\"exams\\\" with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 3: Representación\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 3: Representación\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t3\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t3\"}]}"
   },
   {
     "url": "seo/en/esei/practice/t4.html",
@@ -2663,7 +2663,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/esei/practice/t4",
     "title": "Tema 4: Razonamiento: Sistemas Intelixentes exam questions",
-    "description": "Practice 12 Tema 4: Razonamiento questions from past Sistemas Intelixentes exams with model answers and self-grading. 202322, Universidade da Coruña.",
+    "description": "Practice 12 Tema 4: Razonamiento questions from past Sistemas Intelixentes \"exams\" with model answers and self-grading. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/esei/practice/t4",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -2687,7 +2687,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t4"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 4: Razonamiento: Sistemas Intelixentes exam questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t4\",\"inLanguage\":\"en\",\"description\":\"Practice 12 Tema 4: Razonamiento questions from past Sistemas Intelixentes exams with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 4: Razonamiento\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 4: Razonamiento\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t4\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t4\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 4: Razonamiento: Sistemas Intelixentes exam questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t4\",\"inLanguage\":\"en\",\"description\":\"Practice 12 Tema 4: Razonamiento questions from past Sistemas Intelixentes \\\"exams\\\" with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 4: Razonamiento\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 4: Razonamiento\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t4\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t4\"}]}"
   },
   {
     "url": "seo/en/esei/practice/t5.html",
@@ -2695,7 +2695,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/esei/practice/t5",
     "title": "Tema 5: Planificación: Sistemas Intelixentes exam questions",
-    "description": "Practice 2 Tema 5: Planificación questions from past Sistemas Intelixentes exams with model answers and self-grading. 202322, Universidade da Coruña.",
+    "description": "Practice 2 Tema 5: Planificación questions from past Sistemas Intelixentes \"exams\" with model answers and self-grading. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/esei/practice/t5",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -2719,7 +2719,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t5"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 5: Planificación: Sistemas Intelixentes exam questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t5\",\"inLanguage\":\"en\",\"description\":\"Practice 2 Tema 5: Planificación questions from past Sistemas Intelixentes exams with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 5: Planificación\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 5: Planificación\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t5\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t5\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 5: Planificación: Sistemas Intelixentes exam questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t5\",\"inLanguage\":\"en\",\"description\":\"Practice 2 Tema 5: Planificación questions from past Sistemas Intelixentes \\\"exams\\\" with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 5: Planificación\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 5: Planificación\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t5\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t5\"}]}"
   },
   {
     "url": "seo/en/esei/practice/t6.html",
@@ -2727,7 +2727,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/esei/practice/t6",
     "title": "Tema 6: Introducción a los sistemas subsimbólicos: Sistemas Intelixentes exam questions",
-    "description": "Practice 18 Tema 6: Introducción a los sistemas subsimbólicos questions from past Sistemas Intelixentes exams with model answers and self-grading. 202322, Universidade da Coruña.",
+    "description": "Practice 18 Tema 6: Introducción a los sistemas subsimbólicos questions from past Sistemas Intelixentes \"exams\" with model answers and self-grading. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/esei/practice/t6",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -2751,7 +2751,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t6"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 6: Introducción a los sistemas subsimbólicos: Sistemas Intelixentes exam questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t6\",\"inLanguage\":\"en\",\"description\":\"Practice 18 Tema 6: Introducción a los sistemas subsimbólicos questions from past Sistemas Intelixentes exams with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 6: Introducción a los sistemas subsimbólicos\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 6: Introducción a los sistemas subsimbólicos\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t6\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t6\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 6: Introducción a los sistemas subsimbólicos: Sistemas Intelixentes exam questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t6\",\"inLanguage\":\"en\",\"description\":\"Practice 18 Tema 6: Introducción a los sistemas subsimbólicos questions from past Sistemas Intelixentes \\\"exams\\\" with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 6: Introducción a los sistemas subsimbólicos\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 6: Introducción a los sistemas subsimbólicos\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t6\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t6\"}]}"
   },
   {
     "url": "seo/en/esei/practice/t7.html",
@@ -2759,7 +2759,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/esei/practice/t7",
     "title": "Tema 7: Redes Neuronales Artificiales: modelos y características: Sistemas Intelixentes exam questions",
-    "description": "Practice 40 Tema 7: Redes Neuronales Artificiales: modelos y características questions from past Sistemas Intelixentes exams with model answers and self-grading. 202322, Universidade da Coruña.",
+    "description": "Practice 40 Tema 7: Redes Neuronales Artificiales: modelos y características questions from past Sistemas Intelixentes \"exams\" with model answers and self-grading. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/esei/practice/t7",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -2783,7 +2783,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t7"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 7: Redes Neuronales Artificiales: modelos y características: Sistemas Intelixentes exam questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t7\",\"inLanguage\":\"en\",\"description\":\"Practice 40 Tema 7: Redes Neuronales Artificiales: modelos y características questions from past Sistemas Intelixentes exams with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 7: Redes Neuronales Artificiales: modelos y características\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 7: Redes Neuronales Artificiales: modelos y características\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t7\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t7\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 7: Redes Neuronales Artificiales: modelos y características: Sistemas Intelixentes exam questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t7\",\"inLanguage\":\"en\",\"description\":\"Practice 40 Tema 7: Redes Neuronales Artificiales: modelos y características questions from past Sistemas Intelixentes \\\"exams\\\" with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 7: Redes Neuronales Artificiales: modelos y características\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 7: Redes Neuronales Artificiales: modelos y características\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t7\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t7\"}]}"
   },
   {
     "url": "seo/en/esei/practice/t8.html",
@@ -2791,7 +2791,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/esei/practice/t8",
     "title": "Tema 8: Entrenamiento de Redes Neuronales Artificiales: Sistemas Intelixentes exam questions",
-    "description": "Practice 20 Tema 8: Entrenamiento de Redes Neuronales Artificiales questions from past Sistemas Intelixentes exams with model answers and self-grading. 202322, Universidade da Coruña.",
+    "description": "Practice 20 Tema 8: Entrenamiento de Redes Neuronales Artificiales questions from past Sistemas Intelixentes \"exams\" with model answers and self-grading. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/esei/practice/t8",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -2815,7 +2815,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t8"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 8: Entrenamiento de Redes Neuronales Artificiales: Sistemas Intelixentes exam questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t8\",\"inLanguage\":\"en\",\"description\":\"Practice 20 Tema 8: Entrenamiento de Redes Neuronales Artificiales questions from past Sistemas Intelixentes exams with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 8: Entrenamiento de Redes Neuronales Artificiales\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 8: Entrenamiento de Redes Neuronales Artificiales\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t8\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t8\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 8: Entrenamiento de Redes Neuronales Artificiales: Sistemas Intelixentes exam questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t8\",\"inLanguage\":\"en\",\"description\":\"Practice 20 Tema 8: Entrenamiento de Redes Neuronales Artificiales questions from past Sistemas Intelixentes \\\"exams\\\" with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 8: Entrenamiento de Redes Neuronales Artificiales\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 8: Entrenamiento de Redes Neuronales Artificiales\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t8\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t8\"}]}"
   },
   {
     "url": "seo/en/esei/practice/t9.html",
@@ -2823,7 +2823,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/esei/practice/t9",
     "title": "Tema 9: Sistemas autoorganizativos: Sistemas Intelixentes exam questions",
-    "description": "Practice 59 Tema 9: Sistemas autoorganizativos questions from past Sistemas Intelixentes exams with model answers and self-grading. 202322, Universidade da Coruña.",
+    "description": "Practice 59 Tema 9: Sistemas autoorganizativos questions from past Sistemas Intelixentes \"exams\" with model answers and self-grading. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/esei/practice/t9",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -2847,7 +2847,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t9"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 9: Sistemas autoorganizativos: Sistemas Intelixentes exam questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t9\",\"inLanguage\":\"en\",\"description\":\"Practice 59 Tema 9: Sistemas autoorganizativos questions from past Sistemas Intelixentes exams with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 9: Sistemas autoorganizativos\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 9: Sistemas autoorganizativos\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t9\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t9\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 9: Sistemas autoorganizativos: Sistemas Intelixentes exam questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t9\",\"inLanguage\":\"en\",\"description\":\"Practice 59 Tema 9: Sistemas autoorganizativos questions from past Sistemas Intelixentes \\\"exams\\\" with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 9: Sistemas autoorganizativos\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 9: Sistemas autoorganizativos\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t9\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t9\"}]}"
   },
   {
     "url": "seo/en/esei/practice/t10.html",
@@ -2855,7 +2855,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/esei/practice/t10",
     "title": "Tema 10: Computación Evolutiva: Sistemas Intelixentes exam questions",
-    "description": "Practice 38 Tema 10: Computación Evolutiva questions from past Sistemas Intelixentes exams with model answers and self-grading. 202322, Universidade da Coruña.",
+    "description": "Practice 38 Tema 10: Computación Evolutiva questions from past Sistemas Intelixentes \"exams\" with model answers and self-grading. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/esei/practice/t10",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -2879,15 +2879,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t10"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 10: Computación Evolutiva: Sistemas Intelixentes exam questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t10\",\"inLanguage\":\"en\",\"description\":\"Practice 38 Tema 10: Computación Evolutiva questions from past Sistemas Intelixentes exams with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 10: Computación Evolutiva\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 10: Computación Evolutiva\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t10\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t10\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 10: Computación Evolutiva: Sistemas Intelixentes exam questions\",\"url\":\"https://pe.pablopl.dev/en/esei/practice/t10\",\"inLanguage\":\"en\",\"description\":\"Practice 38 Tema 10: Computación Evolutiva questions from past Sistemas Intelixentes \\\"exams\\\" with model answers and self-grading. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 10: Computación Evolutiva\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 10: Computación Evolutiva\",\"item\":\"https://pe.pablopl.dev/en/esei/practice/t10\"}],\"url\":\"https://pe.pablopl.dev/en/esei/practice/t10\"}]}"
   },
   {
     "url": "seo/en/esei/exam/2023.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/esei/exam/2023",
-    "title": "2023 Sistemas Intelixentes: exam simulator | Pásame Exámenes",
-    "description": "Simulate the 2023 Sistemas Intelixentes exam with 45 questions. 45 points, 120 minutes, model answers and self-grading.",
+    "title": "Posibles preguntas 2023 Sistemas Intelixentes: exam simulator",
+    "description": "Simulate the Posibles preguntas 2023 Sistemas Intelixentes exam with 45 questions. 45 points, 120 minutes, model answers and self-grading.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/esei/exam/2023",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -2911,15 +2911,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/exam/2023"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"2023 Sistemas Intelixentes: exam simulator | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/en/esei/exam/2023\",\"inLanguage\":\"en\",\"description\":\"Simulate the 2023 Sistemas Intelixentes exam with 45 questions. 45 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"2023\",\"item\":\"https://pe.pablopl.dev/en/esei/exam/2023\"}],\"url\":\"https://pe.pablopl.dev/en/esei/exam/2023\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas 2023 Sistemas Intelixentes: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/esei/exam/2023\",\"inLanguage\":\"en\",\"description\":\"Simulate the Posibles preguntas 2023 Sistemas Intelixentes exam with 45 questions. 45 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas 2023\",\"item\":\"https://pe.pablopl.dev/en/esei/exam/2023\"}],\"url\":\"https://pe.pablopl.dev/en/esei/exam/2023\"}]}"
   },
   {
     "url": "seo/en/esei/exam/2024.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/esei/exam/2024",
-    "title": "2024 Sistemas Intelixentes: exam simulator | Pásame Exámenes",
-    "description": "Simulate the 2024 Sistemas Intelixentes exam with 44 questions. 44 points, 120 minutes, model answers and self-grading.",
+    "title": "Posibles preguntas 2024 Sistemas Intelixentes: exam simulator",
+    "description": "Simulate the Posibles preguntas 2024 Sistemas Intelixentes exam with 44 questions. 44 points, 120 minutes, model answers and self-grading.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/esei/exam/2024",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -2943,15 +2943,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/exam/2024"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"2024 Sistemas Intelixentes: exam simulator | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/en/esei/exam/2024\",\"inLanguage\":\"en\",\"description\":\"Simulate the 2024 Sistemas Intelixentes exam with 44 questions. 44 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"2024\",\"item\":\"https://pe.pablopl.dev/en/esei/exam/2024\"}],\"url\":\"https://pe.pablopl.dev/en/esei/exam/2024\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas 2024 Sistemas Intelixentes: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/esei/exam/2024\",\"inLanguage\":\"en\",\"description\":\"Simulate the Posibles preguntas 2024 Sistemas Intelixentes exam with 44 questions. 44 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas 2024\",\"item\":\"https://pe.pablopl.dev/en/esei/exam/2024\"}],\"url\":\"https://pe.pablopl.dev/en/esei/exam/2024\"}]}"
   },
   {
     "url": "seo/en/esei/exam/2025-05.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/esei/exam/2025-05",
-    "title": "Mayo 2025 Sistemas Intelixentes: exam simulator",
-    "description": "Simulate the Mayo 2025 Sistemas Intelixentes exam with 42 questions. 42 points, 120 minutes, model answers and self-grading.",
+    "title": "Posibles preguntas Mayo 2025 Sistemas Intelixentes: exam simulator",
+    "description": "Simulate the Posibles preguntas Mayo 2025 Sistemas Intelixentes exam with 42 questions. 42 points, 120 minutes, model answers and self-grading.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/esei/exam/2025-05",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -2975,15 +2975,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/exam/2025-05"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Mayo 2025 Sistemas Intelixentes: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/esei/exam/2025-05\",\"inLanguage\":\"en\",\"description\":\"Simulate the Mayo 2025 Sistemas Intelixentes exam with 42 questions. 42 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Mayo 2025\",\"item\":\"https://pe.pablopl.dev/en/esei/exam/2025-05\"}],\"url\":\"https://pe.pablopl.dev/en/esei/exam/2025-05\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Mayo 2025 Sistemas Intelixentes: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/esei/exam/2025-05\",\"inLanguage\":\"en\",\"description\":\"Simulate the Posibles preguntas Mayo 2025 Sistemas Intelixentes exam with 42 questions. 42 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Mayo 2025\",\"item\":\"https://pe.pablopl.dev/en/esei/exam/2025-05\"}],\"url\":\"https://pe.pablopl.dev/en/esei/exam/2025-05\"}]}"
   },
   {
     "url": "seo/en/esei/exam/2025-07.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/esei/exam/2025-07",
-    "title": "Julio 2025 Sistemas Intelixentes: exam simulator",
-    "description": "Simulate the Julio 2025 Sistemas Intelixentes exam with 47 questions. 47 points, 120 minutes, model answers and self-grading.",
+    "title": "Posibles preguntas Julio 2025 Sistemas Intelixentes: exam simulator",
+    "description": "Simulate the Posibles preguntas Julio 2025 Sistemas Intelixentes exam with 47 questions. 47 points, 120 minutes, model answers and self-grading.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/esei/exam/2025-07",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -3007,15 +3007,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/exam/2025-07"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Julio 2025 Sistemas Intelixentes: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/esei/exam/2025-07\",\"inLanguage\":\"en\",\"description\":\"Simulate the Julio 2025 Sistemas Intelixentes exam with 47 questions. 47 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Julio 2025\",\"item\":\"https://pe.pablopl.dev/en/esei/exam/2025-07\"}],\"url\":\"https://pe.pablopl.dev/en/esei/exam/2025-07\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Julio 2025 Sistemas Intelixentes: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/esei/exam/2025-07\",\"inLanguage\":\"en\",\"description\":\"Simulate the Posibles preguntas Julio 2025 Sistemas Intelixentes exam with 47 questions. 47 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Julio 2025\",\"item\":\"https://pe.pablopl.dev/en/esei/exam/2025-07\"}],\"url\":\"https://pe.pablopl.dev/en/esei/exam/2025-07\"}]}"
   },
   {
     "url": "seo/en/esei/exam/2026-06.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/esei/exam/2026-06",
-    "title": "Junio 2026 Sistemas Intelixentes: exam simulator",
-    "description": "Simulate the Junio 2026 Sistemas Intelixentes exam with 56 questions. 56 points, 120 minutes, model answers and self-grading.",
+    "title": "Posibles preguntas Junio 2026 Sistemas Intelixentes: exam simulator",
+    "description": "Simulate the Posibles preguntas Junio 2026 Sistemas Intelixentes exam with 56 questions. 56 points, 120 minutes, model answers and self-grading.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/esei/exam/2026-06",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -3039,15 +3039,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/exam/2026-06"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Junio 2026 Sistemas Intelixentes: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/esei/exam/2026-06\",\"inLanguage\":\"en\",\"description\":\"Simulate the Junio 2026 Sistemas Intelixentes exam with 56 questions. 56 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Junio 2026\",\"item\":\"https://pe.pablopl.dev/en/esei/exam/2026-06\"}],\"url\":\"https://pe.pablopl.dev/en/esei/exam/2026-06\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Junio 2026 Sistemas Intelixentes: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/esei/exam/2026-06\",\"inLanguage\":\"en\",\"description\":\"Simulate the Posibles preguntas Junio 2026 Sistemas Intelixentes exam with 56 questions. 56 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/en/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Junio 2026\",\"item\":\"https://pe.pablopl.dev/en/esei/exam/2026-06\"}],\"url\":\"https://pe.pablopl.dev/en/esei/exam/2026-06\"}]}"
   },
   {
     "url": "seo/en/eseo.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/eseo",
-    "title": "Sistemas Operativos: past exams and solved questions",
-    "description": "Practice 119 Sistemas Operativos questions from 9 past exams with model answers and self-grading. 202318, Universidade da Coruña.",
+    "title": "Sistemas Operativos: past \"exams\" and solved questions",
+    "description": "Practice 119 Sistemas Operativos questions from 9 past \"exams\" with model answers and self-grading. 202318, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/eseo",
     "ogImage": "https://pe.pablopl.dev/og/eseo.png",
@@ -3071,7 +3071,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/eseo"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Sistemas Operativos: past exams and solved questions\",\"url\":\"https://pe.pablopl.dev/en/eseo\",\"inLanguage\":\"en\",\"description\":\"Practice 119 Sistemas Operativos questions from 9 past exams with model answers and self-grading. 202318, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/en/eseo\"}],\"url\":\"https://pe.pablopl.dev/en/eseo\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Sistemas Operativos: past \\\"exams\\\" and solved questions\",\"url\":\"https://pe.pablopl.dev/en/eseo\",\"inLanguage\":\"en\",\"description\":\"Practice 119 Sistemas Operativos questions from 9 past \\\"exams\\\" with model answers and self-grading. 202318, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/en/eseo\"}],\"url\":\"https://pe.pablopl.dev/en/eseo\"}]}"
   },
   {
     "url": "seo/en/eseo/practice/sistema-ficheros.html",
@@ -3079,7 +3079,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/eseo/practice/sistema-ficheros",
     "title": "Sistema de Ficheros: Sistemas Operativos exam questions",
-    "description": "Practice 36 Sistema de Ficheros questions from past Sistemas Operativos exams with model answers and self-grading. 202318, Universidade da Coruña.",
+    "description": "Practice 36 Sistema de Ficheros questions from past Sistemas Operativos \"exams\" with model answers and self-grading. 202318, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/eseo/practice/sistema-ficheros",
     "ogImage": "https://pe.pablopl.dev/og/eseo.png",
@@ -3103,7 +3103,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/eseo/practice/sistema-ficheros"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Sistema de Ficheros: Sistemas Operativos exam questions\",\"url\":\"https://pe.pablopl.dev/en/eseo/practice/sistema-ficheros\",\"inLanguage\":\"en\",\"description\":\"Practice 36 Sistema de Ficheros questions from past Sistemas Operativos exams with model answers and self-grading. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Sistema de Ficheros\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/en/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Sistema de Ficheros\",\"item\":\"https://pe.pablopl.dev/en/eseo/practice/sistema-ficheros\"}],\"url\":\"https://pe.pablopl.dev/en/eseo/practice/sistema-ficheros\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Sistema de Ficheros: Sistemas Operativos exam questions\",\"url\":\"https://pe.pablopl.dev/en/eseo/practice/sistema-ficheros\",\"inLanguage\":\"en\",\"description\":\"Practice 36 Sistema de Ficheros questions from past Sistemas Operativos \\\"exams\\\" with model answers and self-grading. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Sistema de Ficheros\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/en/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Sistema de Ficheros\",\"item\":\"https://pe.pablopl.dev/en/eseo/practice/sistema-ficheros\"}],\"url\":\"https://pe.pablopl.dev/en/eseo/practice/sistema-ficheros\"}]}"
   },
   {
     "url": "seo/en/eseo/practice/memoria.html",
@@ -3111,7 +3111,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/eseo/practice/memoria",
     "title": "Gestión de Memoria: Sistemas Operativos exam questions",
-    "description": "Practice 25 Gestión de Memoria questions from past Sistemas Operativos exams with model answers and self-grading. 202318, Universidade da Coruña.",
+    "description": "Practice 25 Gestión de Memoria questions from past Sistemas Operativos \"exams\" with model answers and self-grading. 202318, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/eseo/practice/memoria",
     "ogImage": "https://pe.pablopl.dev/og/eseo.png",
@@ -3135,7 +3135,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/eseo/practice/memoria"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Gestión de Memoria: Sistemas Operativos exam questions\",\"url\":\"https://pe.pablopl.dev/en/eseo/practice/memoria\",\"inLanguage\":\"en\",\"description\":\"Practice 25 Gestión de Memoria questions from past Sistemas Operativos exams with model answers and self-grading. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Gestión de Memoria\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/en/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Gestión de Memoria\",\"item\":\"https://pe.pablopl.dev/en/eseo/practice/memoria\"}],\"url\":\"https://pe.pablopl.dev/en/eseo/practice/memoria\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Gestión de Memoria: Sistemas Operativos exam questions\",\"url\":\"https://pe.pablopl.dev/en/eseo/practice/memoria\",\"inLanguage\":\"en\",\"description\":\"Practice 25 Gestión de Memoria questions from past Sistemas Operativos \\\"exams\\\" with model answers and self-grading. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Gestión de Memoria\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/en/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Gestión de Memoria\",\"item\":\"https://pe.pablopl.dev/en/eseo/practice/memoria\"}],\"url\":\"https://pe.pablopl.dev/en/eseo/practice/memoria\"}]}"
   },
   {
     "url": "seo/en/eseo/practice/procesos.html",
@@ -3143,7 +3143,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/eseo/practice/procesos",
     "title": "Procesos e Hilos: Sistemas Operativos exam questions",
-    "description": "Practice 30 Procesos e Hilos questions from past Sistemas Operativos exams with model answers and self-grading. 202318, Universidade da Coruña.",
+    "description": "Practice 30 Procesos e Hilos questions from past Sistemas Operativos \"exams\" with model answers and self-grading. 202318, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/eseo/practice/procesos",
     "ogImage": "https://pe.pablopl.dev/og/eseo.png",
@@ -3167,7 +3167,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/eseo/practice/procesos"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Procesos e Hilos: Sistemas Operativos exam questions\",\"url\":\"https://pe.pablopl.dev/en/eseo/practice/procesos\",\"inLanguage\":\"en\",\"description\":\"Practice 30 Procesos e Hilos questions from past Sistemas Operativos exams with model answers and self-grading. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Procesos e Hilos\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/en/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Procesos e Hilos\",\"item\":\"https://pe.pablopl.dev/en/eseo/practice/procesos\"}],\"url\":\"https://pe.pablopl.dev/en/eseo/practice/procesos\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Procesos e Hilos: Sistemas Operativos exam questions\",\"url\":\"https://pe.pablopl.dev/en/eseo/practice/procesos\",\"inLanguage\":\"en\",\"description\":\"Practice 30 Procesos e Hilos questions from past Sistemas Operativos \\\"exams\\\" with model answers and self-grading. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Procesos e Hilos\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/en/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Procesos e Hilos\",\"item\":\"https://pe.pablopl.dev/en/eseo/practice/procesos\"}],\"url\":\"https://pe.pablopl.dev/en/eseo/practice/procesos\"}]}"
   },
   {
     "url": "seo/en/eseo/practice/entrada-salida.html",
@@ -3175,7 +3175,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/eseo/practice/entrada-salida",
     "title": "Entrada/Salida: Sistemas Operativos exam questions",
-    "description": "Practice 28 Entrada/Salida questions from past Sistemas Operativos exams with model answers and self-grading. 202318, Universidade da Coruña.",
+    "description": "Practice 28 Entrada/Salida questions from past Sistemas Operativos \"exams\" with model answers and self-grading. 202318, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/eseo/practice/entrada-salida",
     "ogImage": "https://pe.pablopl.dev/og/eseo.png",
@@ -3199,7 +3199,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/eseo/practice/entrada-salida"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Entrada/Salida: Sistemas Operativos exam questions\",\"url\":\"https://pe.pablopl.dev/en/eseo/practice/entrada-salida\",\"inLanguage\":\"en\",\"description\":\"Practice 28 Entrada/Salida questions from past Sistemas Operativos exams with model answers and self-grading. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Entrada/Salida\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/en/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Entrada/Salida\",\"item\":\"https://pe.pablopl.dev/en/eseo/practice/entrada-salida\"}],\"url\":\"https://pe.pablopl.dev/en/eseo/practice/entrada-salida\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Entrada/Salida: Sistemas Operativos exam questions\",\"url\":\"https://pe.pablopl.dev/en/eseo/practice/entrada-salida\",\"inLanguage\":\"en\",\"description\":\"Practice 28 Entrada/Salida questions from past Sistemas Operativos \\\"exams\\\" with model answers and self-grading. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Entrada/Salida\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/en/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Entrada/Salida\",\"item\":\"https://pe.pablopl.dev/en/eseo/practice/entrada-salida\"}],\"url\":\"https://pe.pablopl.dev/en/eseo/practice/entrada-salida\"}]}"
   },
   {
     "url": "seo/en/eseo/exam/2020-01.html",
@@ -3494,8 +3494,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/iesede",
-    "title": "Internet y Sistemas Distribuidos: past exams and solved questions",
-    "description": "Practice 18 Internet y Sistemas Distribuidos questions from 1 past exams with model answers and self-grading. 200188, Universidade da Coruña.",
+    "title": "Internet y Sistemas Distribuidos: past \"exams\" and solved questions",
+    "description": "Practice 18 Internet y Sistemas Distribuidos questions from 1 past \"exams\" with model answers and self-grading. 200188, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/iesede",
     "ogImage": "https://pe.pablopl.dev/og/iesede.png",
@@ -3519,7 +3519,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/iesede"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Internet y Sistemas Distribuidos: past exams and solved questions\",\"url\":\"https://pe.pablopl.dev/en/iesede\",\"inLanguage\":\"en\",\"description\":\"Practice 18 Internet y Sistemas Distribuidos questions from 1 past exams with model answers and self-grading. 200188, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Internet y Sistemas Distribuidos\",\"courseCode\":\"200188\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Internet y Sistemas Distribuidos\",\"item\":\"https://pe.pablopl.dev/en/iesede\"}],\"url\":\"https://pe.pablopl.dev/en/iesede\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Internet y Sistemas Distribuidos: past \\\"exams\\\" and solved questions\",\"url\":\"https://pe.pablopl.dev/en/iesede\",\"inLanguage\":\"en\",\"description\":\"Practice 18 Internet y Sistemas Distribuidos questions from 1 past \\\"exams\\\" with model answers and self-grading. 200188, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Internet y Sistemas Distribuidos\",\"courseCode\":\"200188\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Internet y Sistemas Distribuidos\",\"item\":\"https://pe.pablopl.dev/en/iesede\"}],\"url\":\"https://pe.pablopl.dev/en/iesede\"}]}"
   },
   {
     "url": "seo/en/iesede/practice/general.html",
@@ -3527,7 +3527,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/iesede/practice/general",
     "title": "General: Internet y Sistemas Distribuidos exam questions",
-    "description": "Practice 18 General questions from past Internet y Sistemas Distribuidos exams with model answers and self-grading. 200188, Universidade da Coruña.",
+    "description": "Practice 18 General questions from past Internet y Sistemas Distribuidos \"exams\" with model answers and self-grading. 200188, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/iesede/practice/general",
     "ogImage": "https://pe.pablopl.dev/og/iesede.png",
@@ -3551,15 +3551,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/iesede/practice/general"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"General: Internet y Sistemas Distribuidos exam questions\",\"url\":\"https://pe.pablopl.dev/en/iesede/practice/general\",\"inLanguage\":\"en\",\"description\":\"Practice 18 General questions from past Internet y Sistemas Distribuidos exams with model answers and self-grading. 200188, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"General\"},{\"@type\":\"Course\",\"name\":\"Internet y Sistemas Distribuidos\",\"courseCode\":\"200188\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Internet y Sistemas Distribuidos\",\"item\":\"https://pe.pablopl.dev/en/iesede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"General\",\"item\":\"https://pe.pablopl.dev/en/iesede/practice/general\"}],\"url\":\"https://pe.pablopl.dev/en/iesede/practice/general\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"General: Internet y Sistemas Distribuidos exam questions\",\"url\":\"https://pe.pablopl.dev/en/iesede/practice/general\",\"inLanguage\":\"en\",\"description\":\"Practice 18 General questions from past Internet y Sistemas Distribuidos \\\"exams\\\" with model answers and self-grading. 200188, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"General\"},{\"@type\":\"Course\",\"name\":\"Internet y Sistemas Distribuidos\",\"courseCode\":\"200188\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Internet y Sistemas Distribuidos\",\"item\":\"https://pe.pablopl.dev/en/iesede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"General\",\"item\":\"https://pe.pablopl.dev/en/iesede/practice/general\"}],\"url\":\"https://pe.pablopl.dev/en/iesede/practice/general\"}]}"
   },
   {
     "url": "seo/en/iesede/exam/examen_recopilatorio.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/iesede/exam/examen_recopilatorio",
-    "title": "Examen Recopilatorio Internet y Sistemas Distribuidos: exam simulator",
-    "description": "Simulate the Examen Recopilatorio Internet y Sistemas Distribuidos exam with 18 questions. 18 points, 120 minutes, model answers and self-grading.",
+    "title": "Recopilación Internet y Sistemas Distribuidos: exam simulator",
+    "description": "Simulate the Recopilación Internet y Sistemas Distribuidos exam with 18 questions. 18 points, 120 minutes, model answers and self-grading.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/iesede/exam/examen_recopilatorio",
     "ogImage": "https://pe.pablopl.dev/og/iesede.png",
@@ -3583,15 +3583,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/iesede/exam/examen_recopilatorio"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Examen Recopilatorio Internet y Sistemas Distribuidos: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/iesede/exam/examen_recopilatorio\",\"inLanguage\":\"en\",\"description\":\"Simulate the Examen Recopilatorio Internet y Sistemas Distribuidos exam with 18 questions. 18 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Internet y Sistemas Distribuidos\",\"courseCode\":\"200188\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Internet y Sistemas Distribuidos\",\"item\":\"https://pe.pablopl.dev/en/iesede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Examen Recopilatorio\",\"item\":\"https://pe.pablopl.dev/en/iesede/exam/examen_recopilatorio\"}],\"url\":\"https://pe.pablopl.dev/en/iesede/exam/examen_recopilatorio\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Recopilación Internet y Sistemas Distribuidos: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/iesede/exam/examen_recopilatorio\",\"inLanguage\":\"en\",\"description\":\"Simulate the Recopilación Internet y Sistemas Distribuidos exam with 18 questions. 18 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Internet y Sistemas Distribuidos\",\"courseCode\":\"200188\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Internet y Sistemas Distribuidos\",\"item\":\"https://pe.pablopl.dev/en/iesede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Recopilación\",\"item\":\"https://pe.pablopl.dev/en/iesede/exam/examen_recopilatorio\"}],\"url\":\"https://pe.pablopl.dev/en/iesede/exam/examen_recopilatorio\"}]}"
   },
   {
     "url": "seo/en/peese.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/peese",
-    "title": "Proceso Software: past exams and solved questions",
-    "description": "Practice 17 Proceso Software questions from 1 past exams with model answers and self-grading. 202321, Universidade da Coruña.",
+    "title": "Proceso Software: past \"exams\" and solved questions",
+    "description": "Practice 17 Proceso Software questions from 1 past \"exams\" with model answers and self-grading. 202321, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/peese",
     "ogImage": "https://pe.pablopl.dev/og/peese.png",
@@ -3615,7 +3615,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/peese"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Proceso Software: past exams and solved questions\",\"url\":\"https://pe.pablopl.dev/en/peese\",\"inLanguage\":\"en\",\"description\":\"Practice 17 Proceso Software questions from 1 past exams with model answers and self-grading. 202321, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Proceso Software\",\"courseCode\":\"202321\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Proceso Software\",\"item\":\"https://pe.pablopl.dev/en/peese\"}],\"url\":\"https://pe.pablopl.dev/en/peese\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Proceso Software: past \\\"exams\\\" and solved questions\",\"url\":\"https://pe.pablopl.dev/en/peese\",\"inLanguage\":\"en\",\"description\":\"Practice 17 Proceso Software questions from 1 past \\\"exams\\\" with model answers and self-grading. 202321, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Proceso Software\",\"courseCode\":\"202321\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Proceso Software\",\"item\":\"https://pe.pablopl.dev/en/peese\"}],\"url\":\"https://pe.pablopl.dev/en/peese\"}]}"
   },
   {
     "url": "seo/en/peese/practice/teoria.html",
@@ -3623,7 +3623,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/peese/practice/teoria",
     "title": "Teoría: Proceso Software exam questions | Pásame Exámenes",
-    "description": "Practice 17 Teoría questions from past Proceso Software exams with model answers and self-grading. 202321, Universidade da Coruña.",
+    "description": "Practice 17 Teoría questions from past Proceso Software \"exams\" with model answers and self-grading. 202321, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/peese/practice/teoria",
     "ogImage": "https://pe.pablopl.dev/og/peese.png",
@@ -3647,15 +3647,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/peese/practice/teoria"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Teoría: Proceso Software exam questions | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/en/peese/practice/teoria\",\"inLanguage\":\"en\",\"description\":\"Practice 17 Teoría questions from past Proceso Software exams with model answers and self-grading. 202321, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Teoría\"},{\"@type\":\"Course\",\"name\":\"Proceso Software\",\"courseCode\":\"202321\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Proceso Software\",\"item\":\"https://pe.pablopl.dev/en/peese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Teoría\",\"item\":\"https://pe.pablopl.dev/en/peese/practice/teoria\"}],\"url\":\"https://pe.pablopl.dev/en/peese/practice/teoria\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Teoría: Proceso Software exam questions | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/en/peese/practice/teoria\",\"inLanguage\":\"en\",\"description\":\"Practice 17 Teoría questions from past Proceso Software \\\"exams\\\" with model answers and self-grading. 202321, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Teoría\"},{\"@type\":\"Course\",\"name\":\"Proceso Software\",\"courseCode\":\"202321\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Proceso Software\",\"item\":\"https://pe.pablopl.dev/en/peese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Teoría\",\"item\":\"https://pe.pablopl.dev/en/peese/practice/teoria\"}],\"url\":\"https://pe.pablopl.dev/en/peese/practice/teoria\"}]}"
   },
   {
     "url": "seo/en/peese/exam/2026-05.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/peese/exam/2026-05",
-    "title": "Mayo 2026 Proceso Software: exam simulator | Pásame Exámenes",
-    "description": "Simulate the Mayo 2026 Proceso Software exam with 17 questions. 8.5 points, 120 minutes, model answers and self-grading.",
+    "title": "Posibles preguntas Mayo 2026 Proceso Software: exam simulator",
+    "description": "Simulate the Posibles preguntas Mayo 2026 Proceso Software exam with 17 questions. 8.5 points, 120 minutes, model answers and self-grading.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/peese/exam/2026-05",
     "ogImage": "https://pe.pablopl.dev/og/peese.png",
@@ -3679,15 +3679,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/peese/exam/2026-05"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Mayo 2026 Proceso Software: exam simulator | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/en/peese/exam/2026-05\",\"inLanguage\":\"en\",\"description\":\"Simulate the Mayo 2026 Proceso Software exam with 17 questions. 8.5 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Proceso Software\",\"courseCode\":\"202321\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Proceso Software\",\"item\":\"https://pe.pablopl.dev/en/peese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Mayo 2026\",\"item\":\"https://pe.pablopl.dev/en/peese/exam/2026-05\"}],\"url\":\"https://pe.pablopl.dev/en/peese/exam/2026-05\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Mayo 2026 Proceso Software: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/peese/exam/2026-05\",\"inLanguage\":\"en\",\"description\":\"Simulate the Posibles preguntas Mayo 2026 Proceso Software exam with 17 questions. 8.5 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Proceso Software\",\"courseCode\":\"202321\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Proceso Software\",\"item\":\"https://pe.pablopl.dev/en/peese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Mayo 2026\",\"item\":\"https://pe.pablopl.dev/en/peese/exam/2026-05\"}],\"url\":\"https://pe.pablopl.dev/en/peese/exam/2026-05\"}]}"
   },
   {
     "url": "seo/en/pei.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/pei",
-    "title": "Programación Integrativa: past exams and solved questions",
-    "description": "Practice 54 Programación Integrativa questions from 1 past exams with model answers and self-grading. 200214, Universidade da Coruña.",
+    "title": "Programación Integrativa: past \"exams\" and solved questions",
+    "description": "Practice 54 Programación Integrativa questions from 1 past \"exams\" with model answers and self-grading. 200214, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/pei",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -3711,7 +3711,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Programación Integrativa: past exams and solved questions\",\"url\":\"https://pe.pablopl.dev/en/pei\",\"inLanguage\":\"en\",\"description\":\"Practice 54 Programación Integrativa questions from 1 past exams with model answers and self-grading. 200214, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/en/pei\"}],\"url\":\"https://pe.pablopl.dev/en/pei\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Programación Integrativa: past \\\"exams\\\" and solved questions\",\"url\":\"https://pe.pablopl.dev/en/pei\",\"inLanguage\":\"en\",\"description\":\"Practice 54 Programación Integrativa questions from 1 past \\\"exams\\\" with model answers and self-grading. 200214, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/en/pei\"}],\"url\":\"https://pe.pablopl.dev/en/pei\"}]}"
   },
   {
     "url": "seo/en/pei/practice/pandas.html",
@@ -3719,7 +3719,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/pei/practice/pandas",
     "title": "Pandas y Datos Estructurados: Programación Integrativa exam questions",
-    "description": "Practice 8 Pandas y Datos Estructurados questions from past Programación Integrativa exams with model answers and self-grading. 200214, Universidade da Coruña.",
+    "description": "Practice 8 Pandas y Datos Estructurados questions from past Programación Integrativa \"exams\" with model answers and self-grading. 200214, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/pei/practice/pandas",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -3743,7 +3743,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei/practice/pandas"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Pandas y Datos Estructurados: Programación Integrativa exam questions\",\"url\":\"https://pe.pablopl.dev/en/pei/practice/pandas\",\"inLanguage\":\"en\",\"description\":\"Practice 8 Pandas y Datos Estructurados questions from past Programación Integrativa exams with model answers and self-grading. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Pandas y Datos Estructurados\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/en/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Pandas y Datos Estructurados\",\"item\":\"https://pe.pablopl.dev/en/pei/practice/pandas\"}],\"url\":\"https://pe.pablopl.dev/en/pei/practice/pandas\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Pandas y Datos Estructurados: Programación Integrativa exam questions\",\"url\":\"https://pe.pablopl.dev/en/pei/practice/pandas\",\"inLanguage\":\"en\",\"description\":\"Practice 8 Pandas y Datos Estructurados questions from past Programación Integrativa \\\"exams\\\" with model answers and self-grading. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Pandas y Datos Estructurados\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/en/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Pandas y Datos Estructurados\",\"item\":\"https://pe.pablopl.dev/en/pei/practice/pandas\"}],\"url\":\"https://pe.pablopl.dev/en/pei/practice/pandas\"}]}"
   },
   {
     "url": "seo/en/pei/practice/poo.html",
@@ -3751,7 +3751,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/pei/practice/poo",
     "title": "POO en Python: Programación Integrativa exam questions",
-    "description": "Practice 8 POO en Python questions from past Programación Integrativa exams with model answers and self-grading. 200214, Universidade da Coruña.",
+    "description": "Practice 8 POO en Python questions from past Programación Integrativa \"exams\" with model answers and self-grading. 200214, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/pei/practice/poo",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -3775,7 +3775,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei/practice/poo"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"POO en Python: Programación Integrativa exam questions\",\"url\":\"https://pe.pablopl.dev/en/pei/practice/poo\",\"inLanguage\":\"en\",\"description\":\"Practice 8 POO en Python questions from past Programación Integrativa exams with model answers and self-grading. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"POO en Python\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/en/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"POO en Python\",\"item\":\"https://pe.pablopl.dev/en/pei/practice/poo\"}],\"url\":\"https://pe.pablopl.dev/en/pei/practice/poo\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"POO en Python: Programación Integrativa exam questions\",\"url\":\"https://pe.pablopl.dev/en/pei/practice/poo\",\"inLanguage\":\"en\",\"description\":\"Practice 8 POO en Python questions from past Programación Integrativa \\\"exams\\\" with model answers and self-grading. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"POO en Python\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/en/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"POO en Python\",\"item\":\"https://pe.pablopl.dev/en/pei/practice/poo\"}],\"url\":\"https://pe.pablopl.dev/en/pei/practice/poo\"}]}"
   },
   {
     "url": "seo/en/pei/practice/scripting.html",
@@ -3783,7 +3783,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/pei/practice/scripting",
     "title": "Scripting y Regex: Programación Integrativa exam questions",
-    "description": "Practice 15 Scripting y Regex questions from past Programación Integrativa exams with model answers and self-grading. 200214, Universidade da Coruña.",
+    "description": "Practice 15 Scripting y Regex questions from past Programación Integrativa \"exams\" with model answers and self-grading. 200214, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/pei/practice/scripting",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -3807,7 +3807,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei/practice/scripting"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Scripting y Regex: Programación Integrativa exam questions\",\"url\":\"https://pe.pablopl.dev/en/pei/practice/scripting\",\"inLanguage\":\"en\",\"description\":\"Practice 15 Scripting y Regex questions from past Programación Integrativa exams with model answers and self-grading. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Scripting y Regex\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/en/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Scripting y Regex\",\"item\":\"https://pe.pablopl.dev/en/pei/practice/scripting\"}],\"url\":\"https://pe.pablopl.dev/en/pei/practice/scripting\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Scripting y Regex: Programación Integrativa exam questions\",\"url\":\"https://pe.pablopl.dev/en/pei/practice/scripting\",\"inLanguage\":\"en\",\"description\":\"Practice 15 Scripting y Regex questions from past Programación Integrativa \\\"exams\\\" with model answers and self-grading. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Scripting y Regex\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/en/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Scripting y Regex\",\"item\":\"https://pe.pablopl.dev/en/pei/practice/scripting\"}],\"url\":\"https://pe.pablopl.dev/en/pei/practice/scripting\"}]}"
   },
   {
     "url": "seo/en/pei/practice/django-apis.html",
@@ -3815,7 +3815,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/pei/practice/django-apis",
     "title": "Django, APIs e Integración: Programación Integrativa exam questions",
-    "description": "Practice 14 Django, APIs e Integración questions from past Programación Integrativa exams with model answers and self-grading. 200214, Universidade da Coruña.",
+    "description": "Practice 14 Django, APIs e Integración questions from past Programación Integrativa \"exams\" with model answers and self-grading. 200214, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/pei/practice/django-apis",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -3839,7 +3839,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei/practice/django-apis"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Django, APIs e Integración: Programación Integrativa exam questions\",\"url\":\"https://pe.pablopl.dev/en/pei/practice/django-apis\",\"inLanguage\":\"en\",\"description\":\"Practice 14 Django, APIs e Integración questions from past Programación Integrativa exams with model answers and self-grading. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Django, APIs e Integración\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/en/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Django, APIs e Integración\",\"item\":\"https://pe.pablopl.dev/en/pei/practice/django-apis\"}],\"url\":\"https://pe.pablopl.dev/en/pei/practice/django-apis\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Django, APIs e Integración: Programación Integrativa exam questions\",\"url\":\"https://pe.pablopl.dev/en/pei/practice/django-apis\",\"inLanguage\":\"en\",\"description\":\"Practice 14 Django, APIs e Integración questions from past Programación Integrativa \\\"exams\\\" with model answers and self-grading. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Django, APIs e Integración\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/en/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Django, APIs e Integración\",\"item\":\"https://pe.pablopl.dev/en/pei/practice/django-apis\"}],\"url\":\"https://pe.pablopl.dev/en/pei/practice/django-apis\"}]}"
   },
   {
     "url": "seo/en/pei/practice/conceptos.html",
@@ -3847,7 +3847,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/pei/practice/conceptos",
     "title": "Conceptos y Test: Programación Integrativa exam questions",
-    "description": "Practice 9 Conceptos y Test questions from past Programación Integrativa exams with model answers and self-grading. 200214, Universidade da Coruña.",
+    "description": "Practice 9 Conceptos y Test questions from past Programación Integrativa \"exams\" with model answers and self-grading. 200214, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/pei/practice/conceptos",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -3871,7 +3871,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei/practice/conceptos"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Conceptos y Test: Programación Integrativa exam questions\",\"url\":\"https://pe.pablopl.dev/en/pei/practice/conceptos\",\"inLanguage\":\"en\",\"description\":\"Practice 9 Conceptos y Test questions from past Programación Integrativa exams with model answers and self-grading. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Conceptos y Test\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/en/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Conceptos y Test\",\"item\":\"https://pe.pablopl.dev/en/pei/practice/conceptos\"}],\"url\":\"https://pe.pablopl.dev/en/pei/practice/conceptos\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Conceptos y Test: Programación Integrativa exam questions\",\"url\":\"https://pe.pablopl.dev/en/pei/practice/conceptos\",\"inLanguage\":\"en\",\"description\":\"Practice 9 Conceptos y Test questions from past Programación Integrativa \\\"exams\\\" with model answers and self-grading. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Conceptos y Test\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/en/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Conceptos y Test\",\"item\":\"https://pe.pablopl.dev/en/pei/practice/conceptos\"}],\"url\":\"https://pe.pablopl.dev/en/pei/practice/conceptos\"}]}"
   },
   {
     "url": "seo/en/pei/exam/recopilacion.html",
@@ -3910,8 +3910,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/redes",
-    "title": "Redes: past exams and solved questions | Pásame Exámenes",
-    "description": "Practice 460 Redes questions from 3 past exams with model answers and self-grading. 202319, Universidade da Coruña.",
+    "title": "Redes: past \"exams\" and solved questions | Pásame Exámenes",
+    "description": "Practice 460 Redes questions from 3 past \"exams\" with model answers and self-grading. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/redes",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -3935,7 +3935,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Redes: past exams and solved questions | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/en/redes\",\"inLanguage\":\"en\",\"description\":\"Practice 460 Redes questions from 3 past exams with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"}],\"url\":\"https://pe.pablopl.dev/en/redes\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Redes: past \\\"exams\\\" and solved questions | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/en/redes\",\"inLanguage\":\"en\",\"description\":\"Practice 460 Redes questions from 3 past \\\"exams\\\" with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"}],\"url\":\"https://pe.pablopl.dev/en/redes\"}]}"
   },
   {
     "url": "seo/en/redes/practice/tema-1.html",
@@ -3943,7 +3943,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/redes/practice/tema-1",
     "title": "Tema 1. Redes de ordenadores e Internet: Redes exam questions",
-    "description": "Practice 54 Tema 1. Redes de ordenadores e Internet questions from past Redes exams with model answers and self-grading. 202319, Universidade da Coruña.",
+    "description": "Practice 54 Tema 1. Redes de ordenadores e Internet questions from past Redes \"exams\" with model answers and self-grading. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/redes/practice/tema-1",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -3967,7 +3967,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-1"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 1. Redes de ordenadores e Internet: Redes exam questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-1\",\"inLanguage\":\"en\",\"description\":\"Practice 54 Tema 1. Redes de ordenadores e Internet questions from past Redes exams with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 1. Redes de ordenadores e Internet\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 1. Redes de ordenadores e Internet\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-1\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-1\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 1. Redes de ordenadores e Internet: Redes exam questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-1\",\"inLanguage\":\"en\",\"description\":\"Practice 54 Tema 1. Redes de ordenadores e Internet questions from past Redes \\\"exams\\\" with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 1. Redes de ordenadores e Internet\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 1. Redes de ordenadores e Internet\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-1\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-1\"}]}"
   },
   {
     "url": "seo/en/redes/practice/tema-2.html",
@@ -3975,7 +3975,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/redes/practice/tema-2",
     "title": "Tema 2. Introducción a TCP/IP: Redes exam questions",
-    "description": "Practice 19 Tema 2. Introducción a TCP/IP questions from past Redes exams with model answers and self-grading. 202319, Universidade da Coruña.",
+    "description": "Practice 19 Tema 2. Introducción a TCP/IP questions from past Redes \"exams\" with model answers and self-grading. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/redes/practice/tema-2",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -3999,7 +3999,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-2"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 2. Introducción a TCP/IP: Redes exam questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-2\",\"inLanguage\":\"en\",\"description\":\"Practice 19 Tema 2. Introducción a TCP/IP questions from past Redes exams with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 2. Introducción a TCP/IP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 2. Introducción a TCP/IP\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-2\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-2\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 2. Introducción a TCP/IP: Redes exam questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-2\",\"inLanguage\":\"en\",\"description\":\"Practice 19 Tema 2. Introducción a TCP/IP questions from past Redes \\\"exams\\\" with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 2. Introducción a TCP/IP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 2. Introducción a TCP/IP\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-2\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-2\"}]}"
   },
   {
     "url": "seo/en/redes/practice/tema-3-4.html",
@@ -4007,7 +4007,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/redes/practice/tema-3-4",
     "title": "Tema 3-4. Protocolos nivel de aplicación: Redes exam questions",
-    "description": "Practice 77 Tema 3-4. Protocolos nivel de aplicación questions from past Redes exams with model answers and self-grading. 202319, Universidade da Coruña.",
+    "description": "Practice 77 Tema 3-4. Protocolos nivel de aplicación questions from past Redes \"exams\" with model answers and self-grading. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/redes/practice/tema-3-4",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -4031,7 +4031,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-3-4"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 3-4. Protocolos nivel de aplicación: Redes exam questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-3-4\",\"inLanguage\":\"en\",\"description\":\"Practice 77 Tema 3-4. Protocolos nivel de aplicación questions from past Redes exams with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 3-4. Protocolos nivel de aplicación\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 3-4. Protocolos nivel de aplicación\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-3-4\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-3-4\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 3-4. Protocolos nivel de aplicación: Redes exam questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-3-4\",\"inLanguage\":\"en\",\"description\":\"Practice 77 Tema 3-4. Protocolos nivel de aplicación questions from past Redes \\\"exams\\\" with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 3-4. Protocolos nivel de aplicación\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 3-4. Protocolos nivel de aplicación\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-3-4\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-3-4\"}]}"
   },
   {
     "url": "seo/en/redes/practice/tema-5.html",
@@ -4039,7 +4039,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/redes/practice/tema-5",
     "title": "Tema 5. Protocolos de transporte UDP y TCP: Redes exam questions",
-    "description": "Practice 51 Tema 5. Protocolos de transporte UDP y TCP questions from past Redes exams with model answers and self-grading. 202319, Universidade da Coruña.",
+    "description": "Practice 51 Tema 5. Protocolos de transporte UDP y TCP questions from past Redes \"exams\" with model answers and self-grading. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/redes/practice/tema-5",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -4063,7 +4063,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-5"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 5. Protocolos de transporte UDP y TCP: Redes exam questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-5\",\"inLanguage\":\"en\",\"description\":\"Practice 51 Tema 5. Protocolos de transporte UDP y TCP questions from past Redes exams with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 5. Protocolos de transporte UDP y TCP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 5. Protocolos de transporte UDP y TCP\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-5\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-5\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 5. Protocolos de transporte UDP y TCP: Redes exam questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-5\",\"inLanguage\":\"en\",\"description\":\"Practice 51 Tema 5. Protocolos de transporte UDP y TCP questions from past Redes \\\"exams\\\" with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 5. Protocolos de transporte UDP y TCP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 5. Protocolos de transporte UDP y TCP\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-5\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-5\"}]}"
   },
   {
     "url": "seo/en/redes/practice/tema-6.html",
@@ -4071,7 +4071,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/redes/practice/tema-6",
     "title": "Tema 6. Intercambio de datos TCP: Redes exam questions",
-    "description": "Practice 48 Tema 6. Intercambio de datos TCP questions from past Redes exams with model answers and self-grading. 202319, Universidade da Coruña.",
+    "description": "Practice 48 Tema 6. Intercambio de datos TCP questions from past Redes \"exams\" with model answers and self-grading. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/redes/practice/tema-6",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -4095,7 +4095,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-6"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 6. Intercambio de datos TCP: Redes exam questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-6\",\"inLanguage\":\"en\",\"description\":\"Practice 48 Tema 6. Intercambio de datos TCP questions from past Redes exams with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 6. Intercambio de datos TCP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 6. Intercambio de datos TCP\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-6\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-6\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 6. Intercambio de datos TCP: Redes exam questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-6\",\"inLanguage\":\"en\",\"description\":\"Practice 48 Tema 6. Intercambio de datos TCP questions from past Redes \\\"exams\\\" with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 6. Intercambio de datos TCP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 6. Intercambio de datos TCP\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-6\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-6\"}]}"
   },
   {
     "url": "seo/en/redes/practice/tema-7.html",
@@ -4103,7 +4103,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/redes/practice/tema-7",
     "title": "Tema 7. Nivel de red: protocolo IP: Redes exam questions",
-    "description": "Practice 81 Tema 7. Nivel de red: protocolo IP questions from past Redes exams with model answers and self-grading. 202319, Universidade da Coruña.",
+    "description": "Practice 81 Tema 7. Nivel de red: protocolo IP questions from past Redes \"exams\" with model answers and self-grading. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/redes/practice/tema-7",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -4127,7 +4127,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-7"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 7. Nivel de red: protocolo IP: Redes exam questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-7\",\"inLanguage\":\"en\",\"description\":\"Practice 81 Tema 7. Nivel de red: protocolo IP questions from past Redes exams with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 7. Nivel de red: protocolo IP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 7. Nivel de red: protocolo IP\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-7\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-7\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 7. Nivel de red: protocolo IP: Redes exam questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-7\",\"inLanguage\":\"en\",\"description\":\"Practice 81 Tema 7. Nivel de red: protocolo IP questions from past Redes \\\"exams\\\" with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 7. Nivel de red: protocolo IP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 7. Nivel de red: protocolo IP\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-7\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-7\"}]}"
   },
   {
     "url": "seo/en/redes/practice/tema-8.html",
@@ -4135,7 +4135,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/redes/practice/tema-8",
     "title": "Tema 8. Enrutamiento: Redes exam questions | Pásame Exámenes",
-    "description": "Practice 22 Tema 8. Enrutamiento questions from past Redes exams with model answers and self-grading. 202319, Universidade da Coruña.",
+    "description": "Practice 22 Tema 8. Enrutamiento questions from past Redes \"exams\" with model answers and self-grading. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/redes/practice/tema-8",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -4159,7 +4159,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-8"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 8. Enrutamiento: Redes exam questions | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-8\",\"inLanguage\":\"en\",\"description\":\"Practice 22 Tema 8. Enrutamiento questions from past Redes exams with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 8. Enrutamiento\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 8. Enrutamiento\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-8\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-8\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 8. Enrutamiento: Redes exam questions | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-8\",\"inLanguage\":\"en\",\"description\":\"Practice 22 Tema 8. Enrutamiento questions from past Redes \\\"exams\\\" with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 8. Enrutamiento\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 8. Enrutamiento\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-8\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-8\"}]}"
   },
   {
     "url": "seo/en/redes/practice/tema-9.html",
@@ -4167,7 +4167,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/redes/practice/tema-9",
     "title": "Tema 9. ICMP y fragmentación IP: Redes exam questions",
-    "description": "Practice 24 Tema 9. ICMP y fragmentación IP questions from past Redes exams with model answers and self-grading. 202319, Universidade da Coruña.",
+    "description": "Practice 24 Tema 9. ICMP y fragmentación IP questions from past Redes \"exams\" with model answers and self-grading. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/redes/practice/tema-9",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -4191,7 +4191,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-9"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 9. ICMP y fragmentación IP: Redes exam questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-9\",\"inLanguage\":\"en\",\"description\":\"Practice 24 Tema 9. ICMP y fragmentación IP questions from past Redes exams with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 9. ICMP y fragmentación IP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 9. ICMP y fragmentación IP\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-9\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-9\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 9. ICMP y fragmentación IP: Redes exam questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-9\",\"inLanguage\":\"en\",\"description\":\"Practice 24 Tema 9. ICMP y fragmentación IP questions from past Redes \\\"exams\\\" with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 9. ICMP y fragmentación IP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 9. ICMP y fragmentación IP\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-9\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-9\"}]}"
   },
   {
     "url": "seo/en/redes/practice/tema-10.html",
@@ -4199,7 +4199,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/redes/practice/tema-10",
     "title": "Tema 10. Protocolo IPv6: Redes exam questions",
-    "description": "Practice 11 Tema 10. Protocolo IPv6 questions from past Redes exams with model answers and self-grading. 202319, Universidade da Coruña.",
+    "description": "Practice 11 Tema 10. Protocolo IPv6 questions from past Redes \"exams\" with model answers and self-grading. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/redes/practice/tema-10",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -4223,7 +4223,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-10"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 10. Protocolo IPv6: Redes exam questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-10\",\"inLanguage\":\"en\",\"description\":\"Practice 11 Tema 10. Protocolo IPv6 questions from past Redes exams with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 10. Protocolo IPv6\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 10. Protocolo IPv6\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-10\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-10\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 10. Protocolo IPv6: Redes exam questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-10\",\"inLanguage\":\"en\",\"description\":\"Practice 11 Tema 10. Protocolo IPv6 questions from past Redes \\\"exams\\\" with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 10. Protocolo IPv6\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 10. Protocolo IPv6\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-10\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-10\"}]}"
   },
   {
     "url": "seo/en/redes/practice/tema-11.html",
@@ -4231,7 +4231,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/redes/practice/tema-11",
     "title": "Tema 11. TCP/IP y nivel de enlace: Redes exam questions",
-    "description": "Practice 24 Tema 11. TCP/IP y nivel de enlace questions from past Redes exams with model answers and self-grading. 202319, Universidade da Coruña.",
+    "description": "Practice 24 Tema 11. TCP/IP y nivel de enlace questions from past Redes \"exams\" with model answers and self-grading. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/redes/practice/tema-11",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -4255,7 +4255,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-11"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 11. TCP/IP y nivel de enlace: Redes exam questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-11\",\"inLanguage\":\"en\",\"description\":\"Practice 24 Tema 11. TCP/IP y nivel de enlace questions from past Redes exams with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 11. TCP/IP y nivel de enlace\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 11. TCP/IP y nivel de enlace\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-11\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-11\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 11. TCP/IP y nivel de enlace: Redes exam questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-11\",\"inLanguage\":\"en\",\"description\":\"Practice 24 Tema 11. TCP/IP y nivel de enlace questions from past Redes \\\"exams\\\" with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 11. TCP/IP y nivel de enlace\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 11. TCP/IP y nivel de enlace\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-11\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-11\"}]}"
   },
   {
     "url": "seo/en/redes/practice/tema-12.html",
@@ -4263,7 +4263,7 @@ export const pages = [
     "lang": "en",
     "pathWithoutLang": "/redes/practice/tema-12",
     "title": "Tema 12. Tecnologías del nivel de enlace: Redes exam questions",
-    "description": "Practice 49 Tema 12. Tecnologías del nivel de enlace questions from past Redes exams with model answers and self-grading. 202319, Universidade da Coruña.",
+    "description": "Practice 49 Tema 12. Tecnologías del nivel de enlace questions from past Redes \"exams\" with model answers and self-grading. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/redes/practice/tema-12",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -4287,7 +4287,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-12"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 12. Tecnologías del nivel de enlace: Redes exam questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-12\",\"inLanguage\":\"en\",\"description\":\"Practice 49 Tema 12. Tecnologías del nivel de enlace questions from past Redes exams with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 12. Tecnologías del nivel de enlace\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 12. Tecnologías del nivel de enlace\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-12\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-12\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 12. Tecnologías del nivel de enlace: Redes exam questions\",\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-12\",\"inLanguage\":\"en\",\"description\":\"Practice 49 Tema 12. Tecnologías del nivel de enlace questions from past Redes \\\"exams\\\" with model answers and self-grading. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 12. Tecnologías del nivel de enlace\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 12. Tecnologías del nivel de enlace\",\"item\":\"https://pe.pablopl.dev/en/redes/practice/tema-12\"}],\"url\":\"https://pe.pablopl.dev/en/redes/practice/tema-12\"}]}"
   },
   {
     "url": "seo/en/redes/exam/daypo-recopilatorio-lara.html",
@@ -4358,8 +4358,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "en",
     "pathWithoutLang": "/redes/exam/2025-05",
-    "title": "Mayo 2025 (incompl.) Redes: exam simulator | Pásame Exámenes",
-    "description": "Simulate the Mayo 2025 (incompl.) Redes exam with 37 questions. 37 points, 120 minutes, model answers and self-grading.",
+    "title": "Posibles preguntas Mayo 2025 Redes: exam simulator",
+    "description": "Simulate the Posibles preguntas Mayo 2025 Redes exam with 37 questions. 37 points, 120 minutes, model answers and self-grading.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/en/redes/exam/2025-05",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -4383,7 +4383,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/exam/2025-05"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Mayo 2025 (incompl.) Redes: exam simulator | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/en/redes/exam/2025-05\",\"inLanguage\":\"en\",\"description\":\"Simulate the Mayo 2025 (incompl.) Redes exam with 37 questions. 37 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Mayo 2025 (incompl.)\",\"item\":\"https://pe.pablopl.dev/en/redes/exam/2025-05\"}],\"url\":\"https://pe.pablopl.dev/en/redes/exam/2025-05\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Mayo 2025 Redes: exam simulator\",\"url\":\"https://pe.pablopl.dev/en/redes/exam/2025-05\",\"inLanguage\":\"en\",\"description\":\"Simulate the Posibles preguntas Mayo 2025 Redes exam with 37 questions. 37 points, 120 minutes, model answers and self-grading.\",\"about\":{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/en\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/en/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Mayo 2025\",\"item\":\"https://pe.pablopl.dev/en/redes/exam/2025-05\"}],\"url\":\"https://pe.pablopl.dev/en/redes/exam/2025-05\"}]}"
   },
   {
     "url": "seo/es.html",
@@ -4422,8 +4422,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/bede",
-    "title": "Bases de Datos: exámenes y preguntas resueltas",
-    "description": "Practica 98 preguntas de Bases de Datos de 1 exámenes anteriores con respuestas modelo y autocorrección. 202315, Universidade da Coruña.",
+    "title": "Bases de Datos: \"exámenes\" y preguntas resueltas",
+    "description": "Practica 98 preguntas de Bases de Datos de 1 \"exámenes\" anteriores con respuestas modelo y autocorrección. 202315, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/bede",
     "ogImage": "https://pe.pablopl.dev/og/bede.png",
@@ -4447,7 +4447,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/bede"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Bases de Datos: exámenes y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/bede\",\"inLanguage\":\"es\",\"description\":\"Practica 98 preguntas de Bases de Datos de 1 exámenes anteriores con respuestas modelo y autocorrección. 202315, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/es/bede\"}],\"url\":\"https://pe.pablopl.dev/es/bede\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Bases de Datos: \\\"exámenes\\\" y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/bede\",\"inLanguage\":\"es\",\"description\":\"Practica 98 preguntas de Bases de Datos de 1 \\\"exámenes\\\" anteriores con respuestas modelo y autocorrección. 202315, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/es/bede\"}],\"url\":\"https://pe.pablopl.dev/es/bede\"}]}"
   },
   {
     "url": "seo/es/bede/practice/recuperacion-concurrencia.html",
@@ -4455,7 +4455,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/bede/practice/recuperacion-concurrencia",
     "title": "Recuperación y Concurrencia: preguntas de Bases de Datos",
-    "description": "Practica 48 preguntas de Recuperación y Concurrencia de exámenes anteriores de Bases de Datos, con respuestas modelo y autocorrección. 202315, Universidade da Coruña.",
+    "description": "Practica 48 preguntas de Recuperación y Concurrencia de \"exámenes\" anteriores de Bases de Datos, con respuestas modelo y autocorrección. 202315, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/bede/practice/recuperacion-concurrencia",
     "ogImage": "https://pe.pablopl.dev/og/bede.png",
@@ -4479,7 +4479,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/bede/practice/recuperacion-concurrencia"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Recuperación y Concurrencia: preguntas de Bases de Datos\",\"url\":\"https://pe.pablopl.dev/es/bede/practice/recuperacion-concurrencia\",\"inLanguage\":\"es\",\"description\":\"Practica 48 preguntas de Recuperación y Concurrencia de exámenes anteriores de Bases de Datos, con respuestas modelo y autocorrección. 202315, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Recuperación y Concurrencia\"},{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/es/bede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Recuperación y Concurrencia\",\"item\":\"https://pe.pablopl.dev/es/bede/practice/recuperacion-concurrencia\"}],\"url\":\"https://pe.pablopl.dev/es/bede/practice/recuperacion-concurrencia\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Recuperación y Concurrencia: preguntas de Bases de Datos\",\"url\":\"https://pe.pablopl.dev/es/bede/practice/recuperacion-concurrencia\",\"inLanguage\":\"es\",\"description\":\"Practica 48 preguntas de Recuperación y Concurrencia de \\\"exámenes\\\" anteriores de Bases de Datos, con respuestas modelo y autocorrección. 202315, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Recuperación y Concurrencia\"},{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/es/bede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Recuperación y Concurrencia\",\"item\":\"https://pe.pablopl.dev/es/bede/practice/recuperacion-concurrencia\"}],\"url\":\"https://pe.pablopl.dev/es/bede/practice/recuperacion-concurrencia\"}]}"
   },
   {
     "url": "seo/es/bede/practice/ficheros.html",
@@ -4487,7 +4487,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/bede/practice/ficheros",
     "title": "Ficheros: preguntas de Bases de Datos | Pásame Exámenes",
-    "description": "Practica 50 preguntas de Ficheros de exámenes anteriores de Bases de Datos, con respuestas modelo y autocorrección. 202315, Universidade da Coruña.",
+    "description": "Practica 50 preguntas de Ficheros de \"exámenes\" anteriores de Bases de Datos, con respuestas modelo y autocorrección. 202315, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/bede/practice/ficheros",
     "ogImage": "https://pe.pablopl.dev/og/bede.png",
@@ -4511,7 +4511,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/bede/practice/ficheros"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Ficheros: preguntas de Bases de Datos | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/bede/practice/ficheros\",\"inLanguage\":\"es\",\"description\":\"Practica 50 preguntas de Ficheros de exámenes anteriores de Bases de Datos, con respuestas modelo y autocorrección. 202315, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Ficheros\"},{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/es/bede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Ficheros\",\"item\":\"https://pe.pablopl.dev/es/bede/practice/ficheros\"}],\"url\":\"https://pe.pablopl.dev/es/bede/practice/ficheros\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Ficheros: preguntas de Bases de Datos | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/bede/practice/ficheros\",\"inLanguage\":\"es\",\"description\":\"Practica 50 preguntas de Ficheros de \\\"exámenes\\\" anteriores de Bases de Datos, con respuestas modelo y autocorrección. 202315, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Ficheros\"},{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/es/bede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Ficheros\",\"item\":\"https://pe.pablopl.dev/es/bede/practice/ficheros\"}],\"url\":\"https://pe.pablopl.dev/es/bede/practice/ficheros\"}]}"
   },
   {
     "url": "seo/es/bede/exam/daypo-preguntas.html",
@@ -4550,8 +4550,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/cepe",
-    "title": "Concorrencia e Paralelismo: exámenes y preguntas resueltas",
-    "description": "Practica 76 preguntas de Concorrencia e Paralelismo de 16 exámenes anteriores con respuestas modelo y autocorrección. 202320, Universidade da Coruña.",
+    "title": "Concorrencia e Paralelismo: \"exámenes\" y preguntas resueltas",
+    "description": "Practica 76 preguntas de Concorrencia e Paralelismo de 16 \"exámenes\" anteriores con respuestas modelo y autocorrección. 202320, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/cepe",
     "ogImage": "https://pe.pablopl.dev/og/cepe.png",
@@ -4575,7 +4575,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/cepe"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Concorrencia e Paralelismo: exámenes y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/cepe\",\"inLanguage\":\"es\",\"description\":\"Practica 76 preguntas de Concorrencia e Paralelismo de 16 exámenes anteriores con respuestas modelo y autocorrección. 202320, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/es/cepe\"}],\"url\":\"https://pe.pablopl.dev/es/cepe\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Concorrencia e Paralelismo: \\\"exámenes\\\" y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/cepe\",\"inLanguage\":\"es\",\"description\":\"Practica 76 preguntas de Concorrencia e Paralelismo de 16 \\\"exámenes\\\" anteriores con respuestas modelo y autocorrección. 202320, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/es/cepe\"}],\"url\":\"https://pe.pablopl.dev/es/cepe\"}]}"
   },
   {
     "url": "seo/es/cepe/practice/concurrencia-mutex.html",
@@ -4583,7 +4583,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/cepe/practice/concurrencia-mutex",
     "title": "Mutex y Condiciones: preguntas de Concorrencia e Paralelismo",
-    "description": "Practica 32 preguntas de Mutex y Condiciones de exámenes anteriores de Concorrencia e Paralelismo, con respuestas modelo y autocorrección. 202320, Universidade da Coruña.",
+    "description": "Practica 32 preguntas de Mutex y Condiciones de \"exámenes\" anteriores de Concorrencia e Paralelismo, con respuestas modelo y autocorrección. 202320, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/cepe/practice/concurrencia-mutex",
     "ogImage": "https://pe.pablopl.dev/og/cepe.png",
@@ -4607,7 +4607,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/cepe/practice/concurrencia-mutex"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Mutex y Condiciones: preguntas de Concorrencia e Paralelismo\",\"url\":\"https://pe.pablopl.dev/es/cepe/practice/concurrencia-mutex\",\"inLanguage\":\"es\",\"description\":\"Practica 32 preguntas de Mutex y Condiciones de exámenes anteriores de Concorrencia e Paralelismo, con respuestas modelo y autocorrección. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Mutex y Condiciones\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/es/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Mutex y Condiciones\",\"item\":\"https://pe.pablopl.dev/es/cepe/practice/concurrencia-mutex\"}],\"url\":\"https://pe.pablopl.dev/es/cepe/practice/concurrencia-mutex\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Mutex y Condiciones: preguntas de Concorrencia e Paralelismo\",\"url\":\"https://pe.pablopl.dev/es/cepe/practice/concurrencia-mutex\",\"inLanguage\":\"es\",\"description\":\"Practica 32 preguntas de Mutex y Condiciones de \\\"exámenes\\\" anteriores de Concorrencia e Paralelismo, con respuestas modelo y autocorrección. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Mutex y Condiciones\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/es/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Mutex y Condiciones\",\"item\":\"https://pe.pablopl.dev/es/cepe/practice/concurrencia-mutex\"}],\"url\":\"https://pe.pablopl.dev/es/cepe/practice/concurrencia-mutex\"}]}"
   },
   {
     "url": "seo/es/cepe/practice/concurrencia-erlang.html",
@@ -4615,7 +4615,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/cepe/practice/concurrencia-erlang",
     "title": "Erlang: preguntas de Concorrencia e Paralelismo",
-    "description": "Practica 12 preguntas de Erlang de exámenes anteriores de Concorrencia e Paralelismo, con respuestas modelo y autocorrección. 202320, Universidade da Coruña.",
+    "description": "Practica 12 preguntas de Erlang de \"exámenes\" anteriores de Concorrencia e Paralelismo, con respuestas modelo y autocorrección. 202320, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/cepe/practice/concurrencia-erlang",
     "ogImage": "https://pe.pablopl.dev/og/cepe.png",
@@ -4639,7 +4639,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/cepe/practice/concurrencia-erlang"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Erlang: preguntas de Concorrencia e Paralelismo\",\"url\":\"https://pe.pablopl.dev/es/cepe/practice/concurrencia-erlang\",\"inLanguage\":\"es\",\"description\":\"Practica 12 preguntas de Erlang de exámenes anteriores de Concorrencia e Paralelismo, con respuestas modelo y autocorrección. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Erlang\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/es/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Erlang\",\"item\":\"https://pe.pablopl.dev/es/cepe/practice/concurrencia-erlang\"}],\"url\":\"https://pe.pablopl.dev/es/cepe/practice/concurrencia-erlang\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Erlang: preguntas de Concorrencia e Paralelismo\",\"url\":\"https://pe.pablopl.dev/es/cepe/practice/concurrencia-erlang\",\"inLanguage\":\"es\",\"description\":\"Practica 12 preguntas de Erlang de \\\"exámenes\\\" anteriores de Concorrencia e Paralelismo, con respuestas modelo y autocorrección. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Erlang\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/es/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Erlang\",\"item\":\"https://pe.pablopl.dev/es/cepe/practice/concurrencia-erlang\"}],\"url\":\"https://pe.pablopl.dev/es/cepe/practice/concurrencia-erlang\"}]}"
   },
   {
     "url": "seo/es/cepe/practice/paralelismo-teoria.html",
@@ -4647,7 +4647,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/cepe/practice/paralelismo-teoria",
     "title": "Preguntas Teóricas: preguntas de Concorrencia e Paralelismo",
-    "description": "Practica 19 preguntas de Preguntas Teóricas de exámenes anteriores de Concorrencia e Paralelismo, con respuestas modelo y autocorrección. 202320, Universidade da Coruña.",
+    "description": "Practica 19 preguntas de Preguntas Teóricas de \"exámenes\" anteriores de Concorrencia e Paralelismo, con respuestas modelo y autocorrección. 202320, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/cepe/practice/paralelismo-teoria",
     "ogImage": "https://pe.pablopl.dev/og/cepe.png",
@@ -4671,7 +4671,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/cepe/practice/paralelismo-teoria"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Preguntas Teóricas: preguntas de Concorrencia e Paralelismo\",\"url\":\"https://pe.pablopl.dev/es/cepe/practice/paralelismo-teoria\",\"inLanguage\":\"es\",\"description\":\"Practica 19 preguntas de Preguntas Teóricas de exámenes anteriores de Concorrencia e Paralelismo, con respuestas modelo y autocorrección. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Preguntas Teóricas\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/es/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Preguntas Teóricas\",\"item\":\"https://pe.pablopl.dev/es/cepe/practice/paralelismo-teoria\"}],\"url\":\"https://pe.pablopl.dev/es/cepe/practice/paralelismo-teoria\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Preguntas Teóricas: preguntas de Concorrencia e Paralelismo\",\"url\":\"https://pe.pablopl.dev/es/cepe/practice/paralelismo-teoria\",\"inLanguage\":\"es\",\"description\":\"Practica 19 preguntas de Preguntas Teóricas de \\\"exámenes\\\" anteriores de Concorrencia e Paralelismo, con respuestas modelo y autocorrección. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Preguntas Teóricas\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/es/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Preguntas Teóricas\",\"item\":\"https://pe.pablopl.dev/es/cepe/practice/paralelismo-teoria\"}],\"url\":\"https://pe.pablopl.dev/es/cepe/practice/paralelismo-teoria\"}]}"
   },
   {
     "url": "seo/es/cepe/practice/paralelismo-mpi.html",
@@ -4679,7 +4679,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/cepe/practice/paralelismo-mpi",
     "title": "Ejercicios de MPI: preguntas de Concorrencia e Paralelismo",
-    "description": "Practica 13 preguntas de Ejercicios de MPI de exámenes anteriores de Concorrencia e Paralelismo, con respuestas modelo y autocorrección. 202320, Universidade da Coruña.",
+    "description": "Practica 13 preguntas de Ejercicios de MPI de \"exámenes\" anteriores de Concorrencia e Paralelismo, con respuestas modelo y autocorrección. 202320, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/cepe/practice/paralelismo-mpi",
     "ogImage": "https://pe.pablopl.dev/og/cepe.png",
@@ -4703,7 +4703,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/cepe/practice/paralelismo-mpi"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Ejercicios de MPI: preguntas de Concorrencia e Paralelismo\",\"url\":\"https://pe.pablopl.dev/es/cepe/practice/paralelismo-mpi\",\"inLanguage\":\"es\",\"description\":\"Practica 13 preguntas de Ejercicios de MPI de exámenes anteriores de Concorrencia e Paralelismo, con respuestas modelo y autocorrección. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Ejercicios de MPI\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/es/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Ejercicios de MPI\",\"item\":\"https://pe.pablopl.dev/es/cepe/practice/paralelismo-mpi\"}],\"url\":\"https://pe.pablopl.dev/es/cepe/practice/paralelismo-mpi\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Ejercicios de MPI: preguntas de Concorrencia e Paralelismo\",\"url\":\"https://pe.pablopl.dev/es/cepe/practice/paralelismo-mpi\",\"inLanguage\":\"es\",\"description\":\"Practica 13 preguntas de Ejercicios de MPI de \\\"exámenes\\\" anteriores de Concorrencia e Paralelismo, con respuestas modelo y autocorrección. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Ejercicios de MPI\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/es/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Ejercicios de MPI\",\"item\":\"https://pe.pablopl.dev/es/cepe/practice/paralelismo-mpi\"}],\"url\":\"https://pe.pablopl.dev/es/cepe/practice/paralelismo-mpi\"}]}"
   },
   {
     "url": "seo/es/cepe/exam/2018-06.html",
@@ -5222,8 +5222,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/deese",
-    "title": "Deseño de Software: exámenes y preguntas resueltas",
-    "description": "Practica 55 preguntas de Deseño de Software de 2 exámenes anteriores con respuestas modelo y autocorrección. 202317, Universidade da Coruña.",
+    "title": "Deseño de Software: \"exámenes\" y preguntas resueltas",
+    "description": "Practica 55 preguntas de Deseño de Software de 2 \"exámenes\" anteriores con respuestas modelo y autocorrección. 202317, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/deese",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -5247,7 +5247,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Deseño de Software: exámenes y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/deese\",\"inLanguage\":\"es\",\"description\":\"Practica 55 preguntas de Deseño de Software de 2 exámenes anteriores con respuestas modelo y autocorrección. 202317, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/es/deese\"}],\"url\":\"https://pe.pablopl.dev/es/deese\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Deseño de Software: \\\"exámenes\\\" y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/deese\",\"inLanguage\":\"es\",\"description\":\"Practica 55 preguntas de Deseño de Software de 2 \\\"exámenes\\\" anteriores con respuestas modelo y autocorrección. 202317, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/es/deese\"}],\"url\":\"https://pe.pablopl.dev/es/deese\"}]}"
   },
   {
     "url": "seo/es/deese/practice/intro-y-objetos.html",
@@ -5255,7 +5255,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/deese/practice/intro-y-objetos",
     "title": "Introducción y Elementos Básicos de la OO: preguntas de Deseño de Software",
-    "description": "Practica 12 preguntas de Introducción y Elementos Básicos de la OO de exámenes anteriores de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.",
+    "description": "Practica 12 preguntas de Introducción y Elementos Básicos de la OO de \"exámenes\" anteriores de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/deese/practice/intro-y-objetos",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -5279,7 +5279,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/practice/intro-y-objetos"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Introducción y Elementos Básicos de la OO: preguntas de Deseño de Software\",\"url\":\"https://pe.pablopl.dev/es/deese/practice/intro-y-objetos\",\"inLanguage\":\"es\",\"description\":\"Practica 12 preguntas de Introducción y Elementos Básicos de la OO de exámenes anteriores de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Introducción y Elementos Básicos de la OO\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/es/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Introducción y Elementos Básicos de la OO\",\"item\":\"https://pe.pablopl.dev/es/deese/practice/intro-y-objetos\"}],\"url\":\"https://pe.pablopl.dev/es/deese/practice/intro-y-objetos\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Introducción y Elementos Básicos de la OO: preguntas de Deseño de Software\",\"url\":\"https://pe.pablopl.dev/es/deese/practice/intro-y-objetos\",\"inLanguage\":\"es\",\"description\":\"Practica 12 preguntas de Introducción y Elementos Básicos de la OO de \\\"exámenes\\\" anteriores de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Introducción y Elementos Básicos de la OO\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/es/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Introducción y Elementos Básicos de la OO\",\"item\":\"https://pe.pablopl.dev/es/deese/practice/intro-y-objetos\"}],\"url\":\"https://pe.pablopl.dev/es/deese/practice/intro-y-objetos\"}]}"
   },
   {
     "url": "seo/es/deese/practice/propiedades-oo.html",
@@ -5287,7 +5287,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/deese/practice/propiedades-oo",
     "title": "Propiedades Básicas de la OO: preguntas de Deseño de Software",
-    "description": "Practica 11 preguntas de Propiedades Básicas de la OO de exámenes anteriores de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.",
+    "description": "Practica 11 preguntas de Propiedades Básicas de la OO de \"exámenes\" anteriores de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/deese/practice/propiedades-oo",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -5311,7 +5311,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/practice/propiedades-oo"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Propiedades Básicas de la OO: preguntas de Deseño de Software\",\"url\":\"https://pe.pablopl.dev/es/deese/practice/propiedades-oo\",\"inLanguage\":\"es\",\"description\":\"Practica 11 preguntas de Propiedades Básicas de la OO de exámenes anteriores de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Propiedades Básicas de la OO\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/es/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Propiedades Básicas de la OO\",\"item\":\"https://pe.pablopl.dev/es/deese/practice/propiedades-oo\"}],\"url\":\"https://pe.pablopl.dev/es/deese/practice/propiedades-oo\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Propiedades Básicas de la OO: preguntas de Deseño de Software\",\"url\":\"https://pe.pablopl.dev/es/deese/practice/propiedades-oo\",\"inLanguage\":\"es\",\"description\":\"Practica 11 preguntas de Propiedades Básicas de la OO de \\\"exámenes\\\" anteriores de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Propiedades Básicas de la OO\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/es/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Propiedades Básicas de la OO\",\"item\":\"https://pe.pablopl.dev/es/deese/practice/propiedades-oo\"}],\"url\":\"https://pe.pablopl.dev/es/deese/practice/propiedades-oo\"}]}"
   },
   {
     "url": "seo/es/deese/practice/uml.html",
@@ -5319,7 +5319,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/deese/practice/uml",
     "title": "UML: preguntas de Deseño de Software | Pásame Exámenes",
-    "description": "Practica 10 preguntas de UML de exámenes anteriores de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.",
+    "description": "Practica 10 preguntas de UML de \"exámenes\" anteriores de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/deese/practice/uml",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -5343,7 +5343,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/practice/uml"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"UML: preguntas de Deseño de Software | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/deese/practice/uml\",\"inLanguage\":\"es\",\"description\":\"Practica 10 preguntas de UML de exámenes anteriores de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"UML\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/es/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"UML\",\"item\":\"https://pe.pablopl.dev/es/deese/practice/uml\"}],\"url\":\"https://pe.pablopl.dev/es/deese/practice/uml\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"UML: preguntas de Deseño de Software | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/deese/practice/uml\",\"inLanguage\":\"es\",\"description\":\"Practica 10 preguntas de UML de \\\"exámenes\\\" anteriores de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"UML\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/es/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"UML\",\"item\":\"https://pe.pablopl.dev/es/deese/practice/uml\"}],\"url\":\"https://pe.pablopl.dev/es/deese/practice/uml\"}]}"
   },
   {
     "url": "seo/es/deese/practice/principios-diseno.html",
@@ -5351,7 +5351,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/deese/practice/principios-diseno",
     "title": "Principios de Diseño: preguntas de Deseño de Software",
-    "description": "Practica 12 preguntas de Principios de Diseño de exámenes anteriores de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.",
+    "description": "Practica 12 preguntas de Principios de Diseño de \"exámenes\" anteriores de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/deese/practice/principios-diseno",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -5375,7 +5375,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/practice/principios-diseno"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Principios de Diseño: preguntas de Deseño de Software\",\"url\":\"https://pe.pablopl.dev/es/deese/practice/principios-diseno\",\"inLanguage\":\"es\",\"description\":\"Practica 12 preguntas de Principios de Diseño de exámenes anteriores de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Principios de Diseño\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/es/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Principios de Diseño\",\"item\":\"https://pe.pablopl.dev/es/deese/practice/principios-diseno\"}],\"url\":\"https://pe.pablopl.dev/es/deese/practice/principios-diseno\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Principios de Diseño: preguntas de Deseño de Software\",\"url\":\"https://pe.pablopl.dev/es/deese/practice/principios-diseno\",\"inLanguage\":\"es\",\"description\":\"Practica 12 preguntas de Principios de Diseño de \\\"exámenes\\\" anteriores de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Principios de Diseño\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/es/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Principios de Diseño\",\"item\":\"https://pe.pablopl.dev/es/deese/practice/principios-diseno\"}],\"url\":\"https://pe.pablopl.dev/es/deese/practice/principios-diseno\"}]}"
   },
   {
     "url": "seo/es/deese/practice/patrones-diseno.html",
@@ -5383,7 +5383,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/deese/practice/patrones-diseno",
     "title": "Patrones de Diseño: preguntas de Deseño de Software",
-    "description": "Practica 10 preguntas de Patrones de Diseño de exámenes anteriores de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.",
+    "description": "Practica 10 preguntas de Patrones de Diseño de \"exámenes\" anteriores de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/deese/practice/patrones-diseno",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -5407,15 +5407,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/practice/patrones-diseno"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Patrones de Diseño: preguntas de Deseño de Software\",\"url\":\"https://pe.pablopl.dev/es/deese/practice/patrones-diseno\",\"inLanguage\":\"es\",\"description\":\"Practica 10 preguntas de Patrones de Diseño de exámenes anteriores de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Patrones de Diseño\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/es/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Patrones de Diseño\",\"item\":\"https://pe.pablopl.dev/es/deese/practice/patrones-diseno\"}],\"url\":\"https://pe.pablopl.dev/es/deese/practice/patrones-diseno\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Patrones de Diseño: preguntas de Deseño de Software\",\"url\":\"https://pe.pablopl.dev/es/deese/practice/patrones-diseno\",\"inLanguage\":\"es\",\"description\":\"Practica 10 preguntas de Patrones de Diseño de \\\"exámenes\\\" anteriores de Deseño de Software, con respuestas modelo y autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Patrones de Diseño\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/es/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Patrones de Diseño\",\"item\":\"https://pe.pablopl.dev/es/deese/practice/patrones-diseno\"}],\"url\":\"https://pe.pablopl.dev/es/deese/practice/patrones-diseno\"}]}"
   },
   {
     "url": "seo/es/deese/exam/2020-01.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/deese/exam/2020-01",
-    "title": "Enero 2020 de Deseño de Software: simulador | Pásame Exámenes",
-    "description": "Simula el examen Enero 2020 de Deseño de Software con 30 preguntas. 30 puntos, 150 minutos, respuestas modelo y autocorrección.",
+    "title": "Posibles preguntas Enero 2020 de Deseño de Software: simulador",
+    "description": "Simula el examen Posibles preguntas Enero 2020 de Deseño de Software con 30 preguntas. 30 puntos, 150 minutos, respuestas modelo y autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/deese/exam/2020-01",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -5439,15 +5439,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/exam/2020-01"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Enero 2020 de Deseño de Software: simulador | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/deese/exam/2020-01\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Enero 2020 de Deseño de Software con 30 preguntas. 30 puntos, 150 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/es/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Enero 2020\",\"item\":\"https://pe.pablopl.dev/es/deese/exam/2020-01\"}],\"url\":\"https://pe.pablopl.dev/es/deese/exam/2020-01\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Enero 2020 de Deseño de Software: simulador\",\"url\":\"https://pe.pablopl.dev/es/deese/exam/2020-01\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Posibles preguntas Enero 2020 de Deseño de Software con 30 preguntas. 30 puntos, 150 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/es/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Enero 2020\",\"item\":\"https://pe.pablopl.dev/es/deese/exam/2020-01\"}],\"url\":\"https://pe.pablopl.dev/es/deese/exam/2020-01\"}]}"
   },
   {
     "url": "seo/es/deese/exam/2022-01.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/deese/exam/2022-01",
-    "title": "Enero 2022 de Deseño de Software: simulador | Pásame Exámenes",
-    "description": "Simula el examen Enero 2022 de Deseño de Software con 25 preguntas. 25 puntos, 150 minutos, respuestas modelo y autocorrección.",
+    "title": "Posibles preguntas Enero 2022 de Deseño de Software: simulador",
+    "description": "Simula el examen Posibles preguntas Enero 2022 de Deseño de Software con 25 preguntas. 25 puntos, 150 minutos, respuestas modelo y autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/deese/exam/2022-01",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -5471,15 +5471,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/exam/2022-01"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Enero 2022 de Deseño de Software: simulador | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/deese/exam/2022-01\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Enero 2022 de Deseño de Software con 25 preguntas. 25 puntos, 150 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/es/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Enero 2022\",\"item\":\"https://pe.pablopl.dev/es/deese/exam/2022-01\"}],\"url\":\"https://pe.pablopl.dev/es/deese/exam/2022-01\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Enero 2022 de Deseño de Software: simulador\",\"url\":\"https://pe.pablopl.dev/es/deese/exam/2022-01\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Posibles preguntas Enero 2022 de Deseño de Software con 25 preguntas. 25 puntos, 150 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/es/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Enero 2022\",\"item\":\"https://pe.pablopl.dev/es/deese/exam/2022-01\"}],\"url\":\"https://pe.pablopl.dev/es/deese/exam/2022-01\"}]}"
   },
   {
     "url": "seo/es/ece.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/ece",
-    "title": "Estrutura de Computadores: exámenes y preguntas resueltas",
-    "description": "Practica 51 preguntas de Estrutura de Computadores de 11 exámenes anteriores con respuestas modelo y autocorrección. 202314, Universidade da Coruña.",
+    "title": "Estrutura de Computadores: \"exámenes\" y preguntas resueltas",
+    "description": "Practica 51 preguntas de Estrutura de Computadores de 11 \"exámenes\" anteriores con respuestas modelo y autocorrección. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/ece",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -5503,7 +5503,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Estrutura de Computadores: exámenes y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/ece\",\"inLanguage\":\"es\",\"description\":\"Practica 51 preguntas de Estrutura de Computadores de 11 exámenes anteriores con respuestas modelo y autocorrección. 202314, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/es/ece\"}],\"url\":\"https://pe.pablopl.dev/es/ece\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Estrutura de Computadores: \\\"exámenes\\\" y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/ece\",\"inLanguage\":\"es\",\"description\":\"Practica 51 preguntas de Estrutura de Computadores de 11 \\\"exámenes\\\" anteriores con respuestas modelo y autocorrección. 202314, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/es/ece\"}],\"url\":\"https://pe.pablopl.dev/es/ece\"}]}"
   },
   {
     "url": "seo/es/ece/practice/rendimiento.html",
@@ -5511,7 +5511,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/ece/practice/rendimiento",
     "title": "Rendimiento: preguntas de Estrutura de Computadores",
-    "description": "Practica 7 preguntas de Rendimiento de exámenes anteriores de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.",
+    "description": "Practica 7 preguntas de Rendimiento de \"exámenes\" anteriores de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/ece/practice/rendimiento",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -5535,7 +5535,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece/practice/rendimiento"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Rendimiento: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/es/ece/practice/rendimiento\",\"inLanguage\":\"es\",\"description\":\"Practica 7 preguntas de Rendimiento de exámenes anteriores de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Rendimiento\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/es/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Rendimiento\",\"item\":\"https://pe.pablopl.dev/es/ece/practice/rendimiento\"}],\"url\":\"https://pe.pablopl.dev/es/ece/practice/rendimiento\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Rendimiento: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/es/ece/practice/rendimiento\",\"inLanguage\":\"es\",\"description\":\"Practica 7 preguntas de Rendimiento de \\\"exámenes\\\" anteriores de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Rendimiento\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/es/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Rendimiento\",\"item\":\"https://pe.pablopl.dev/es/ece/practice/rendimiento\"}],\"url\":\"https://pe.pablopl.dev/es/ece/practice/rendimiento\"}]}"
   },
   {
     "url": "seo/es/ece/practice/segmentacion.html",
@@ -5543,7 +5543,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/ece/practice/segmentacion",
     "title": "Segmentación: preguntas de Estrutura de Computadores",
-    "description": "Practica 7 preguntas de Segmentación de exámenes anteriores de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.",
+    "description": "Practica 7 preguntas de Segmentación de \"exámenes\" anteriores de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/ece/practice/segmentacion",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -5567,7 +5567,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece/practice/segmentacion"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Segmentación: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/es/ece/practice/segmentacion\",\"inLanguage\":\"es\",\"description\":\"Practica 7 preguntas de Segmentación de exámenes anteriores de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Segmentación\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/es/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Segmentación\",\"item\":\"https://pe.pablopl.dev/es/ece/practice/segmentacion\"}],\"url\":\"https://pe.pablopl.dev/es/ece/practice/segmentacion\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Segmentación: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/es/ece/practice/segmentacion\",\"inLanguage\":\"es\",\"description\":\"Practica 7 preguntas de Segmentación de \\\"exámenes\\\" anteriores de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Segmentación\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/es/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Segmentación\",\"item\":\"https://pe.pablopl.dev/es/ece/practice/segmentacion\"}],\"url\":\"https://pe.pablopl.dev/es/ece/practice/segmentacion\"}]}"
   },
   {
     "url": "seo/es/ece/practice/cache.html",
@@ -5575,7 +5575,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/ece/practice/cache",
     "title": "Memoria caché: preguntas de Estrutura de Computadores",
-    "description": "Practica 7 preguntas de Memoria caché de exámenes anteriores de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.",
+    "description": "Practica 7 preguntas de Memoria caché de \"exámenes\" anteriores de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/ece/practice/cache",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -5599,7 +5599,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece/practice/cache"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Memoria caché: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/es/ece/practice/cache\",\"inLanguage\":\"es\",\"description\":\"Practica 7 preguntas de Memoria caché de exámenes anteriores de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Memoria caché\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/es/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Memoria caché\",\"item\":\"https://pe.pablopl.dev/es/ece/practice/cache\"}],\"url\":\"https://pe.pablopl.dev/es/ece/practice/cache\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Memoria caché: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/es/ece/practice/cache\",\"inLanguage\":\"es\",\"description\":\"Practica 7 preguntas de Memoria caché de \\\"exámenes\\\" anteriores de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Memoria caché\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/es/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Memoria caché\",\"item\":\"https://pe.pablopl.dev/es/ece/practice/cache\"}],\"url\":\"https://pe.pablopl.dev/es/ece/practice/cache\"}]}"
   },
   {
     "url": "seo/es/ece/practice/memoria-virtual.html",
@@ -5607,7 +5607,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/ece/practice/memoria-virtual",
     "title": "Memoria virtual: preguntas de Estrutura de Computadores",
-    "description": "Practica 11 preguntas de Memoria virtual de exámenes anteriores de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.",
+    "description": "Practica 11 preguntas de Memoria virtual de \"exámenes\" anteriores de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/ece/practice/memoria-virtual",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -5631,7 +5631,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece/practice/memoria-virtual"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Memoria virtual: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/es/ece/practice/memoria-virtual\",\"inLanguage\":\"es\",\"description\":\"Practica 11 preguntas de Memoria virtual de exámenes anteriores de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Memoria virtual\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/es/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Memoria virtual\",\"item\":\"https://pe.pablopl.dev/es/ece/practice/memoria-virtual\"}],\"url\":\"https://pe.pablopl.dev/es/ece/practice/memoria-virtual\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Memoria virtual: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/es/ece/practice/memoria-virtual\",\"inLanguage\":\"es\",\"description\":\"Practica 11 preguntas de Memoria virtual de \\\"exámenes\\\" anteriores de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Memoria virtual\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/es/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Memoria virtual\",\"item\":\"https://pe.pablopl.dev/es/ece/practice/memoria-virtual\"}],\"url\":\"https://pe.pablopl.dev/es/ece/practice/memoria-virtual\"}]}"
   },
   {
     "url": "seo/es/ece/practice/buses.html",
@@ -5639,7 +5639,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/ece/practice/buses",
     "title": "Buses y E/S: preguntas de Estrutura de Computadores",
-    "description": "Practica 11 preguntas de Buses y E/S de exámenes anteriores de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.",
+    "description": "Practica 11 preguntas de Buses y E/S de \"exámenes\" anteriores de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/ece/practice/buses",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -5663,7 +5663,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece/practice/buses"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Buses y E/S: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/es/ece/practice/buses\",\"inLanguage\":\"es\",\"description\":\"Practica 11 preguntas de Buses y E/S de exámenes anteriores de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Buses y E/S\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/es/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Buses y E/S\",\"item\":\"https://pe.pablopl.dev/es/ece/practice/buses\"}],\"url\":\"https://pe.pablopl.dev/es/ece/practice/buses\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Buses y E/S: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/es/ece/practice/buses\",\"inLanguage\":\"es\",\"description\":\"Practica 11 preguntas de Buses y E/S de \\\"exámenes\\\" anteriores de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Buses y E/S\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/es/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Buses y E/S\",\"item\":\"https://pe.pablopl.dev/es/ece/practice/buses\"}],\"url\":\"https://pe.pablopl.dev/es/ece/practice/buses\"}]}"
   },
   {
     "url": "seo/es/ece/practice/raid.html",
@@ -5671,7 +5671,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/ece/practice/raid",
     "title": "RAID y almacenamiento: preguntas de Estrutura de Computadores",
-    "description": "Practica 8 preguntas de RAID y almacenamiento de exámenes anteriores de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.",
+    "description": "Practica 8 preguntas de RAID y almacenamiento de \"exámenes\" anteriores de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/ece/practice/raid",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -5695,7 +5695,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece/practice/raid"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"RAID y almacenamiento: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/es/ece/practice/raid\",\"inLanguage\":\"es\",\"description\":\"Practica 8 preguntas de RAID y almacenamiento de exámenes anteriores de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"RAID y almacenamiento\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/es/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"RAID y almacenamiento\",\"item\":\"https://pe.pablopl.dev/es/ece/practice/raid\"}],\"url\":\"https://pe.pablopl.dev/es/ece/practice/raid\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"RAID y almacenamiento: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/es/ece/practice/raid\",\"inLanguage\":\"es\",\"description\":\"Practica 8 preguntas de RAID y almacenamiento de \\\"exámenes\\\" anteriores de Estrutura de Computadores, con respuestas modelo y autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"RAID y almacenamiento\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/es/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"RAID y almacenamiento\",\"item\":\"https://pe.pablopl.dev/es/ece/practice/raid\"}],\"url\":\"https://pe.pablopl.dev/es/ece/practice/raid\"}]}"
   },
   {
     "url": "seo/es/ece/exam/2021-01.html",
@@ -6054,8 +6054,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/emeele",
-    "title": "Introduction to Machine Learning: exámenes y preguntas resueltas",
-    "description": "Practica 47 preguntas de Introduction to Machine Learning de 2 exámenes anteriores con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
+    "title": "Introduction to Machine Learning: \"exámenes\" y preguntas resueltas",
+    "description": "Practica 47 preguntas de Introduction to Machine Learning de 2 \"exámenes\" anteriores con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/emeele",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -6079,7 +6079,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Introduction to Machine Learning: exámenes y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/emeele\",\"inLanguage\":\"es\",\"description\":\"Practica 47 preguntas de Introduction to Machine Learning de 2 exámenes anteriores con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Linnaeus University\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"}],\"url\":\"https://pe.pablopl.dev/es/emeele\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Introduction to Machine Learning: \\\"exámenes\\\" y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/emeele\",\"inLanguage\":\"es\",\"description\":\"Practica 47 preguntas de Introduction to Machine Learning de 2 \\\"exámenes\\\" anteriores con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Linnaeus University\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"}],\"url\":\"https://pe.pablopl.dev/es/emeele\"}]}"
   },
   {
     "url": "seo/es/emeele/practice/kNN.html",
@@ -6087,7 +6087,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/emeele/practice/kNN",
     "title": "k-Nearest Neighbors: preguntas de Introduction to Machine Learning",
-    "description": "Practica 6 preguntas de k-Nearest Neighbors de exámenes anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
+    "description": "Practica 6 preguntas de k-Nearest Neighbors de \"exámenes\" anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/emeele/practice/kNN",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -6111,7 +6111,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/kNN"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"k-Nearest Neighbors: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/es/emeele/practice/kNN\",\"inLanguage\":\"es\",\"description\":\"Practica 6 preguntas de k-Nearest Neighbors de exámenes anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"k-Nearest Neighbors\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"k-Nearest Neighbors\",\"item\":\"https://pe.pablopl.dev/es/emeele/practice/kNN\"}],\"url\":\"https://pe.pablopl.dev/es/emeele/practice/kNN\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"k-Nearest Neighbors: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/es/emeele/practice/kNN\",\"inLanguage\":\"es\",\"description\":\"Practica 6 preguntas de k-Nearest Neighbors de \\\"exámenes\\\" anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"k-Nearest Neighbors\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"k-Nearest Neighbors\",\"item\":\"https://pe.pablopl.dev/es/emeele/practice/kNN\"}],\"url\":\"https://pe.pablopl.dev/es/emeele/practice/kNN\"}]}"
   },
   {
     "url": "seo/es/emeele/practice/Bias-Variance.html",
@@ -6119,7 +6119,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/emeele/practice/Bias-Variance",
     "title": "Bias-Variance Tradeoff: preguntas de Introduction to Machine Learning",
-    "description": "Practica 5 preguntas de Bias-Variance Tradeoff de exámenes anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
+    "description": "Practica 5 preguntas de Bias-Variance Tradeoff de \"exámenes\" anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/emeele/practice/Bias-Variance",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -6143,7 +6143,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Bias-Variance"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Bias-Variance Tradeoff: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Bias-Variance\",\"inLanguage\":\"es\",\"description\":\"Practica 5 preguntas de Bias-Variance Tradeoff de exámenes anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Bias-Variance Tradeoff\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Bias-Variance Tradeoff\",\"item\":\"https://pe.pablopl.dev/es/emeele/practice/Bias-Variance\"}],\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Bias-Variance\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Bias-Variance Tradeoff: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Bias-Variance\",\"inLanguage\":\"es\",\"description\":\"Practica 5 preguntas de Bias-Variance Tradeoff de \\\"exámenes\\\" anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Bias-Variance Tradeoff\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Bias-Variance Tradeoff\",\"item\":\"https://pe.pablopl.dev/es/emeele/practice/Bias-Variance\"}],\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Bias-Variance\"}]}"
   },
   {
     "url": "seo/es/emeele/practice/Linear%20%26%20Logistic%20Regression.html",
@@ -6151,7 +6151,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/emeele/practice/Linear & Logistic Regression",
     "title": "Linear & Logistic Regression: preguntas de Introduction to Machine Learning",
-    "description": "Practica 5 preguntas de Linear & Logistic Regression de exámenes anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
+    "description": "Practica 5 preguntas de Linear & Logistic Regression de \"exámenes\" anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/emeele/practice/Linear%20%26%20Logistic%20Regression",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -6175,7 +6175,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Linear%20%26%20Logistic%20Regression"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Linear & Logistic Regression: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Linear%20%26%20Logistic%20Regression\",\"inLanguage\":\"es\",\"description\":\"Practica 5 preguntas de Linear & Logistic Regression de exámenes anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Linear & Logistic Regression\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Linear & Logistic Regression\",\"item\":\"https://pe.pablopl.dev/es/emeele/practice/Linear%20%26%20Logistic%20Regression\"}],\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Linear%20%26%20Logistic%20Regression\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Linear & Logistic Regression: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Linear%20%26%20Logistic%20Regression\",\"inLanguage\":\"es\",\"description\":\"Practica 5 preguntas de Linear & Logistic Regression de \\\"exámenes\\\" anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Linear & Logistic Regression\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Linear & Logistic Regression\",\"item\":\"https://pe.pablopl.dev/es/emeele/practice/Linear%20%26%20Logistic%20Regression\"}],\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Linear%20%26%20Logistic%20Regression\"}]}"
   },
   {
     "url": "seo/es/emeele/practice/Model%20Selection%20%26%20Regularization.html",
@@ -6183,7 +6183,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/emeele/practice/Model Selection & Regularization",
     "title": "Model Selection & Regularization: preguntas de Introduction to Machine Learning",
-    "description": "Practica 5 preguntas de Model Selection & Regularization de exámenes anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
+    "description": "Practica 5 preguntas de Model Selection & Regularization de \"exámenes\" anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/emeele/practice/Model%20Selection%20%26%20Regularization",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -6207,7 +6207,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Model%20Selection%20%26%20Regularization"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Model Selection & Regularization: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Model%20Selection%20%26%20Regularization\",\"inLanguage\":\"es\",\"description\":\"Practica 5 preguntas de Model Selection & Regularization de exámenes anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Model Selection & Regularization\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Model Selection & Regularization\",\"item\":\"https://pe.pablopl.dev/es/emeele/practice/Model%20Selection%20%26%20Regularization\"}],\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Model%20Selection%20%26%20Regularization\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Model Selection & Regularization: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Model%20Selection%20%26%20Regularization\",\"inLanguage\":\"es\",\"description\":\"Practica 5 preguntas de Model Selection & Regularization de \\\"exámenes\\\" anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Model Selection & Regularization\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Model Selection & Regularization\",\"item\":\"https://pe.pablopl.dev/es/emeele/practice/Model%20Selection%20%26%20Regularization\"}],\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Model%20Selection%20%26%20Regularization\"}]}"
   },
   {
     "url": "seo/es/emeele/practice/Neural%20Networks.html",
@@ -6215,7 +6215,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/emeele/practice/Neural Networks",
     "title": "Neural Networks: preguntas de Introduction to Machine Learning",
-    "description": "Practica 6 preguntas de Neural Networks de exámenes anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
+    "description": "Practica 6 preguntas de Neural Networks de \"exámenes\" anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/emeele/practice/Neural%20Networks",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -6239,7 +6239,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Neural%20Networks"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Neural Networks: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Neural%20Networks\",\"inLanguage\":\"es\",\"description\":\"Practica 6 preguntas de Neural Networks de exámenes anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Neural Networks\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Neural Networks\",\"item\":\"https://pe.pablopl.dev/es/emeele/practice/Neural%20Networks\"}],\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Neural%20Networks\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Neural Networks: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Neural%20Networks\",\"inLanguage\":\"es\",\"description\":\"Practica 6 preguntas de Neural Networks de \\\"exámenes\\\" anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Neural Networks\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Neural Networks\",\"item\":\"https://pe.pablopl.dev/es/emeele/practice/Neural%20Networks\"}],\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Neural%20Networks\"}]}"
   },
   {
     "url": "seo/es/emeele/practice/Decision%20Trees%20%26%20Ensembles.html",
@@ -6247,7 +6247,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/emeele/practice/Decision Trees & Ensembles",
     "title": "Decision Trees & Ensembles: preguntas de Introduction to Machine Learning",
-    "description": "Practica 4 preguntas de Decision Trees & Ensembles de exámenes anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
+    "description": "Practica 4 preguntas de Decision Trees & Ensembles de \"exámenes\" anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/emeele/practice/Decision%20Trees%20%26%20Ensembles",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -6271,7 +6271,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Decision%20Trees%20%26%20Ensembles"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Decision Trees & Ensembles: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Decision%20Trees%20%26%20Ensembles\",\"inLanguage\":\"es\",\"description\":\"Practica 4 preguntas de Decision Trees & Ensembles de exámenes anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Decision Trees & Ensembles\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Decision Trees & Ensembles\",\"item\":\"https://pe.pablopl.dev/es/emeele/practice/Decision%20Trees%20%26%20Ensembles\"}],\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Decision%20Trees%20%26%20Ensembles\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Decision Trees & Ensembles: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Decision%20Trees%20%26%20Ensembles\",\"inLanguage\":\"es\",\"description\":\"Practica 4 preguntas de Decision Trees & Ensembles de \\\"exámenes\\\" anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Decision Trees & Ensembles\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Decision Trees & Ensembles\",\"item\":\"https://pe.pablopl.dev/es/emeele/practice/Decision%20Trees%20%26%20Ensembles\"}],\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Decision%20Trees%20%26%20Ensembles\"}]}"
   },
   {
     "url": "seo/es/emeele/practice/Support%20Vector%20Machines.html",
@@ -6279,7 +6279,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/emeele/practice/Support Vector Machines",
     "title": "Support Vector Machines: preguntas de Introduction to Machine Learning",
-    "description": "Practica 6 preguntas de Support Vector Machines de exámenes anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
+    "description": "Practica 6 preguntas de Support Vector Machines de \"exámenes\" anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/emeele/practice/Support%20Vector%20Machines",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -6303,7 +6303,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Support%20Vector%20Machines"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Support Vector Machines: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Support%20Vector%20Machines\",\"inLanguage\":\"es\",\"description\":\"Practica 6 preguntas de Support Vector Machines de exámenes anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Support Vector Machines\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Support Vector Machines\",\"item\":\"https://pe.pablopl.dev/es/emeele/practice/Support%20Vector%20Machines\"}],\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Support%20Vector%20Machines\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Support Vector Machines: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Support%20Vector%20Machines\",\"inLanguage\":\"es\",\"description\":\"Practica 6 preguntas de Support Vector Machines de \\\"exámenes\\\" anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Support Vector Machines\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Support Vector Machines\",\"item\":\"https://pe.pablopl.dev/es/emeele/practice/Support%20Vector%20Machines\"}],\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Support%20Vector%20Machines\"}]}"
   },
   {
     "url": "seo/es/emeele/practice/Clustering.html",
@@ -6311,7 +6311,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/emeele/practice/Clustering",
     "title": "Clustering: preguntas de Introduction to Machine Learning",
-    "description": "Practica 6 preguntas de Clustering de exámenes anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
+    "description": "Practica 6 preguntas de Clustering de \"exámenes\" anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/emeele/practice/Clustering",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -6335,7 +6335,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Clustering"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Clustering: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Clustering\",\"inLanguage\":\"es\",\"description\":\"Practica 6 preguntas de Clustering de exámenes anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Clustering\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Clustering\",\"item\":\"https://pe.pablopl.dev/es/emeele/practice/Clustering\"}],\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Clustering\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Clustering: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Clustering\",\"inLanguage\":\"es\",\"description\":\"Practica 6 preguntas de Clustering de \\\"exámenes\\\" anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Clustering\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Clustering\",\"item\":\"https://pe.pablopl.dev/es/emeele/practice/Clustering\"}],\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Clustering\"}]}"
   },
   {
     "url": "seo/es/emeele/practice/Dimensionality%20Reduction.html",
@@ -6343,7 +6343,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/emeele/practice/Dimensionality Reduction",
     "title": "Dimensionality Reduction: preguntas de Introduction to Machine Learning",
-    "description": "Practica 4 preguntas de Dimensionality Reduction de exámenes anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
+    "description": "Practica 4 preguntas de Dimensionality Reduction de \"exámenes\" anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/emeele/practice/Dimensionality%20Reduction",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -6367,7 +6367,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Dimensionality%20Reduction"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Dimensionality Reduction: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Dimensionality%20Reduction\",\"inLanguage\":\"es\",\"description\":\"Practica 4 preguntas de Dimensionality Reduction de exámenes anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Dimensionality Reduction\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Dimensionality Reduction\",\"item\":\"https://pe.pablopl.dev/es/emeele/practice/Dimensionality%20Reduction\"}],\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Dimensionality%20Reduction\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Dimensionality Reduction: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Dimensionality%20Reduction\",\"inLanguage\":\"es\",\"description\":\"Practica 4 preguntas de Dimensionality Reduction de \\\"exámenes\\\" anteriores de Introduction to Machine Learning, con respuestas modelo y autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Dimensionality Reduction\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/es/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Dimensionality Reduction\",\"item\":\"https://pe.pablopl.dev/es/emeele/practice/Dimensionality%20Reduction\"}],\"url\":\"https://pe.pablopl.dev/es/emeele/practice/Dimensionality%20Reduction\"}]}"
   },
   {
     "url": "seo/es/emeele/exam/2024.html",
@@ -6438,8 +6438,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/equisi",
-    "title": "Xestión de Infraestruturas: exámenes y preguntas resueltas",
-    "description": "Practica 381 preguntas de Xestión de Infraestruturas de 4 exámenes anteriores con respuestas modelo y autocorrección. 200190, Universidade da Coruña.",
+    "title": "Xestión de Infraestruturas: \"exámenes\" y preguntas resueltas",
+    "description": "Practica 381 preguntas de Xestión de Infraestruturas de 4 \"exámenes\" anteriores con respuestas modelo y autocorrección. 200190, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/equisi",
     "ogImage": "https://pe.pablopl.dev/og/equisi.png",
@@ -6463,7 +6463,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equisi"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Xestión de Infraestruturas: exámenes y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/equisi\",\"inLanguage\":\"es\",\"description\":\"Practica 381 preguntas de Xestión de Infraestruturas de 4 exámenes anteriores con respuestas modelo y autocorrección. 200190, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/es/equisi\"}],\"url\":\"https://pe.pablopl.dev/es/equisi\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Xestión de Infraestruturas: \\\"exámenes\\\" y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/equisi\",\"inLanguage\":\"es\",\"description\":\"Practica 381 preguntas de Xestión de Infraestruturas de 4 \\\"exámenes\\\" anteriores con respuestas modelo y autocorrección. 200190, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/es/equisi\"}],\"url\":\"https://pe.pablopl.dev/es/equisi\"}]}"
   },
   {
     "url": "seo/es/equisi/practice/modulo-i.html",
@@ -6471,7 +6471,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/equisi/practice/modulo-i",
     "title": "Módulo I: Sinais e Comunicacións: preguntas de Xestión de Infraestruturas",
-    "description": "Practica 130 preguntas de Módulo I: Sinais e Comunicacións de exámenes anteriores de Xestión de Infraestruturas, con respuestas modelo y autocorrección. 200190, Universidade da Coruña.",
+    "description": "Practica 130 preguntas de Módulo I: Sinais e Comunicacións de \"exámenes\" anteriores de Xestión de Infraestruturas, con respuestas modelo y autocorrección. 200190, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/equisi/practice/modulo-i",
     "ogImage": "https://pe.pablopl.dev/og/equisi.png",
@@ -6495,7 +6495,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equisi/practice/modulo-i"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Módulo I: Sinais e Comunicacións: preguntas de Xestión de Infraestruturas\",\"url\":\"https://pe.pablopl.dev/es/equisi/practice/modulo-i\",\"inLanguage\":\"es\",\"description\":\"Practica 130 preguntas de Módulo I: Sinais e Comunicacións de exámenes anteriores de Xestión de Infraestruturas, con respuestas modelo y autocorrección. 200190, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Módulo I: Sinais e Comunicacións\"},{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/es/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Módulo I: Sinais e Comunicacións\",\"item\":\"https://pe.pablopl.dev/es/equisi/practice/modulo-i\"}],\"url\":\"https://pe.pablopl.dev/es/equisi/practice/modulo-i\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Módulo I: Sinais e Comunicacións: preguntas de Xestión de Infraestruturas\",\"url\":\"https://pe.pablopl.dev/es/equisi/practice/modulo-i\",\"inLanguage\":\"es\",\"description\":\"Practica 130 preguntas de Módulo I: Sinais e Comunicacións de \\\"exámenes\\\" anteriores de Xestión de Infraestruturas, con respuestas modelo y autocorrección. 200190, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Módulo I: Sinais e Comunicacións\"},{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/es/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Módulo I: Sinais e Comunicacións\",\"item\":\"https://pe.pablopl.dev/es/equisi/practice/modulo-i\"}],\"url\":\"https://pe.pablopl.dev/es/equisi/practice/modulo-i\"}]}"
   },
   {
     "url": "seo/es/equisi/practice/modulo-ii.html",
@@ -6503,7 +6503,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/equisi/practice/modulo-ii",
     "title": "Módulo II: Infraestruturas TI: preguntas de Xestión de Infraestruturas",
-    "description": "Practica 251 preguntas de Módulo II: Infraestruturas TI de exámenes anteriores de Xestión de Infraestruturas, con respuestas modelo y autocorrección. 200190, Universidade da Coruña.",
+    "description": "Practica 251 preguntas de Módulo II: Infraestruturas TI de \"exámenes\" anteriores de Xestión de Infraestruturas, con respuestas modelo y autocorrección. 200190, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/equisi/practice/modulo-ii",
     "ogImage": "https://pe.pablopl.dev/og/equisi.png",
@@ -6527,15 +6527,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equisi/practice/modulo-ii"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Módulo II: Infraestruturas TI: preguntas de Xestión de Infraestruturas\",\"url\":\"https://pe.pablopl.dev/es/equisi/practice/modulo-ii\",\"inLanguage\":\"es\",\"description\":\"Practica 251 preguntas de Módulo II: Infraestruturas TI de exámenes anteriores de Xestión de Infraestruturas, con respuestas modelo y autocorrección. 200190, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Módulo II: Infraestruturas TI\"},{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/es/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Módulo II: Infraestruturas TI\",\"item\":\"https://pe.pablopl.dev/es/equisi/practice/modulo-ii\"}],\"url\":\"https://pe.pablopl.dev/es/equisi/practice/modulo-ii\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Módulo II: Infraestruturas TI: preguntas de Xestión de Infraestruturas\",\"url\":\"https://pe.pablopl.dev/es/equisi/practice/modulo-ii\",\"inLanguage\":\"es\",\"description\":\"Practica 251 preguntas de Módulo II: Infraestruturas TI de \\\"exámenes\\\" anteriores de Xestión de Infraestruturas, con respuestas modelo y autocorrección. 200190, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Módulo II: Infraestruturas TI\"},{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/es/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Módulo II: Infraestruturas TI\",\"item\":\"https://pe.pablopl.dev/es/equisi/practice/modulo-ii\"}],\"url\":\"https://pe.pablopl.dev/es/equisi/practice/modulo-ii\"}]}"
   },
   {
     "url": "seo/es/equisi/exam/2024-07.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/equisi/exam/2024-07",
-    "title": "Xullo 2024 de Xestión de Infraestruturas: simulador",
-    "description": "Simula el examen Xullo 2024 de Xestión de Infraestruturas con 20 preguntas. 10 puntos, 45 minutos, respuestas modelo y autocorrección.",
+    "title": "Posibles preguntas Xullo 2024 de Xestión de Infraestruturas: simulador",
+    "description": "Simula el examen Posibles preguntas Xullo 2024 de Xestión de Infraestruturas con 20 preguntas. 10 puntos, 45 minutos, respuestas modelo y autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/equisi/exam/2024-07",
     "ogImage": "https://pe.pablopl.dev/og/equisi.png",
@@ -6559,7 +6559,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equisi/exam/2024-07"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Xullo 2024 de Xestión de Infraestruturas: simulador\",\"url\":\"https://pe.pablopl.dev/es/equisi/exam/2024-07\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Xullo 2024 de Xestión de Infraestruturas con 20 preguntas. 10 puntos, 45 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/es/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Xullo 2024\",\"item\":\"https://pe.pablopl.dev/es/equisi/exam/2024-07\"}],\"url\":\"https://pe.pablopl.dev/es/equisi/exam/2024-07\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Xullo 2024 de Xestión de Infraestruturas: simulador\",\"url\":\"https://pe.pablopl.dev/es/equisi/exam/2024-07\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Posibles preguntas Xullo 2024 de Xestión de Infraestruturas con 20 preguntas. 10 puntos, 45 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/es/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Xullo 2024\",\"item\":\"https://pe.pablopl.dev/es/equisi/exam/2024-07\"}],\"url\":\"https://pe.pablopl.dev/es/equisi/exam/2024-07\"}]}"
   },
   {
     "url": "seo/es/equisi/exam/daypo-modulo-i.html",
@@ -6662,8 +6662,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/equispe",
-    "title": "Xestión de Proxectos: exámenes y preguntas resueltas",
-    "description": "Practica 175 preguntas de Xestión de Proxectos de 5 exámenes anteriores con respuestas modelo y autocorrección. 202323, Universidade da Coruña.",
+    "title": "Xestión de Proxectos: \"exámenes\" y preguntas resueltas",
+    "description": "Practica 175 preguntas de Xestión de Proxectos de 5 \"exámenes\" anteriores con respuestas modelo y autocorrección. 202323, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/equispe",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -6687,7 +6687,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Xestión de Proxectos: exámenes y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/equispe\",\"inLanguage\":\"es\",\"description\":\"Practica 175 preguntas de Xestión de Proxectos de 5 exámenes anteriores con respuestas modelo y autocorrección. 202323, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/es/equispe\"}],\"url\":\"https://pe.pablopl.dev/es/equispe\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Xestión de Proxectos: \\\"exámenes\\\" y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/equispe\",\"inLanguage\":\"es\",\"description\":\"Practica 175 preguntas de Xestión de Proxectos de 5 \\\"exámenes\\\" anteriores con respuestas modelo y autocorrección. 202323, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/es/equispe\"}],\"url\":\"https://pe.pablopl.dev/es/equispe\"}]}"
   },
   {
     "url": "seo/es/equispe/practice/teoria.html",
@@ -6695,7 +6695,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/equispe/practice/teoria",
     "title": "Teoría: preguntas de Xestión de Proxectos | Pásame Exámenes",
-    "description": "Practica 107 preguntas de Teoría de exámenes anteriores de Xestión de Proxectos, con respuestas modelo y autocorrección. 202323, Universidade da Coruña.",
+    "description": "Practica 107 preguntas de Teoría de \"exámenes\" anteriores de Xestión de Proxectos, con respuestas modelo y autocorrección. 202323, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/equispe/practice/teoria",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -6719,7 +6719,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe/practice/teoria"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Teoría: preguntas de Xestión de Proxectos | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/equispe/practice/teoria\",\"inLanguage\":\"es\",\"description\":\"Practica 107 preguntas de Teoría de exámenes anteriores de Xestión de Proxectos, con respuestas modelo y autocorrección. 202323, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Teoría\"},{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/es/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Teoría\",\"item\":\"https://pe.pablopl.dev/es/equispe/practice/teoria\"}],\"url\":\"https://pe.pablopl.dev/es/equispe/practice/teoria\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Teoría: preguntas de Xestión de Proxectos | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/equispe/practice/teoria\",\"inLanguage\":\"es\",\"description\":\"Practica 107 preguntas de Teoría de \\\"exámenes\\\" anteriores de Xestión de Proxectos, con respuestas modelo y autocorrección. 202323, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Teoría\"},{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/es/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Teoría\",\"item\":\"https://pe.pablopl.dev/es/equispe/practice/teoria\"}],\"url\":\"https://pe.pablopl.dev/es/equispe/practice/teoria\"}]}"
   },
   {
     "url": "seo/es/equispe/practice/practica.html",
@@ -6727,7 +6727,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/equispe/practice/practica",
     "title": "Práctica: preguntas de Xestión de Proxectos | Pásame Exámenes",
-    "description": "Practica 68 preguntas de Práctica de exámenes anteriores de Xestión de Proxectos, con respuestas modelo y autocorrección. 202323, Universidade da Coruña.",
+    "description": "Practica 68 preguntas de Práctica de \"exámenes\" anteriores de Xestión de Proxectos, con respuestas modelo y autocorrección. 202323, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/equispe/practice/practica",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -6751,15 +6751,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe/practice/practica"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Práctica: preguntas de Xestión de Proxectos | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/equispe/practice/practica\",\"inLanguage\":\"es\",\"description\":\"Practica 68 preguntas de Práctica de exámenes anteriores de Xestión de Proxectos, con respuestas modelo y autocorrección. 202323, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Práctica\"},{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/es/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Práctica\",\"item\":\"https://pe.pablopl.dev/es/equispe/practice/practica\"}],\"url\":\"https://pe.pablopl.dev/es/equispe/practice/practica\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Práctica: preguntas de Xestión de Proxectos | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/equispe/practice/practica\",\"inLanguage\":\"es\",\"description\":\"Practica 68 preguntas de Práctica de \\\"exámenes\\\" anteriores de Xestión de Proxectos, con respuestas modelo y autocorrección. 202323, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Práctica\"},{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/es/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Práctica\",\"item\":\"https://pe.pablopl.dev/es/equispe/practice/practica\"}],\"url\":\"https://pe.pablopl.dev/es/equispe/practice/practica\"}]}"
   },
   {
     "url": "seo/es/equispe/exam/2024-01.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/equispe/exam/2024-01",
-    "title": "Xaneiro 2024 de Xestión de Proxectos: simulador",
-    "description": "Simula el examen Xaneiro 2024 de Xestión de Proxectos con 7 preguntas. 10 puntos, 120 minutos, respuestas modelo y autocorrección.",
+    "title": "Posibles preguntas Xaneiro 2024 de Xestión de Proxectos: simulador",
+    "description": "Simula el examen Posibles preguntas Xaneiro 2024 de Xestión de Proxectos con 7 preguntas. 10 puntos, 120 minutos, respuestas modelo y autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/equispe/exam/2024-01",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -6783,15 +6783,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe/exam/2024-01"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Xaneiro 2024 de Xestión de Proxectos: simulador\",\"url\":\"https://pe.pablopl.dev/es/equispe/exam/2024-01\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Xaneiro 2024 de Xestión de Proxectos con 7 preguntas. 10 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/es/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Xaneiro 2024\",\"item\":\"https://pe.pablopl.dev/es/equispe/exam/2024-01\"}],\"url\":\"https://pe.pablopl.dev/es/equispe/exam/2024-01\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Xaneiro 2024 de Xestión de Proxectos: simulador\",\"url\":\"https://pe.pablopl.dev/es/equispe/exam/2024-01\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Posibles preguntas Xaneiro 2024 de Xestión de Proxectos con 7 preguntas. 10 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/es/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Xaneiro 2024\",\"item\":\"https://pe.pablopl.dev/es/equispe/exam/2024-01\"}],\"url\":\"https://pe.pablopl.dev/es/equispe/exam/2024-01\"}]}"
   },
   {
     "url": "seo/es/equispe/exam/2026-01.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/equispe/exam/2026-01",
-    "title": "Xaneiro 2026 de Xestión de Proxectos: simulador",
-    "description": "Simula el examen Xaneiro 2026 de Xestión de Proxectos con 13 preguntas. 25 puntos, 180 minutos, respuestas modelo y autocorrección.",
+    "title": "Posibles preguntas Xaneiro 2026 de Xestión de Proxectos: simulador",
+    "description": "Simula el examen Posibles preguntas Xaneiro 2026 de Xestión de Proxectos con 13 preguntas. 25 puntos, 180 minutos, respuestas modelo y autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/equispe/exam/2026-01",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -6815,7 +6815,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe/exam/2026-01"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Xaneiro 2026 de Xestión de Proxectos: simulador\",\"url\":\"https://pe.pablopl.dev/es/equispe/exam/2026-01\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Xaneiro 2026 de Xestión de Proxectos con 13 preguntas. 25 puntos, 180 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/es/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Xaneiro 2026\",\"item\":\"https://pe.pablopl.dev/es/equispe/exam/2026-01\"}],\"url\":\"https://pe.pablopl.dev/es/equispe/exam/2026-01\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Xaneiro 2026 de Xestión de Proxectos: simulador\",\"url\":\"https://pe.pablopl.dev/es/equispe/exam/2026-01\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Posibles preguntas Xaneiro 2026 de Xestión de Proxectos con 13 preguntas. 25 puntos, 180 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/es/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Xaneiro 2026\",\"item\":\"https://pe.pablopl.dev/es/equispe/exam/2026-01\"}],\"url\":\"https://pe.pablopl.dev/es/equispe/exam/2026-01\"}]}"
   },
   {
     "url": "seo/es/equispe/exam/daypo-tipo-udc.html",
@@ -6918,8 +6918,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/esei",
-    "title": "Sistemas Intelixentes: exámenes y preguntas resueltas",
-    "description": "Practica 234 preguntas de Sistemas Intelixentes de 5 exámenes anteriores con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
+    "title": "Sistemas Intelixentes: \"exámenes\" y preguntas resueltas",
+    "description": "Practica 234 preguntas de Sistemas Intelixentes de 5 \"exámenes\" anteriores con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/esei",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -6943,7 +6943,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Sistemas Intelixentes: exámenes y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/esei\",\"inLanguage\":\"es\",\"description\":\"Practica 234 preguntas de Sistemas Intelixentes de 5 exámenes anteriores con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"}],\"url\":\"https://pe.pablopl.dev/es/esei\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Sistemas Intelixentes: \\\"exámenes\\\" y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/esei\",\"inLanguage\":\"es\",\"description\":\"Practica 234 preguntas de Sistemas Intelixentes de 5 \\\"exámenes\\\" anteriores con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"}],\"url\":\"https://pe.pablopl.dev/es/esei\"}]}"
   },
   {
     "url": "seo/es/esei/practice/t1.html",
@@ -6951,7 +6951,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/esei/practice/t1",
     "title": "Tema 1: Introducción: preguntas de Sistemas Intelixentes",
-    "description": "Practica 4 preguntas de Tema 1: Introducción de exámenes anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 4 preguntas de Tema 1: Introducción de \"exámenes\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/esei/practice/t1",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -6975,7 +6975,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t1"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 1: Introducción: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t1\",\"inLanguage\":\"es\",\"description\":\"Practica 4 preguntas de Tema 1: Introducción de exámenes anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 1: Introducción\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 1: Introducción\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t1\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t1\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 1: Introducción: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t1\",\"inLanguage\":\"es\",\"description\":\"Practica 4 preguntas de Tema 1: Introducción de \\\"exámenes\\\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 1: Introducción\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 1: Introducción\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t1\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t1\"}]}"
   },
   {
     "url": "seo/es/esei/practice/t2.html",
@@ -6983,7 +6983,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/esei/practice/t2",
     "title": "Tema 2: Búsqueda: preguntas de Sistemas Intelixentes",
-    "description": "Practica 24 preguntas de Tema 2: Búsqueda de exámenes anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 24 preguntas de Tema 2: Búsqueda de \"exámenes\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/esei/practice/t2",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -7007,7 +7007,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t2"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 2: Búsqueda: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t2\",\"inLanguage\":\"es\",\"description\":\"Practica 24 preguntas de Tema 2: Búsqueda de exámenes anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 2: Búsqueda\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 2: Búsqueda\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t2\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t2\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 2: Búsqueda: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t2\",\"inLanguage\":\"es\",\"description\":\"Practica 24 preguntas de Tema 2: Búsqueda de \\\"exámenes\\\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 2: Búsqueda\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 2: Búsqueda\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t2\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t2\"}]}"
   },
   {
     "url": "seo/es/esei/practice/t3.html",
@@ -7015,7 +7015,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/esei/practice/t3",
     "title": "Tema 3: Representación: preguntas de Sistemas Intelixentes",
-    "description": "Practica 17 preguntas de Tema 3: Representación de exámenes anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 17 preguntas de Tema 3: Representación de \"exámenes\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/esei/practice/t3",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -7039,7 +7039,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t3"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 3: Representación: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t3\",\"inLanguage\":\"es\",\"description\":\"Practica 17 preguntas de Tema 3: Representación de exámenes anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 3: Representación\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 3: Representación\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t3\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t3\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 3: Representación: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t3\",\"inLanguage\":\"es\",\"description\":\"Practica 17 preguntas de Tema 3: Representación de \\\"exámenes\\\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 3: Representación\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 3: Representación\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t3\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t3\"}]}"
   },
   {
     "url": "seo/es/esei/practice/t4.html",
@@ -7047,7 +7047,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/esei/practice/t4",
     "title": "Tema 4: Razonamiento: preguntas de Sistemas Intelixentes",
-    "description": "Practica 12 preguntas de Tema 4: Razonamiento de exámenes anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 12 preguntas de Tema 4: Razonamiento de \"exámenes\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/esei/practice/t4",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -7071,7 +7071,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t4"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 4: Razonamiento: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t4\",\"inLanguage\":\"es\",\"description\":\"Practica 12 preguntas de Tema 4: Razonamiento de exámenes anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 4: Razonamiento\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 4: Razonamiento\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t4\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t4\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 4: Razonamiento: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t4\",\"inLanguage\":\"es\",\"description\":\"Practica 12 preguntas de Tema 4: Razonamiento de \\\"exámenes\\\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 4: Razonamiento\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 4: Razonamiento\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t4\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t4\"}]}"
   },
   {
     "url": "seo/es/esei/practice/t5.html",
@@ -7079,7 +7079,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/esei/practice/t5",
     "title": "Tema 5: Planificación: preguntas de Sistemas Intelixentes",
-    "description": "Practica 2 preguntas de Tema 5: Planificación de exámenes anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 2 preguntas de Tema 5: Planificación de \"exámenes\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/esei/practice/t5",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -7103,7 +7103,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t5"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 5: Planificación: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t5\",\"inLanguage\":\"es\",\"description\":\"Practica 2 preguntas de Tema 5: Planificación de exámenes anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 5: Planificación\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 5: Planificación\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t5\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t5\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 5: Planificación: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t5\",\"inLanguage\":\"es\",\"description\":\"Practica 2 preguntas de Tema 5: Planificación de \\\"exámenes\\\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 5: Planificación\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 5: Planificación\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t5\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t5\"}]}"
   },
   {
     "url": "seo/es/esei/practice/t6.html",
@@ -7111,7 +7111,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/esei/practice/t6",
     "title": "Tema 6: Introducción a los sistemas subsimbólicos: preguntas de Sistemas Intelixentes",
-    "description": "Practica 18 preguntas de Tema 6: Introducción a los sistemas subsimbólicos de exámenes anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 18 preguntas de Tema 6: Introducción a los sistemas subsimbólicos de \"exámenes\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/esei/practice/t6",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -7135,7 +7135,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t6"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 6: Introducción a los sistemas subsimbólicos: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t6\",\"inLanguage\":\"es\",\"description\":\"Practica 18 preguntas de Tema 6: Introducción a los sistemas subsimbólicos de exámenes anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 6: Introducción a los sistemas subsimbólicos\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 6: Introducción a los sistemas subsimbólicos\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t6\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t6\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 6: Introducción a los sistemas subsimbólicos: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t6\",\"inLanguage\":\"es\",\"description\":\"Practica 18 preguntas de Tema 6: Introducción a los sistemas subsimbólicos de \\\"exámenes\\\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 6: Introducción a los sistemas subsimbólicos\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 6: Introducción a los sistemas subsimbólicos\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t6\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t6\"}]}"
   },
   {
     "url": "seo/es/esei/practice/t7.html",
@@ -7143,7 +7143,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/esei/practice/t7",
     "title": "Tema 7: Redes Neuronales Artificiales: modelos y características: preguntas de Sistemas Intelixentes",
-    "description": "Practica 40 preguntas de Tema 7: Redes Neuronales Artificiales: modelos y características de exámenes anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 40 preguntas de Tema 7: Redes Neuronales Artificiales: modelos y características de \"exámenes\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/esei/practice/t7",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -7167,7 +7167,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t7"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 7: Redes Neuronales Artificiales: modelos y características: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t7\",\"inLanguage\":\"es\",\"description\":\"Practica 40 preguntas de Tema 7: Redes Neuronales Artificiales: modelos y características de exámenes anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 7: Redes Neuronales Artificiales: modelos y características\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 7: Redes Neuronales Artificiales: modelos y características\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t7\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t7\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 7: Redes Neuronales Artificiales: modelos y características: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t7\",\"inLanguage\":\"es\",\"description\":\"Practica 40 preguntas de Tema 7: Redes Neuronales Artificiales: modelos y características de \\\"exámenes\\\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 7: Redes Neuronales Artificiales: modelos y características\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 7: Redes Neuronales Artificiales: modelos y características\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t7\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t7\"}]}"
   },
   {
     "url": "seo/es/esei/practice/t8.html",
@@ -7175,7 +7175,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/esei/practice/t8",
     "title": "Tema 8: Entrenamiento de Redes Neuronales Artificiales: preguntas de Sistemas Intelixentes",
-    "description": "Practica 20 preguntas de Tema 8: Entrenamiento de Redes Neuronales Artificiales de exámenes anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 20 preguntas de Tema 8: Entrenamiento de Redes Neuronales Artificiales de \"exámenes\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/esei/practice/t8",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -7199,7 +7199,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t8"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 8: Entrenamiento de Redes Neuronales Artificiales: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t8\",\"inLanguage\":\"es\",\"description\":\"Practica 20 preguntas de Tema 8: Entrenamiento de Redes Neuronales Artificiales de exámenes anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 8: Entrenamiento de Redes Neuronales Artificiales\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 8: Entrenamiento de Redes Neuronales Artificiales\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t8\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t8\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 8: Entrenamiento de Redes Neuronales Artificiales: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t8\",\"inLanguage\":\"es\",\"description\":\"Practica 20 preguntas de Tema 8: Entrenamiento de Redes Neuronales Artificiales de \\\"exámenes\\\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 8: Entrenamiento de Redes Neuronales Artificiales\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 8: Entrenamiento de Redes Neuronales Artificiales\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t8\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t8\"}]}"
   },
   {
     "url": "seo/es/esei/practice/t9.html",
@@ -7207,7 +7207,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/esei/practice/t9",
     "title": "Tema 9: Sistemas autoorganizativos: preguntas de Sistemas Intelixentes",
-    "description": "Practica 59 preguntas de Tema 9: Sistemas autoorganizativos de exámenes anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 59 preguntas de Tema 9: Sistemas autoorganizativos de \"exámenes\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/esei/practice/t9",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -7231,7 +7231,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t9"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 9: Sistemas autoorganizativos: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t9\",\"inLanguage\":\"es\",\"description\":\"Practica 59 preguntas de Tema 9: Sistemas autoorganizativos de exámenes anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 9: Sistemas autoorganizativos\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 9: Sistemas autoorganizativos\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t9\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t9\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 9: Sistemas autoorganizativos: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t9\",\"inLanguage\":\"es\",\"description\":\"Practica 59 preguntas de Tema 9: Sistemas autoorganizativos de \\\"exámenes\\\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 9: Sistemas autoorganizativos\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 9: Sistemas autoorganizativos\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t9\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t9\"}]}"
   },
   {
     "url": "seo/es/esei/practice/t10.html",
@@ -7239,7 +7239,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/esei/practice/t10",
     "title": "Tema 10: Computación Evolutiva: preguntas de Sistemas Intelixentes",
-    "description": "Practica 38 preguntas de Tema 10: Computación Evolutiva de exámenes anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 38 preguntas de Tema 10: Computación Evolutiva de \"exámenes\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/esei/practice/t10",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -7263,15 +7263,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t10"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 10: Computación Evolutiva: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t10\",\"inLanguage\":\"es\",\"description\":\"Practica 38 preguntas de Tema 10: Computación Evolutiva de exámenes anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 10: Computación Evolutiva\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 10: Computación Evolutiva\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t10\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t10\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 10: Computación Evolutiva: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/es/esei/practice/t10\",\"inLanguage\":\"es\",\"description\":\"Practica 38 preguntas de Tema 10: Computación Evolutiva de \\\"exámenes\\\" anteriores de Sistemas Intelixentes, con respuestas modelo y autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 10: Computación Evolutiva\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 10: Computación Evolutiva\",\"item\":\"https://pe.pablopl.dev/es/esei/practice/t10\"}],\"url\":\"https://pe.pablopl.dev/es/esei/practice/t10\"}]}"
   },
   {
     "url": "seo/es/esei/exam/2023.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/esei/exam/2023",
-    "title": "2023 de Sistemas Intelixentes: simulador | Pásame Exámenes",
-    "description": "Simula el examen 2023 de Sistemas Intelixentes con 45 preguntas. 45 puntos, 120 minutos, respuestas modelo y autocorrección.",
+    "title": "Posibles preguntas 2023 de Sistemas Intelixentes: simulador",
+    "description": "Simula el examen Posibles preguntas 2023 de Sistemas Intelixentes con 45 preguntas. 45 puntos, 120 minutos, respuestas modelo y autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/esei/exam/2023",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -7295,15 +7295,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/exam/2023"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"2023 de Sistemas Intelixentes: simulador | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/esei/exam/2023\",\"inLanguage\":\"es\",\"description\":\"Simula el examen 2023 de Sistemas Intelixentes con 45 preguntas. 45 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"2023\",\"item\":\"https://pe.pablopl.dev/es/esei/exam/2023\"}],\"url\":\"https://pe.pablopl.dev/es/esei/exam/2023\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas 2023 de Sistemas Intelixentes: simulador\",\"url\":\"https://pe.pablopl.dev/es/esei/exam/2023\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Posibles preguntas 2023 de Sistemas Intelixentes con 45 preguntas. 45 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas 2023\",\"item\":\"https://pe.pablopl.dev/es/esei/exam/2023\"}],\"url\":\"https://pe.pablopl.dev/es/esei/exam/2023\"}]}"
   },
   {
     "url": "seo/es/esei/exam/2024.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/esei/exam/2024",
-    "title": "2024 de Sistemas Intelixentes: simulador | Pásame Exámenes",
-    "description": "Simula el examen 2024 de Sistemas Intelixentes con 44 preguntas. 44 puntos, 120 minutos, respuestas modelo y autocorrección.",
+    "title": "Posibles preguntas 2024 de Sistemas Intelixentes: simulador",
+    "description": "Simula el examen Posibles preguntas 2024 de Sistemas Intelixentes con 44 preguntas. 44 puntos, 120 minutos, respuestas modelo y autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/esei/exam/2024",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -7327,15 +7327,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/exam/2024"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"2024 de Sistemas Intelixentes: simulador | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/esei/exam/2024\",\"inLanguage\":\"es\",\"description\":\"Simula el examen 2024 de Sistemas Intelixentes con 44 preguntas. 44 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"2024\",\"item\":\"https://pe.pablopl.dev/es/esei/exam/2024\"}],\"url\":\"https://pe.pablopl.dev/es/esei/exam/2024\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas 2024 de Sistemas Intelixentes: simulador\",\"url\":\"https://pe.pablopl.dev/es/esei/exam/2024\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Posibles preguntas 2024 de Sistemas Intelixentes con 44 preguntas. 44 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas 2024\",\"item\":\"https://pe.pablopl.dev/es/esei/exam/2024\"}],\"url\":\"https://pe.pablopl.dev/es/esei/exam/2024\"}]}"
   },
   {
     "url": "seo/es/esei/exam/2025-05.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/esei/exam/2025-05",
-    "title": "Mayo 2025 de Sistemas Intelixentes: simulador",
-    "description": "Simula el examen Mayo 2025 de Sistemas Intelixentes con 42 preguntas. 42 puntos, 120 minutos, respuestas modelo y autocorrección.",
+    "title": "Posibles preguntas Mayo 2025 de Sistemas Intelixentes: simulador",
+    "description": "Simula el examen Posibles preguntas Mayo 2025 de Sistemas Intelixentes con 42 preguntas. 42 puntos, 120 minutos, respuestas modelo y autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/esei/exam/2025-05",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -7359,15 +7359,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/exam/2025-05"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Mayo 2025 de Sistemas Intelixentes: simulador\",\"url\":\"https://pe.pablopl.dev/es/esei/exam/2025-05\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Mayo 2025 de Sistemas Intelixentes con 42 preguntas. 42 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Mayo 2025\",\"item\":\"https://pe.pablopl.dev/es/esei/exam/2025-05\"}],\"url\":\"https://pe.pablopl.dev/es/esei/exam/2025-05\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Mayo 2025 de Sistemas Intelixentes: simulador\",\"url\":\"https://pe.pablopl.dev/es/esei/exam/2025-05\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Posibles preguntas Mayo 2025 de Sistemas Intelixentes con 42 preguntas. 42 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Mayo 2025\",\"item\":\"https://pe.pablopl.dev/es/esei/exam/2025-05\"}],\"url\":\"https://pe.pablopl.dev/es/esei/exam/2025-05\"}]}"
   },
   {
     "url": "seo/es/esei/exam/2025-07.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/esei/exam/2025-07",
-    "title": "Julio 2025 de Sistemas Intelixentes: simulador",
-    "description": "Simula el examen Julio 2025 de Sistemas Intelixentes con 47 preguntas. 47 puntos, 120 minutos, respuestas modelo y autocorrección.",
+    "title": "Posibles preguntas Julio 2025 de Sistemas Intelixentes: simulador",
+    "description": "Simula el examen Posibles preguntas Julio 2025 de Sistemas Intelixentes con 47 preguntas. 47 puntos, 120 minutos, respuestas modelo y autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/esei/exam/2025-07",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -7391,15 +7391,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/exam/2025-07"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Julio 2025 de Sistemas Intelixentes: simulador\",\"url\":\"https://pe.pablopl.dev/es/esei/exam/2025-07\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Julio 2025 de Sistemas Intelixentes con 47 preguntas. 47 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Julio 2025\",\"item\":\"https://pe.pablopl.dev/es/esei/exam/2025-07\"}],\"url\":\"https://pe.pablopl.dev/es/esei/exam/2025-07\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Julio 2025 de Sistemas Intelixentes: simulador\",\"url\":\"https://pe.pablopl.dev/es/esei/exam/2025-07\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Posibles preguntas Julio 2025 de Sistemas Intelixentes con 47 preguntas. 47 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Julio 2025\",\"item\":\"https://pe.pablopl.dev/es/esei/exam/2025-07\"}],\"url\":\"https://pe.pablopl.dev/es/esei/exam/2025-07\"}]}"
   },
   {
     "url": "seo/es/esei/exam/2026-06.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/esei/exam/2026-06",
-    "title": "Junio 2026 de Sistemas Intelixentes: simulador",
-    "description": "Simula el examen Junio 2026 de Sistemas Intelixentes con 56 preguntas. 56 puntos, 120 minutos, respuestas modelo y autocorrección.",
+    "title": "Posibles preguntas Junio 2026 de Sistemas Intelixentes: simulador",
+    "description": "Simula el examen Posibles preguntas Junio 2026 de Sistemas Intelixentes con 56 preguntas. 56 puntos, 120 minutos, respuestas modelo y autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/esei/exam/2026-06",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -7423,15 +7423,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/exam/2026-06"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Junio 2026 de Sistemas Intelixentes: simulador\",\"url\":\"https://pe.pablopl.dev/es/esei/exam/2026-06\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Junio 2026 de Sistemas Intelixentes con 56 preguntas. 56 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Junio 2026\",\"item\":\"https://pe.pablopl.dev/es/esei/exam/2026-06\"}],\"url\":\"https://pe.pablopl.dev/es/esei/exam/2026-06\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Junio 2026 de Sistemas Intelixentes: simulador\",\"url\":\"https://pe.pablopl.dev/es/esei/exam/2026-06\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Posibles preguntas Junio 2026 de Sistemas Intelixentes con 56 preguntas. 56 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/es/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Junio 2026\",\"item\":\"https://pe.pablopl.dev/es/esei/exam/2026-06\"}],\"url\":\"https://pe.pablopl.dev/es/esei/exam/2026-06\"}]}"
   },
   {
     "url": "seo/es/eseo.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/eseo",
-    "title": "Sistemas Operativos: exámenes y preguntas resueltas",
-    "description": "Practica 119 preguntas de Sistemas Operativos de 9 exámenes anteriores con respuestas modelo y autocorrección. 202318, Universidade da Coruña.",
+    "title": "Sistemas Operativos: \"exámenes\" y preguntas resueltas",
+    "description": "Practica 119 preguntas de Sistemas Operativos de 9 \"exámenes\" anteriores con respuestas modelo y autocorrección. 202318, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/eseo",
     "ogImage": "https://pe.pablopl.dev/og/eseo.png",
@@ -7455,7 +7455,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/eseo"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Sistemas Operativos: exámenes y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/eseo\",\"inLanguage\":\"es\",\"description\":\"Practica 119 preguntas de Sistemas Operativos de 9 exámenes anteriores con respuestas modelo y autocorrección. 202318, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/es/eseo\"}],\"url\":\"https://pe.pablopl.dev/es/eseo\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Sistemas Operativos: \\\"exámenes\\\" y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/eseo\",\"inLanguage\":\"es\",\"description\":\"Practica 119 preguntas de Sistemas Operativos de 9 \\\"exámenes\\\" anteriores con respuestas modelo y autocorrección. 202318, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/es/eseo\"}],\"url\":\"https://pe.pablopl.dev/es/eseo\"}]}"
   },
   {
     "url": "seo/es/eseo/practice/sistema-ficheros.html",
@@ -7463,7 +7463,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/eseo/practice/sistema-ficheros",
     "title": "Sistema de Ficheros: preguntas de Sistemas Operativos",
-    "description": "Practica 36 preguntas de Sistema de Ficheros de exámenes anteriores de Sistemas Operativos, con respuestas modelo y autocorrección. 202318, Universidade da Coruña.",
+    "description": "Practica 36 preguntas de Sistema de Ficheros de \"exámenes\" anteriores de Sistemas Operativos, con respuestas modelo y autocorrección. 202318, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/eseo/practice/sistema-ficheros",
     "ogImage": "https://pe.pablopl.dev/og/eseo.png",
@@ -7487,7 +7487,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/eseo/practice/sistema-ficheros"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Sistema de Ficheros: preguntas de Sistemas Operativos\",\"url\":\"https://pe.pablopl.dev/es/eseo/practice/sistema-ficheros\",\"inLanguage\":\"es\",\"description\":\"Practica 36 preguntas de Sistema de Ficheros de exámenes anteriores de Sistemas Operativos, con respuestas modelo y autocorrección. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Sistema de Ficheros\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/es/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Sistema de Ficheros\",\"item\":\"https://pe.pablopl.dev/es/eseo/practice/sistema-ficheros\"}],\"url\":\"https://pe.pablopl.dev/es/eseo/practice/sistema-ficheros\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Sistema de Ficheros: preguntas de Sistemas Operativos\",\"url\":\"https://pe.pablopl.dev/es/eseo/practice/sistema-ficheros\",\"inLanguage\":\"es\",\"description\":\"Practica 36 preguntas de Sistema de Ficheros de \\\"exámenes\\\" anteriores de Sistemas Operativos, con respuestas modelo y autocorrección. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Sistema de Ficheros\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/es/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Sistema de Ficheros\",\"item\":\"https://pe.pablopl.dev/es/eseo/practice/sistema-ficheros\"}],\"url\":\"https://pe.pablopl.dev/es/eseo/practice/sistema-ficheros\"}]}"
   },
   {
     "url": "seo/es/eseo/practice/memoria.html",
@@ -7495,7 +7495,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/eseo/practice/memoria",
     "title": "Gestión de Memoria: preguntas de Sistemas Operativos",
-    "description": "Practica 25 preguntas de Gestión de Memoria de exámenes anteriores de Sistemas Operativos, con respuestas modelo y autocorrección. 202318, Universidade da Coruña.",
+    "description": "Practica 25 preguntas de Gestión de Memoria de \"exámenes\" anteriores de Sistemas Operativos, con respuestas modelo y autocorrección. 202318, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/eseo/practice/memoria",
     "ogImage": "https://pe.pablopl.dev/og/eseo.png",
@@ -7519,7 +7519,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/eseo/practice/memoria"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Gestión de Memoria: preguntas de Sistemas Operativos\",\"url\":\"https://pe.pablopl.dev/es/eseo/practice/memoria\",\"inLanguage\":\"es\",\"description\":\"Practica 25 preguntas de Gestión de Memoria de exámenes anteriores de Sistemas Operativos, con respuestas modelo y autocorrección. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Gestión de Memoria\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/es/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Gestión de Memoria\",\"item\":\"https://pe.pablopl.dev/es/eseo/practice/memoria\"}],\"url\":\"https://pe.pablopl.dev/es/eseo/practice/memoria\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Gestión de Memoria: preguntas de Sistemas Operativos\",\"url\":\"https://pe.pablopl.dev/es/eseo/practice/memoria\",\"inLanguage\":\"es\",\"description\":\"Practica 25 preguntas de Gestión de Memoria de \\\"exámenes\\\" anteriores de Sistemas Operativos, con respuestas modelo y autocorrección. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Gestión de Memoria\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/es/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Gestión de Memoria\",\"item\":\"https://pe.pablopl.dev/es/eseo/practice/memoria\"}],\"url\":\"https://pe.pablopl.dev/es/eseo/practice/memoria\"}]}"
   },
   {
     "url": "seo/es/eseo/practice/procesos.html",
@@ -7527,7 +7527,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/eseo/practice/procesos",
     "title": "Procesos e Hilos: preguntas de Sistemas Operativos",
-    "description": "Practica 30 preguntas de Procesos e Hilos de exámenes anteriores de Sistemas Operativos, con respuestas modelo y autocorrección. 202318, Universidade da Coruña.",
+    "description": "Practica 30 preguntas de Procesos e Hilos de \"exámenes\" anteriores de Sistemas Operativos, con respuestas modelo y autocorrección. 202318, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/eseo/practice/procesos",
     "ogImage": "https://pe.pablopl.dev/og/eseo.png",
@@ -7551,7 +7551,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/eseo/practice/procesos"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Procesos e Hilos: preguntas de Sistemas Operativos\",\"url\":\"https://pe.pablopl.dev/es/eseo/practice/procesos\",\"inLanguage\":\"es\",\"description\":\"Practica 30 preguntas de Procesos e Hilos de exámenes anteriores de Sistemas Operativos, con respuestas modelo y autocorrección. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Procesos e Hilos\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/es/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Procesos e Hilos\",\"item\":\"https://pe.pablopl.dev/es/eseo/practice/procesos\"}],\"url\":\"https://pe.pablopl.dev/es/eseo/practice/procesos\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Procesos e Hilos: preguntas de Sistemas Operativos\",\"url\":\"https://pe.pablopl.dev/es/eseo/practice/procesos\",\"inLanguage\":\"es\",\"description\":\"Practica 30 preguntas de Procesos e Hilos de \\\"exámenes\\\" anteriores de Sistemas Operativos, con respuestas modelo y autocorrección. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Procesos e Hilos\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/es/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Procesos e Hilos\",\"item\":\"https://pe.pablopl.dev/es/eseo/practice/procesos\"}],\"url\":\"https://pe.pablopl.dev/es/eseo/practice/procesos\"}]}"
   },
   {
     "url": "seo/es/eseo/practice/entrada-salida.html",
@@ -7559,7 +7559,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/eseo/practice/entrada-salida",
     "title": "Entrada/Salida: preguntas de Sistemas Operativos",
-    "description": "Practica 28 preguntas de Entrada/Salida de exámenes anteriores de Sistemas Operativos, con respuestas modelo y autocorrección. 202318, Universidade da Coruña.",
+    "description": "Practica 28 preguntas de Entrada/Salida de \"exámenes\" anteriores de Sistemas Operativos, con respuestas modelo y autocorrección. 202318, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/eseo/practice/entrada-salida",
     "ogImage": "https://pe.pablopl.dev/og/eseo.png",
@@ -7583,7 +7583,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/eseo/practice/entrada-salida"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Entrada/Salida: preguntas de Sistemas Operativos\",\"url\":\"https://pe.pablopl.dev/es/eseo/practice/entrada-salida\",\"inLanguage\":\"es\",\"description\":\"Practica 28 preguntas de Entrada/Salida de exámenes anteriores de Sistemas Operativos, con respuestas modelo y autocorrección. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Entrada/Salida\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/es/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Entrada/Salida\",\"item\":\"https://pe.pablopl.dev/es/eseo/practice/entrada-salida\"}],\"url\":\"https://pe.pablopl.dev/es/eseo/practice/entrada-salida\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Entrada/Salida: preguntas de Sistemas Operativos\",\"url\":\"https://pe.pablopl.dev/es/eseo/practice/entrada-salida\",\"inLanguage\":\"es\",\"description\":\"Practica 28 preguntas de Entrada/Salida de \\\"exámenes\\\" anteriores de Sistemas Operativos, con respuestas modelo y autocorrección. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Entrada/Salida\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/es/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Entrada/Salida\",\"item\":\"https://pe.pablopl.dev/es/eseo/practice/entrada-salida\"}],\"url\":\"https://pe.pablopl.dev/es/eseo/practice/entrada-salida\"}]}"
   },
   {
     "url": "seo/es/eseo/exam/2020-01.html",
@@ -7878,8 +7878,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/iesede",
-    "title": "Internet y Sistemas Distribuidos: exámenes y preguntas resueltas",
-    "description": "Practica 18 preguntas de Internet y Sistemas Distribuidos de 1 exámenes anteriores con respuestas modelo y autocorrección. 200188, Universidade da Coruña.",
+    "title": "Internet y Sistemas Distribuidos: \"exámenes\" y preguntas resueltas",
+    "description": "Practica 18 preguntas de Internet y Sistemas Distribuidos de 1 \"exámenes\" anteriores con respuestas modelo y autocorrección. 200188, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/iesede",
     "ogImage": "https://pe.pablopl.dev/og/iesede.png",
@@ -7903,7 +7903,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/iesede"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Internet y Sistemas Distribuidos: exámenes y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/iesede\",\"inLanguage\":\"es\",\"description\":\"Practica 18 preguntas de Internet y Sistemas Distribuidos de 1 exámenes anteriores con respuestas modelo y autocorrección. 200188, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Internet y Sistemas Distribuidos\",\"courseCode\":\"200188\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Internet y Sistemas Distribuidos\",\"item\":\"https://pe.pablopl.dev/es/iesede\"}],\"url\":\"https://pe.pablopl.dev/es/iesede\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Internet y Sistemas Distribuidos: \\\"exámenes\\\" y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/iesede\",\"inLanguage\":\"es\",\"description\":\"Practica 18 preguntas de Internet y Sistemas Distribuidos de 1 \\\"exámenes\\\" anteriores con respuestas modelo y autocorrección. 200188, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Internet y Sistemas Distribuidos\",\"courseCode\":\"200188\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Internet y Sistemas Distribuidos\",\"item\":\"https://pe.pablopl.dev/es/iesede\"}],\"url\":\"https://pe.pablopl.dev/es/iesede\"}]}"
   },
   {
     "url": "seo/es/iesede/practice/general.html",
@@ -7911,7 +7911,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/iesede/practice/general",
     "title": "General: preguntas de Internet y Sistemas Distribuidos",
-    "description": "Practica 18 preguntas de General de exámenes anteriores de Internet y Sistemas Distribuidos, con respuestas modelo y autocorrección. 200188, Universidade da Coruña.",
+    "description": "Practica 18 preguntas de General de \"exámenes\" anteriores de Internet y Sistemas Distribuidos, con respuestas modelo y autocorrección. 200188, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/iesede/practice/general",
     "ogImage": "https://pe.pablopl.dev/og/iesede.png",
@@ -7935,15 +7935,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/iesede/practice/general"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"General: preguntas de Internet y Sistemas Distribuidos\",\"url\":\"https://pe.pablopl.dev/es/iesede/practice/general\",\"inLanguage\":\"es\",\"description\":\"Practica 18 preguntas de General de exámenes anteriores de Internet y Sistemas Distribuidos, con respuestas modelo y autocorrección. 200188, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"General\"},{\"@type\":\"Course\",\"name\":\"Internet y Sistemas Distribuidos\",\"courseCode\":\"200188\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Internet y Sistemas Distribuidos\",\"item\":\"https://pe.pablopl.dev/es/iesede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"General\",\"item\":\"https://pe.pablopl.dev/es/iesede/practice/general\"}],\"url\":\"https://pe.pablopl.dev/es/iesede/practice/general\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"General: preguntas de Internet y Sistemas Distribuidos\",\"url\":\"https://pe.pablopl.dev/es/iesede/practice/general\",\"inLanguage\":\"es\",\"description\":\"Practica 18 preguntas de General de \\\"exámenes\\\" anteriores de Internet y Sistemas Distribuidos, con respuestas modelo y autocorrección. 200188, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"General\"},{\"@type\":\"Course\",\"name\":\"Internet y Sistemas Distribuidos\",\"courseCode\":\"200188\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Internet y Sistemas Distribuidos\",\"item\":\"https://pe.pablopl.dev/es/iesede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"General\",\"item\":\"https://pe.pablopl.dev/es/iesede/practice/general\"}],\"url\":\"https://pe.pablopl.dev/es/iesede/practice/general\"}]}"
   },
   {
     "url": "seo/es/iesede/exam/examen_recopilatorio.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/iesede/exam/examen_recopilatorio",
-    "title": "Examen Recopilatorio de Internet y Sistemas Distribuidos: simulador",
-    "description": "Simula el examen Examen Recopilatorio de Internet y Sistemas Distribuidos con 18 preguntas. 18 puntos, 120 minutos, respuestas modelo y autocorrección.",
+    "title": "Recopilación de Internet y Sistemas Distribuidos: simulador",
+    "description": "Simula el examen Recopilación de Internet y Sistemas Distribuidos con 18 preguntas. 18 puntos, 120 minutos, respuestas modelo y autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/iesede/exam/examen_recopilatorio",
     "ogImage": "https://pe.pablopl.dev/og/iesede.png",
@@ -7967,15 +7967,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/iesede/exam/examen_recopilatorio"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Examen Recopilatorio de Internet y Sistemas Distribuidos: simulador\",\"url\":\"https://pe.pablopl.dev/es/iesede/exam/examen_recopilatorio\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Examen Recopilatorio de Internet y Sistemas Distribuidos con 18 preguntas. 18 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Internet y Sistemas Distribuidos\",\"courseCode\":\"200188\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Internet y Sistemas Distribuidos\",\"item\":\"https://pe.pablopl.dev/es/iesede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Examen Recopilatorio\",\"item\":\"https://pe.pablopl.dev/es/iesede/exam/examen_recopilatorio\"}],\"url\":\"https://pe.pablopl.dev/es/iesede/exam/examen_recopilatorio\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Recopilación de Internet y Sistemas Distribuidos: simulador\",\"url\":\"https://pe.pablopl.dev/es/iesede/exam/examen_recopilatorio\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Recopilación de Internet y Sistemas Distribuidos con 18 preguntas. 18 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Internet y Sistemas Distribuidos\",\"courseCode\":\"200188\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Internet y Sistemas Distribuidos\",\"item\":\"https://pe.pablopl.dev/es/iesede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Recopilación\",\"item\":\"https://pe.pablopl.dev/es/iesede/exam/examen_recopilatorio\"}],\"url\":\"https://pe.pablopl.dev/es/iesede/exam/examen_recopilatorio\"}]}"
   },
   {
     "url": "seo/es/peese.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/peese",
-    "title": "Proceso Software: exámenes y preguntas resueltas",
-    "description": "Practica 17 preguntas de Proceso Software de 1 exámenes anteriores con respuestas modelo y autocorrección. 202321, Universidade da Coruña.",
+    "title": "Proceso Software: \"exámenes\" y preguntas resueltas",
+    "description": "Practica 17 preguntas de Proceso Software de 1 \"exámenes\" anteriores con respuestas modelo y autocorrección. 202321, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/peese",
     "ogImage": "https://pe.pablopl.dev/og/peese.png",
@@ -7999,7 +7999,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/peese"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Proceso Software: exámenes y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/peese\",\"inLanguage\":\"es\",\"description\":\"Practica 17 preguntas de Proceso Software de 1 exámenes anteriores con respuestas modelo y autocorrección. 202321, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Proceso Software\",\"courseCode\":\"202321\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Proceso Software\",\"item\":\"https://pe.pablopl.dev/es/peese\"}],\"url\":\"https://pe.pablopl.dev/es/peese\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Proceso Software: \\\"exámenes\\\" y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/peese\",\"inLanguage\":\"es\",\"description\":\"Practica 17 preguntas de Proceso Software de 1 \\\"exámenes\\\" anteriores con respuestas modelo y autocorrección. 202321, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Proceso Software\",\"courseCode\":\"202321\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Proceso Software\",\"item\":\"https://pe.pablopl.dev/es/peese\"}],\"url\":\"https://pe.pablopl.dev/es/peese\"}]}"
   },
   {
     "url": "seo/es/peese/practice/teoria.html",
@@ -8007,7 +8007,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/peese/practice/teoria",
     "title": "Teoría: preguntas de Proceso Software | Pásame Exámenes",
-    "description": "Practica 17 preguntas de Teoría de exámenes anteriores de Proceso Software, con respuestas modelo y autocorrección. 202321, Universidade da Coruña.",
+    "description": "Practica 17 preguntas de Teoría de \"exámenes\" anteriores de Proceso Software, con respuestas modelo y autocorrección. 202321, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/peese/practice/teoria",
     "ogImage": "https://pe.pablopl.dev/og/peese.png",
@@ -8031,15 +8031,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/peese/practice/teoria"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Teoría: preguntas de Proceso Software | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/peese/practice/teoria\",\"inLanguage\":\"es\",\"description\":\"Practica 17 preguntas de Teoría de exámenes anteriores de Proceso Software, con respuestas modelo y autocorrección. 202321, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Teoría\"},{\"@type\":\"Course\",\"name\":\"Proceso Software\",\"courseCode\":\"202321\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Proceso Software\",\"item\":\"https://pe.pablopl.dev/es/peese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Teoría\",\"item\":\"https://pe.pablopl.dev/es/peese/practice/teoria\"}],\"url\":\"https://pe.pablopl.dev/es/peese/practice/teoria\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Teoría: preguntas de Proceso Software | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/peese/practice/teoria\",\"inLanguage\":\"es\",\"description\":\"Practica 17 preguntas de Teoría de \\\"exámenes\\\" anteriores de Proceso Software, con respuestas modelo y autocorrección. 202321, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Teoría\"},{\"@type\":\"Course\",\"name\":\"Proceso Software\",\"courseCode\":\"202321\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Proceso Software\",\"item\":\"https://pe.pablopl.dev/es/peese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Teoría\",\"item\":\"https://pe.pablopl.dev/es/peese/practice/teoria\"}],\"url\":\"https://pe.pablopl.dev/es/peese/practice/teoria\"}]}"
   },
   {
     "url": "seo/es/peese/exam/2026-05.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/peese/exam/2026-05",
-    "title": "Mayo 2026 de Proceso Software: simulador | Pásame Exámenes",
-    "description": "Simula el examen Mayo 2026 de Proceso Software con 17 preguntas. 8.5 puntos, 120 minutos, respuestas modelo y autocorrección.",
+    "title": "Posibles preguntas Mayo 2026 de Proceso Software: simulador",
+    "description": "Simula el examen Posibles preguntas Mayo 2026 de Proceso Software con 17 preguntas. 8.5 puntos, 120 minutos, respuestas modelo y autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/peese/exam/2026-05",
     "ogImage": "https://pe.pablopl.dev/og/peese.png",
@@ -8063,15 +8063,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/peese/exam/2026-05"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Mayo 2026 de Proceso Software: simulador | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/peese/exam/2026-05\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Mayo 2026 de Proceso Software con 17 preguntas. 8.5 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Proceso Software\",\"courseCode\":\"202321\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Proceso Software\",\"item\":\"https://pe.pablopl.dev/es/peese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Mayo 2026\",\"item\":\"https://pe.pablopl.dev/es/peese/exam/2026-05\"}],\"url\":\"https://pe.pablopl.dev/es/peese/exam/2026-05\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Mayo 2026 de Proceso Software: simulador\",\"url\":\"https://pe.pablopl.dev/es/peese/exam/2026-05\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Posibles preguntas Mayo 2026 de Proceso Software con 17 preguntas. 8.5 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Proceso Software\",\"courseCode\":\"202321\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Proceso Software\",\"item\":\"https://pe.pablopl.dev/es/peese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Mayo 2026\",\"item\":\"https://pe.pablopl.dev/es/peese/exam/2026-05\"}],\"url\":\"https://pe.pablopl.dev/es/peese/exam/2026-05\"}]}"
   },
   {
     "url": "seo/es/pei.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/pei",
-    "title": "Programación Integrativa: exámenes y preguntas resueltas",
-    "description": "Practica 54 preguntas de Programación Integrativa de 1 exámenes anteriores con respuestas modelo y autocorrección. 200214, Universidade da Coruña.",
+    "title": "Programación Integrativa: \"exámenes\" y preguntas resueltas",
+    "description": "Practica 54 preguntas de Programación Integrativa de 1 \"exámenes\" anteriores con respuestas modelo y autocorrección. 200214, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/pei",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -8095,7 +8095,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Programación Integrativa: exámenes y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/pei\",\"inLanguage\":\"es\",\"description\":\"Practica 54 preguntas de Programación Integrativa de 1 exámenes anteriores con respuestas modelo y autocorrección. 200214, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/es/pei\"}],\"url\":\"https://pe.pablopl.dev/es/pei\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Programación Integrativa: \\\"exámenes\\\" y preguntas resueltas\",\"url\":\"https://pe.pablopl.dev/es/pei\",\"inLanguage\":\"es\",\"description\":\"Practica 54 preguntas de Programación Integrativa de 1 \\\"exámenes\\\" anteriores con respuestas modelo y autocorrección. 200214, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/es/pei\"}],\"url\":\"https://pe.pablopl.dev/es/pei\"}]}"
   },
   {
     "url": "seo/es/pei/practice/pandas.html",
@@ -8103,7 +8103,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/pei/practice/pandas",
     "title": "Pandas y Datos Estructurados: preguntas de Programación Integrativa",
-    "description": "Practica 8 preguntas de Pandas y Datos Estructurados de exámenes anteriores de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.",
+    "description": "Practica 8 preguntas de Pandas y Datos Estructurados de \"exámenes\" anteriores de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/pei/practice/pandas",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -8127,7 +8127,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei/practice/pandas"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Pandas y Datos Estructurados: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/es/pei/practice/pandas\",\"inLanguage\":\"es\",\"description\":\"Practica 8 preguntas de Pandas y Datos Estructurados de exámenes anteriores de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Pandas y Datos Estructurados\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/es/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Pandas y Datos Estructurados\",\"item\":\"https://pe.pablopl.dev/es/pei/practice/pandas\"}],\"url\":\"https://pe.pablopl.dev/es/pei/practice/pandas\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Pandas y Datos Estructurados: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/es/pei/practice/pandas\",\"inLanguage\":\"es\",\"description\":\"Practica 8 preguntas de Pandas y Datos Estructurados de \\\"exámenes\\\" anteriores de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Pandas y Datos Estructurados\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/es/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Pandas y Datos Estructurados\",\"item\":\"https://pe.pablopl.dev/es/pei/practice/pandas\"}],\"url\":\"https://pe.pablopl.dev/es/pei/practice/pandas\"}]}"
   },
   {
     "url": "seo/es/pei/practice/poo.html",
@@ -8135,7 +8135,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/pei/practice/poo",
     "title": "POO en Python: preguntas de Programación Integrativa",
-    "description": "Practica 8 preguntas de POO en Python de exámenes anteriores de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.",
+    "description": "Practica 8 preguntas de POO en Python de \"exámenes\" anteriores de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/pei/practice/poo",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -8159,7 +8159,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei/practice/poo"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"POO en Python: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/es/pei/practice/poo\",\"inLanguage\":\"es\",\"description\":\"Practica 8 preguntas de POO en Python de exámenes anteriores de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"POO en Python\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/es/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"POO en Python\",\"item\":\"https://pe.pablopl.dev/es/pei/practice/poo\"}],\"url\":\"https://pe.pablopl.dev/es/pei/practice/poo\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"POO en Python: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/es/pei/practice/poo\",\"inLanguage\":\"es\",\"description\":\"Practica 8 preguntas de POO en Python de \\\"exámenes\\\" anteriores de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"POO en Python\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/es/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"POO en Python\",\"item\":\"https://pe.pablopl.dev/es/pei/practice/poo\"}],\"url\":\"https://pe.pablopl.dev/es/pei/practice/poo\"}]}"
   },
   {
     "url": "seo/es/pei/practice/scripting.html",
@@ -8167,7 +8167,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/pei/practice/scripting",
     "title": "Scripting y Regex: preguntas de Programación Integrativa",
-    "description": "Practica 15 preguntas de Scripting y Regex de exámenes anteriores de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.",
+    "description": "Practica 15 preguntas de Scripting y Regex de \"exámenes\" anteriores de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/pei/practice/scripting",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -8191,7 +8191,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei/practice/scripting"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Scripting y Regex: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/es/pei/practice/scripting\",\"inLanguage\":\"es\",\"description\":\"Practica 15 preguntas de Scripting y Regex de exámenes anteriores de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Scripting y Regex\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/es/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Scripting y Regex\",\"item\":\"https://pe.pablopl.dev/es/pei/practice/scripting\"}],\"url\":\"https://pe.pablopl.dev/es/pei/practice/scripting\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Scripting y Regex: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/es/pei/practice/scripting\",\"inLanguage\":\"es\",\"description\":\"Practica 15 preguntas de Scripting y Regex de \\\"exámenes\\\" anteriores de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Scripting y Regex\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/es/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Scripting y Regex\",\"item\":\"https://pe.pablopl.dev/es/pei/practice/scripting\"}],\"url\":\"https://pe.pablopl.dev/es/pei/practice/scripting\"}]}"
   },
   {
     "url": "seo/es/pei/practice/django-apis.html",
@@ -8199,7 +8199,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/pei/practice/django-apis",
     "title": "Django, APIs e Integración: preguntas de Programación Integrativa",
-    "description": "Practica 14 preguntas de Django, APIs e Integración de exámenes anteriores de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.",
+    "description": "Practica 14 preguntas de Django, APIs e Integración de \"exámenes\" anteriores de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/pei/practice/django-apis",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -8223,7 +8223,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei/practice/django-apis"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Django, APIs e Integración: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/es/pei/practice/django-apis\",\"inLanguage\":\"es\",\"description\":\"Practica 14 preguntas de Django, APIs e Integración de exámenes anteriores de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Django, APIs e Integración\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/es/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Django, APIs e Integración\",\"item\":\"https://pe.pablopl.dev/es/pei/practice/django-apis\"}],\"url\":\"https://pe.pablopl.dev/es/pei/practice/django-apis\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Django, APIs e Integración: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/es/pei/practice/django-apis\",\"inLanguage\":\"es\",\"description\":\"Practica 14 preguntas de Django, APIs e Integración de \\\"exámenes\\\" anteriores de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Django, APIs e Integración\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/es/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Django, APIs e Integración\",\"item\":\"https://pe.pablopl.dev/es/pei/practice/django-apis\"}],\"url\":\"https://pe.pablopl.dev/es/pei/practice/django-apis\"}]}"
   },
   {
     "url": "seo/es/pei/practice/conceptos.html",
@@ -8231,7 +8231,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/pei/practice/conceptos",
     "title": "Conceptos y Test: preguntas de Programación Integrativa",
-    "description": "Practica 9 preguntas de Conceptos y Test de exámenes anteriores de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.",
+    "description": "Practica 9 preguntas de Conceptos y Test de \"exámenes\" anteriores de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/pei/practice/conceptos",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -8255,7 +8255,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei/practice/conceptos"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Conceptos y Test: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/es/pei/practice/conceptos\",\"inLanguage\":\"es\",\"description\":\"Practica 9 preguntas de Conceptos y Test de exámenes anteriores de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Conceptos y Test\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/es/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Conceptos y Test\",\"item\":\"https://pe.pablopl.dev/es/pei/practice/conceptos\"}],\"url\":\"https://pe.pablopl.dev/es/pei/practice/conceptos\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Conceptos y Test: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/es/pei/practice/conceptos\",\"inLanguage\":\"es\",\"description\":\"Practica 9 preguntas de Conceptos y Test de \\\"exámenes\\\" anteriores de Programación Integrativa, con respuestas modelo y autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Conceptos y Test\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/es/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Conceptos y Test\",\"item\":\"https://pe.pablopl.dev/es/pei/practice/conceptos\"}],\"url\":\"https://pe.pablopl.dev/es/pei/practice/conceptos\"}]}"
   },
   {
     "url": "seo/es/pei/exam/recopilacion.html",
@@ -8294,8 +8294,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/redes",
-    "title": "Redes: exámenes y preguntas resueltas | Pásame Exámenes",
-    "description": "Practica 460 preguntas de Redes de 3 exámenes anteriores con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
+    "title": "Redes: \"exámenes\" y preguntas resueltas | Pásame Exámenes",
+    "description": "Practica 460 preguntas de Redes de 3 \"exámenes\" anteriores con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/redes",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -8319,7 +8319,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Redes: exámenes y preguntas resueltas | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/redes\",\"inLanguage\":\"es\",\"description\":\"Practica 460 preguntas de Redes de 3 exámenes anteriores con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"}],\"url\":\"https://pe.pablopl.dev/es/redes\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Redes: \\\"exámenes\\\" y preguntas resueltas | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/redes\",\"inLanguage\":\"es\",\"description\":\"Practica 460 preguntas de Redes de 3 \\\"exámenes\\\" anteriores con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"}],\"url\":\"https://pe.pablopl.dev/es/redes\"}]}"
   },
   {
     "url": "seo/es/redes/practice/tema-1.html",
@@ -8327,7 +8327,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/redes/practice/tema-1",
     "title": "Tema 1. Redes de ordenadores e Internet: preguntas de Redes",
-    "description": "Practica 54 preguntas de Tema 1. Redes de ordenadores e Internet de exámenes anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 54 preguntas de Tema 1. Redes de ordenadores e Internet de \"exámenes\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/redes/practice/tema-1",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -8351,7 +8351,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-1"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 1. Redes de ordenadores e Internet: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-1\",\"inLanguage\":\"es\",\"description\":\"Practica 54 preguntas de Tema 1. Redes de ordenadores e Internet de exámenes anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 1. Redes de ordenadores e Internet\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 1. Redes de ordenadores e Internet\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-1\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-1\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 1. Redes de ordenadores e Internet: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-1\",\"inLanguage\":\"es\",\"description\":\"Practica 54 preguntas de Tema 1. Redes de ordenadores e Internet de \\\"exámenes\\\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 1. Redes de ordenadores e Internet\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 1. Redes de ordenadores e Internet\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-1\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-1\"}]}"
   },
   {
     "url": "seo/es/redes/practice/tema-2.html",
@@ -8359,7 +8359,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/redes/practice/tema-2",
     "title": "Tema 2. Introducción a TCP/IP: preguntas de Redes",
-    "description": "Practica 19 preguntas de Tema 2. Introducción a TCP/IP de exámenes anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 19 preguntas de Tema 2. Introducción a TCP/IP de \"exámenes\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/redes/practice/tema-2",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -8383,7 +8383,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-2"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 2. Introducción a TCP/IP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-2\",\"inLanguage\":\"es\",\"description\":\"Practica 19 preguntas de Tema 2. Introducción a TCP/IP de exámenes anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 2. Introducción a TCP/IP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 2. Introducción a TCP/IP\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-2\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-2\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 2. Introducción a TCP/IP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-2\",\"inLanguage\":\"es\",\"description\":\"Practica 19 preguntas de Tema 2. Introducción a TCP/IP de \\\"exámenes\\\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 2. Introducción a TCP/IP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 2. Introducción a TCP/IP\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-2\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-2\"}]}"
   },
   {
     "url": "seo/es/redes/practice/tema-3-4.html",
@@ -8391,7 +8391,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/redes/practice/tema-3-4",
     "title": "Tema 3-4. Protocolos nivel de aplicación: preguntas de Redes",
-    "description": "Practica 77 preguntas de Tema 3-4. Protocolos nivel de aplicación de exámenes anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 77 preguntas de Tema 3-4. Protocolos nivel de aplicación de \"exámenes\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/redes/practice/tema-3-4",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -8415,7 +8415,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-3-4"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 3-4. Protocolos nivel de aplicación: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-3-4\",\"inLanguage\":\"es\",\"description\":\"Practica 77 preguntas de Tema 3-4. Protocolos nivel de aplicación de exámenes anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 3-4. Protocolos nivel de aplicación\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 3-4. Protocolos nivel de aplicación\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-3-4\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-3-4\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 3-4. Protocolos nivel de aplicación: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-3-4\",\"inLanguage\":\"es\",\"description\":\"Practica 77 preguntas de Tema 3-4. Protocolos nivel de aplicación de \\\"exámenes\\\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 3-4. Protocolos nivel de aplicación\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 3-4. Protocolos nivel de aplicación\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-3-4\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-3-4\"}]}"
   },
   {
     "url": "seo/es/redes/practice/tema-5.html",
@@ -8423,7 +8423,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/redes/practice/tema-5",
     "title": "Tema 5. Protocolos de transporte UDP y TCP: preguntas de Redes",
-    "description": "Practica 51 preguntas de Tema 5. Protocolos de transporte UDP y TCP de exámenes anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 51 preguntas de Tema 5. Protocolos de transporte UDP y TCP de \"exámenes\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/redes/practice/tema-5",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -8447,7 +8447,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-5"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 5. Protocolos de transporte UDP y TCP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-5\",\"inLanguage\":\"es\",\"description\":\"Practica 51 preguntas de Tema 5. Protocolos de transporte UDP y TCP de exámenes anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 5. Protocolos de transporte UDP y TCP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 5. Protocolos de transporte UDP y TCP\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-5\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-5\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 5. Protocolos de transporte UDP y TCP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-5\",\"inLanguage\":\"es\",\"description\":\"Practica 51 preguntas de Tema 5. Protocolos de transporte UDP y TCP de \\\"exámenes\\\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 5. Protocolos de transporte UDP y TCP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 5. Protocolos de transporte UDP y TCP\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-5\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-5\"}]}"
   },
   {
     "url": "seo/es/redes/practice/tema-6.html",
@@ -8455,7 +8455,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/redes/practice/tema-6",
     "title": "Tema 6. Intercambio de datos TCP: preguntas de Redes",
-    "description": "Practica 48 preguntas de Tema 6. Intercambio de datos TCP de exámenes anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 48 preguntas de Tema 6. Intercambio de datos TCP de \"exámenes\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/redes/practice/tema-6",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -8479,7 +8479,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-6"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 6. Intercambio de datos TCP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-6\",\"inLanguage\":\"es\",\"description\":\"Practica 48 preguntas de Tema 6. Intercambio de datos TCP de exámenes anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 6. Intercambio de datos TCP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 6. Intercambio de datos TCP\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-6\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-6\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 6. Intercambio de datos TCP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-6\",\"inLanguage\":\"es\",\"description\":\"Practica 48 preguntas de Tema 6. Intercambio de datos TCP de \\\"exámenes\\\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 6. Intercambio de datos TCP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 6. Intercambio de datos TCP\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-6\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-6\"}]}"
   },
   {
     "url": "seo/es/redes/practice/tema-7.html",
@@ -8487,7 +8487,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/redes/practice/tema-7",
     "title": "Tema 7. Nivel de red: protocolo IP: preguntas de Redes",
-    "description": "Practica 81 preguntas de Tema 7. Nivel de red: protocolo IP de exámenes anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 81 preguntas de Tema 7. Nivel de red: protocolo IP de \"exámenes\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/redes/practice/tema-7",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -8511,7 +8511,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-7"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 7. Nivel de red: protocolo IP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-7\",\"inLanguage\":\"es\",\"description\":\"Practica 81 preguntas de Tema 7. Nivel de red: protocolo IP de exámenes anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 7. Nivel de red: protocolo IP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 7. Nivel de red: protocolo IP\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-7\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-7\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 7. Nivel de red: protocolo IP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-7\",\"inLanguage\":\"es\",\"description\":\"Practica 81 preguntas de Tema 7. Nivel de red: protocolo IP de \\\"exámenes\\\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 7. Nivel de red: protocolo IP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 7. Nivel de red: protocolo IP\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-7\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-7\"}]}"
   },
   {
     "url": "seo/es/redes/practice/tema-8.html",
@@ -8519,7 +8519,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/redes/practice/tema-8",
     "title": "Tema 8. Enrutamiento: preguntas de Redes | Pásame Exámenes",
-    "description": "Practica 22 preguntas de Tema 8. Enrutamiento de exámenes anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 22 preguntas de Tema 8. Enrutamiento de \"exámenes\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/redes/practice/tema-8",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -8543,7 +8543,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-8"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 8. Enrutamiento: preguntas de Redes | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-8\",\"inLanguage\":\"es\",\"description\":\"Practica 22 preguntas de Tema 8. Enrutamiento de exámenes anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 8. Enrutamiento\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 8. Enrutamiento\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-8\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-8\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 8. Enrutamiento: preguntas de Redes | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-8\",\"inLanguage\":\"es\",\"description\":\"Practica 22 preguntas de Tema 8. Enrutamiento de \\\"exámenes\\\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 8. Enrutamiento\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 8. Enrutamiento\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-8\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-8\"}]}"
   },
   {
     "url": "seo/es/redes/practice/tema-9.html",
@@ -8551,7 +8551,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/redes/practice/tema-9",
     "title": "Tema 9. ICMP y fragmentación IP: preguntas de Redes",
-    "description": "Practica 24 preguntas de Tema 9. ICMP y fragmentación IP de exámenes anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 24 preguntas de Tema 9. ICMP y fragmentación IP de \"exámenes\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/redes/practice/tema-9",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -8575,7 +8575,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-9"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 9. ICMP y fragmentación IP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-9\",\"inLanguage\":\"es\",\"description\":\"Practica 24 preguntas de Tema 9. ICMP y fragmentación IP de exámenes anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 9. ICMP y fragmentación IP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 9. ICMP y fragmentación IP\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-9\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-9\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 9. ICMP y fragmentación IP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-9\",\"inLanguage\":\"es\",\"description\":\"Practica 24 preguntas de Tema 9. ICMP y fragmentación IP de \\\"exámenes\\\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 9. ICMP y fragmentación IP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 9. ICMP y fragmentación IP\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-9\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-9\"}]}"
   },
   {
     "url": "seo/es/redes/practice/tema-10.html",
@@ -8583,7 +8583,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/redes/practice/tema-10",
     "title": "Tema 10. Protocolo IPv6: preguntas de Redes | Pásame Exámenes",
-    "description": "Practica 11 preguntas de Tema 10. Protocolo IPv6 de exámenes anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 11 preguntas de Tema 10. Protocolo IPv6 de \"exámenes\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/redes/practice/tema-10",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -8607,7 +8607,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-10"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 10. Protocolo IPv6: preguntas de Redes | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-10\",\"inLanguage\":\"es\",\"description\":\"Practica 11 preguntas de Tema 10. Protocolo IPv6 de exámenes anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 10. Protocolo IPv6\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 10. Protocolo IPv6\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-10\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-10\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 10. Protocolo IPv6: preguntas de Redes | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-10\",\"inLanguage\":\"es\",\"description\":\"Practica 11 preguntas de Tema 10. Protocolo IPv6 de \\\"exámenes\\\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 10. Protocolo IPv6\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 10. Protocolo IPv6\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-10\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-10\"}]}"
   },
   {
     "url": "seo/es/redes/practice/tema-11.html",
@@ -8615,7 +8615,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/redes/practice/tema-11",
     "title": "Tema 11. TCP/IP y nivel de enlace: preguntas de Redes",
-    "description": "Practica 24 preguntas de Tema 11. TCP/IP y nivel de enlace de exámenes anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 24 preguntas de Tema 11. TCP/IP y nivel de enlace de \"exámenes\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/redes/practice/tema-11",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -8639,7 +8639,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-11"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 11. TCP/IP y nivel de enlace: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-11\",\"inLanguage\":\"es\",\"description\":\"Practica 24 preguntas de Tema 11. TCP/IP y nivel de enlace de exámenes anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 11. TCP/IP y nivel de enlace\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 11. TCP/IP y nivel de enlace\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-11\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-11\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 11. TCP/IP y nivel de enlace: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-11\",\"inLanguage\":\"es\",\"description\":\"Practica 24 preguntas de Tema 11. TCP/IP y nivel de enlace de \\\"exámenes\\\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 11. TCP/IP y nivel de enlace\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 11. TCP/IP y nivel de enlace\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-11\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-11\"}]}"
   },
   {
     "url": "seo/es/redes/practice/tema-12.html",
@@ -8647,7 +8647,7 @@ export const pages = [
     "lang": "es",
     "pathWithoutLang": "/redes/practice/tema-12",
     "title": "Tema 12. Tecnologías del nivel de enlace: preguntas de Redes",
-    "description": "Practica 49 preguntas de Tema 12. Tecnologías del nivel de enlace de exámenes anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 49 preguntas de Tema 12. Tecnologías del nivel de enlace de \"exámenes\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/redes/practice/tema-12",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -8671,7 +8671,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-12"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 12. Tecnologías del nivel de enlace: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-12\",\"inLanguage\":\"es\",\"description\":\"Practica 49 preguntas de Tema 12. Tecnologías del nivel de enlace de exámenes anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 12. Tecnologías del nivel de enlace\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 12. Tecnologías del nivel de enlace\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-12\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-12\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 12. Tecnologías del nivel de enlace: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-12\",\"inLanguage\":\"es\",\"description\":\"Practica 49 preguntas de Tema 12. Tecnologías del nivel de enlace de \\\"exámenes\\\" anteriores de Redes, con respuestas modelo y autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 12. Tecnologías del nivel de enlace\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 12. Tecnologías del nivel de enlace\",\"item\":\"https://pe.pablopl.dev/es/redes/practice/tema-12\"}],\"url\":\"https://pe.pablopl.dev/es/redes/practice/tema-12\"}]}"
   },
   {
     "url": "seo/es/redes/exam/daypo-recopilatorio-lara.html",
@@ -8742,8 +8742,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "es",
     "pathWithoutLang": "/redes/exam/2025-05",
-    "title": "Mayo 2025 (incompl.) de Redes: simulador | Pásame Exámenes",
-    "description": "Simula el examen Mayo 2025 (incompl.) de Redes con 37 preguntas. 37 puntos, 120 minutos, respuestas modelo y autocorrección.",
+    "title": "Posibles preguntas Mayo 2025 de Redes: simulador",
+    "description": "Simula el examen Posibles preguntas Mayo 2025 de Redes con 37 preguntas. 37 puntos, 120 minutos, respuestas modelo y autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/es/redes/exam/2025-05",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -8767,7 +8767,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/exam/2025-05"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Mayo 2025 (incompl.) de Redes: simulador | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/es/redes/exam/2025-05\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Mayo 2025 (incompl.) de Redes con 37 preguntas. 37 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Mayo 2025 (incompl.)\",\"item\":\"https://pe.pablopl.dev/es/redes/exam/2025-05\"}],\"url\":\"https://pe.pablopl.dev/es/redes/exam/2025-05\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Mayo 2025 de Redes: simulador\",\"url\":\"https://pe.pablopl.dev/es/redes/exam/2025-05\",\"inLanguage\":\"es\",\"description\":\"Simula el examen Posibles preguntas Mayo 2025 de Redes con 37 preguntas. 37 puntos, 120 minutos, respuestas modelo y autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/es\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/es/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Mayo 2025\",\"item\":\"https://pe.pablopl.dev/es/redes/exam/2025-05\"}],\"url\":\"https://pe.pablopl.dev/es/redes/exam/2025-05\"}]}"
   },
   {
     "url": "seo/gl.html",
@@ -8806,8 +8806,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/bede",
-    "title": "Bases de Datos: exames e preguntas resoltas | Pásame Exámenes",
-    "description": "Practica 98 preguntas de Bases de Datos de 1 exames anteriores con respostas modelo e autocorrección. 202315, Universidade da Coruña.",
+    "title": "Bases de Datos: \"exames\" e preguntas resoltas",
+    "description": "Practica 98 preguntas de Bases de Datos de 1 \"exames\" anteriores con respostas modelo e autocorrección. 202315, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/bede",
     "ogImage": "https://pe.pablopl.dev/og/bede.png",
@@ -8831,7 +8831,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/bede"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Bases de Datos: exames e preguntas resoltas | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/bede\",\"inLanguage\":\"gl\",\"description\":\"Practica 98 preguntas de Bases de Datos de 1 exames anteriores con respostas modelo e autocorrección. 202315, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/gl/bede\"}],\"url\":\"https://pe.pablopl.dev/gl/bede\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Bases de Datos: \\\"exames\\\" e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/bede\",\"inLanguage\":\"gl\",\"description\":\"Practica 98 preguntas de Bases de Datos de 1 \\\"exames\\\" anteriores con respostas modelo e autocorrección. 202315, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/gl/bede\"}],\"url\":\"https://pe.pablopl.dev/gl/bede\"}]}"
   },
   {
     "url": "seo/gl/bede/practice/recuperacion-concurrencia.html",
@@ -8839,7 +8839,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/bede/practice/recuperacion-concurrencia",
     "title": "Recuperación y Concurrencia: preguntas de Bases de Datos",
-    "description": "Practica 48 preguntas de Recuperación y Concurrencia de exames anteriores de Bases de Datos, con respostas modelo e autocorrección. 202315, Universidade da Coruña.",
+    "description": "Practica 48 preguntas de Recuperación y Concurrencia de \"exames\" anteriores de Bases de Datos, con respostas modelo e autocorrección. 202315, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/bede/practice/recuperacion-concurrencia",
     "ogImage": "https://pe.pablopl.dev/og/bede.png",
@@ -8863,7 +8863,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/bede/practice/recuperacion-concurrencia"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Recuperación y Concurrencia: preguntas de Bases de Datos\",\"url\":\"https://pe.pablopl.dev/gl/bede/practice/recuperacion-concurrencia\",\"inLanguage\":\"gl\",\"description\":\"Practica 48 preguntas de Recuperación y Concurrencia de exames anteriores de Bases de Datos, con respostas modelo e autocorrección. 202315, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Recuperación y Concurrencia\"},{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/gl/bede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Recuperación y Concurrencia\",\"item\":\"https://pe.pablopl.dev/gl/bede/practice/recuperacion-concurrencia\"}],\"url\":\"https://pe.pablopl.dev/gl/bede/practice/recuperacion-concurrencia\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Recuperación y Concurrencia: preguntas de Bases de Datos\",\"url\":\"https://pe.pablopl.dev/gl/bede/practice/recuperacion-concurrencia\",\"inLanguage\":\"gl\",\"description\":\"Practica 48 preguntas de Recuperación y Concurrencia de \\\"exames\\\" anteriores de Bases de Datos, con respostas modelo e autocorrección. 202315, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Recuperación y Concurrencia\"},{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/gl/bede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Recuperación y Concurrencia\",\"item\":\"https://pe.pablopl.dev/gl/bede/practice/recuperacion-concurrencia\"}],\"url\":\"https://pe.pablopl.dev/gl/bede/practice/recuperacion-concurrencia\"}]}"
   },
   {
     "url": "seo/gl/bede/practice/ficheros.html",
@@ -8871,7 +8871,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/bede/practice/ficheros",
     "title": "Ficheros: preguntas de Bases de Datos | Pásame Exámenes",
-    "description": "Practica 50 preguntas de Ficheros de exames anteriores de Bases de Datos, con respostas modelo e autocorrección. 202315, Universidade da Coruña.",
+    "description": "Practica 50 preguntas de Ficheros de \"exames\" anteriores de Bases de Datos, con respostas modelo e autocorrección. 202315, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/bede/practice/ficheros",
     "ogImage": "https://pe.pablopl.dev/og/bede.png",
@@ -8895,7 +8895,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/bede/practice/ficheros"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Ficheros: preguntas de Bases de Datos | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/bede/practice/ficheros\",\"inLanguage\":\"gl\",\"description\":\"Practica 50 preguntas de Ficheros de exames anteriores de Bases de Datos, con respostas modelo e autocorrección. 202315, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Ficheros\"},{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/gl/bede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Ficheros\",\"item\":\"https://pe.pablopl.dev/gl/bede/practice/ficheros\"}],\"url\":\"https://pe.pablopl.dev/gl/bede/practice/ficheros\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Ficheros: preguntas de Bases de Datos | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/bede/practice/ficheros\",\"inLanguage\":\"gl\",\"description\":\"Practica 50 preguntas de Ficheros de \\\"exames\\\" anteriores de Bases de Datos, con respostas modelo e autocorrección. 202315, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Ficheros\"},{\"@type\":\"Course\",\"name\":\"Bases de Datos\",\"courseCode\":\"202315\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Bases de Datos\",\"item\":\"https://pe.pablopl.dev/gl/bede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Ficheros\",\"item\":\"https://pe.pablopl.dev/gl/bede/practice/ficheros\"}],\"url\":\"https://pe.pablopl.dev/gl/bede/practice/ficheros\"}]}"
   },
   {
     "url": "seo/gl/bede/exam/daypo-preguntas.html",
@@ -8934,8 +8934,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/cepe",
-    "title": "Concorrencia e Paralelismo: exames e preguntas resoltas",
-    "description": "Practica 76 preguntas de Concorrencia e Paralelismo de 16 exames anteriores con respostas modelo e autocorrección. 202320, Universidade da Coruña.",
+    "title": "Concorrencia e Paralelismo: \"exames\" e preguntas resoltas",
+    "description": "Practica 76 preguntas de Concorrencia e Paralelismo de 16 \"exames\" anteriores con respostas modelo e autocorrección. 202320, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/cepe",
     "ogImage": "https://pe.pablopl.dev/og/cepe.png",
@@ -8959,7 +8959,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/cepe"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Concorrencia e Paralelismo: exames e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/cepe\",\"inLanguage\":\"gl\",\"description\":\"Practica 76 preguntas de Concorrencia e Paralelismo de 16 exames anteriores con respostas modelo e autocorrección. 202320, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/gl/cepe\"}],\"url\":\"https://pe.pablopl.dev/gl/cepe\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Concorrencia e Paralelismo: \\\"exames\\\" e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/cepe\",\"inLanguage\":\"gl\",\"description\":\"Practica 76 preguntas de Concorrencia e Paralelismo de 16 \\\"exames\\\" anteriores con respostas modelo e autocorrección. 202320, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/gl/cepe\"}],\"url\":\"https://pe.pablopl.dev/gl/cepe\"}]}"
   },
   {
     "url": "seo/gl/cepe/practice/concurrencia-mutex.html",
@@ -8967,7 +8967,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/cepe/practice/concurrencia-mutex",
     "title": "Mutex y Condiciones: preguntas de Concorrencia e Paralelismo",
-    "description": "Practica 32 preguntas de Mutex y Condiciones de exames anteriores de Concorrencia e Paralelismo, con respostas modelo e autocorrección. 202320, Universidade da Coruña.",
+    "description": "Practica 32 preguntas de Mutex y Condiciones de \"exames\" anteriores de Concorrencia e Paralelismo, con respostas modelo e autocorrección. 202320, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/cepe/practice/concurrencia-mutex",
     "ogImage": "https://pe.pablopl.dev/og/cepe.png",
@@ -8991,7 +8991,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/cepe/practice/concurrencia-mutex"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Mutex y Condiciones: preguntas de Concorrencia e Paralelismo\",\"url\":\"https://pe.pablopl.dev/gl/cepe/practice/concurrencia-mutex\",\"inLanguage\":\"gl\",\"description\":\"Practica 32 preguntas de Mutex y Condiciones de exames anteriores de Concorrencia e Paralelismo, con respostas modelo e autocorrección. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Mutex y Condiciones\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/gl/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Mutex y Condiciones\",\"item\":\"https://pe.pablopl.dev/gl/cepe/practice/concurrencia-mutex\"}],\"url\":\"https://pe.pablopl.dev/gl/cepe/practice/concurrencia-mutex\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Mutex y Condiciones: preguntas de Concorrencia e Paralelismo\",\"url\":\"https://pe.pablopl.dev/gl/cepe/practice/concurrencia-mutex\",\"inLanguage\":\"gl\",\"description\":\"Practica 32 preguntas de Mutex y Condiciones de \\\"exames\\\" anteriores de Concorrencia e Paralelismo, con respostas modelo e autocorrección. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Mutex y Condiciones\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/gl/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Mutex y Condiciones\",\"item\":\"https://pe.pablopl.dev/gl/cepe/practice/concurrencia-mutex\"}],\"url\":\"https://pe.pablopl.dev/gl/cepe/practice/concurrencia-mutex\"}]}"
   },
   {
     "url": "seo/gl/cepe/practice/concurrencia-erlang.html",
@@ -8999,7 +8999,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/cepe/practice/concurrencia-erlang",
     "title": "Erlang: preguntas de Concorrencia e Paralelismo",
-    "description": "Practica 12 preguntas de Erlang de exames anteriores de Concorrencia e Paralelismo, con respostas modelo e autocorrección. 202320, Universidade da Coruña.",
+    "description": "Practica 12 preguntas de Erlang de \"exames\" anteriores de Concorrencia e Paralelismo, con respostas modelo e autocorrección. 202320, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/cepe/practice/concurrencia-erlang",
     "ogImage": "https://pe.pablopl.dev/og/cepe.png",
@@ -9023,7 +9023,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/cepe/practice/concurrencia-erlang"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Erlang: preguntas de Concorrencia e Paralelismo\",\"url\":\"https://pe.pablopl.dev/gl/cepe/practice/concurrencia-erlang\",\"inLanguage\":\"gl\",\"description\":\"Practica 12 preguntas de Erlang de exames anteriores de Concorrencia e Paralelismo, con respostas modelo e autocorrección. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Erlang\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/gl/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Erlang\",\"item\":\"https://pe.pablopl.dev/gl/cepe/practice/concurrencia-erlang\"}],\"url\":\"https://pe.pablopl.dev/gl/cepe/practice/concurrencia-erlang\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Erlang: preguntas de Concorrencia e Paralelismo\",\"url\":\"https://pe.pablopl.dev/gl/cepe/practice/concurrencia-erlang\",\"inLanguage\":\"gl\",\"description\":\"Practica 12 preguntas de Erlang de \\\"exames\\\" anteriores de Concorrencia e Paralelismo, con respostas modelo e autocorrección. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Erlang\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/gl/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Erlang\",\"item\":\"https://pe.pablopl.dev/gl/cepe/practice/concurrencia-erlang\"}],\"url\":\"https://pe.pablopl.dev/gl/cepe/practice/concurrencia-erlang\"}]}"
   },
   {
     "url": "seo/gl/cepe/practice/paralelismo-teoria.html",
@@ -9031,7 +9031,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/cepe/practice/paralelismo-teoria",
     "title": "Preguntas Teóricas: preguntas de Concorrencia e Paralelismo",
-    "description": "Practica 19 preguntas de Preguntas Teóricas de exames anteriores de Concorrencia e Paralelismo, con respostas modelo e autocorrección. 202320, Universidade da Coruña.",
+    "description": "Practica 19 preguntas de Preguntas Teóricas de \"exames\" anteriores de Concorrencia e Paralelismo, con respostas modelo e autocorrección. 202320, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/cepe/practice/paralelismo-teoria",
     "ogImage": "https://pe.pablopl.dev/og/cepe.png",
@@ -9055,7 +9055,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/cepe/practice/paralelismo-teoria"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Preguntas Teóricas: preguntas de Concorrencia e Paralelismo\",\"url\":\"https://pe.pablopl.dev/gl/cepe/practice/paralelismo-teoria\",\"inLanguage\":\"gl\",\"description\":\"Practica 19 preguntas de Preguntas Teóricas de exames anteriores de Concorrencia e Paralelismo, con respostas modelo e autocorrección. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Preguntas Teóricas\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/gl/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Preguntas Teóricas\",\"item\":\"https://pe.pablopl.dev/gl/cepe/practice/paralelismo-teoria\"}],\"url\":\"https://pe.pablopl.dev/gl/cepe/practice/paralelismo-teoria\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Preguntas Teóricas: preguntas de Concorrencia e Paralelismo\",\"url\":\"https://pe.pablopl.dev/gl/cepe/practice/paralelismo-teoria\",\"inLanguage\":\"gl\",\"description\":\"Practica 19 preguntas de Preguntas Teóricas de \\\"exames\\\" anteriores de Concorrencia e Paralelismo, con respostas modelo e autocorrección. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Preguntas Teóricas\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/gl/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Preguntas Teóricas\",\"item\":\"https://pe.pablopl.dev/gl/cepe/practice/paralelismo-teoria\"}],\"url\":\"https://pe.pablopl.dev/gl/cepe/practice/paralelismo-teoria\"}]}"
   },
   {
     "url": "seo/gl/cepe/practice/paralelismo-mpi.html",
@@ -9063,7 +9063,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/cepe/practice/paralelismo-mpi",
     "title": "Ejercicios de MPI: preguntas de Concorrencia e Paralelismo",
-    "description": "Practica 13 preguntas de Ejercicios de MPI de exames anteriores de Concorrencia e Paralelismo, con respostas modelo e autocorrección. 202320, Universidade da Coruña.",
+    "description": "Practica 13 preguntas de Ejercicios de MPI de \"exames\" anteriores de Concorrencia e Paralelismo, con respostas modelo e autocorrección. 202320, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/cepe/practice/paralelismo-mpi",
     "ogImage": "https://pe.pablopl.dev/og/cepe.png",
@@ -9087,7 +9087,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/cepe/practice/paralelismo-mpi"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Ejercicios de MPI: preguntas de Concorrencia e Paralelismo\",\"url\":\"https://pe.pablopl.dev/gl/cepe/practice/paralelismo-mpi\",\"inLanguage\":\"gl\",\"description\":\"Practica 13 preguntas de Ejercicios de MPI de exames anteriores de Concorrencia e Paralelismo, con respostas modelo e autocorrección. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Ejercicios de MPI\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/gl/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Ejercicios de MPI\",\"item\":\"https://pe.pablopl.dev/gl/cepe/practice/paralelismo-mpi\"}],\"url\":\"https://pe.pablopl.dev/gl/cepe/practice/paralelismo-mpi\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Ejercicios de MPI: preguntas de Concorrencia e Paralelismo\",\"url\":\"https://pe.pablopl.dev/gl/cepe/practice/paralelismo-mpi\",\"inLanguage\":\"gl\",\"description\":\"Practica 13 preguntas de Ejercicios de MPI de \\\"exames\\\" anteriores de Concorrencia e Paralelismo, con respostas modelo e autocorrección. 202320, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Ejercicios de MPI\"},{\"@type\":\"Course\",\"name\":\"Concorrencia e Paralelismo\",\"courseCode\":\"202320\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Concorrencia e Paralelismo\",\"item\":\"https://pe.pablopl.dev/gl/cepe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Ejercicios de MPI\",\"item\":\"https://pe.pablopl.dev/gl/cepe/practice/paralelismo-mpi\"}],\"url\":\"https://pe.pablopl.dev/gl/cepe/practice/paralelismo-mpi\"}]}"
   },
   {
     "url": "seo/gl/cepe/exam/2018-06.html",
@@ -9606,8 +9606,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/deese",
-    "title": "Deseño de Software: exames e preguntas resoltas",
-    "description": "Practica 55 preguntas de Deseño de Software de 2 exames anteriores con respostas modelo e autocorrección. 202317, Universidade da Coruña.",
+    "title": "Deseño de Software: \"exames\" e preguntas resoltas",
+    "description": "Practica 55 preguntas de Deseño de Software de 2 \"exames\" anteriores con respostas modelo e autocorrección. 202317, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/deese",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -9631,7 +9631,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Deseño de Software: exames e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/deese\",\"inLanguage\":\"gl\",\"description\":\"Practica 55 preguntas de Deseño de Software de 2 exames anteriores con respostas modelo e autocorrección. 202317, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/gl/deese\"}],\"url\":\"https://pe.pablopl.dev/gl/deese\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Deseño de Software: \\\"exames\\\" e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/deese\",\"inLanguage\":\"gl\",\"description\":\"Practica 55 preguntas de Deseño de Software de 2 \\\"exames\\\" anteriores con respostas modelo e autocorrección. 202317, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/gl/deese\"}],\"url\":\"https://pe.pablopl.dev/gl/deese\"}]}"
   },
   {
     "url": "seo/gl/deese/practice/intro-y-objetos.html",
@@ -9639,7 +9639,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/deese/practice/intro-y-objetos",
     "title": "Introducción y Elementos Básicos de la OO: preguntas de Deseño de Software",
-    "description": "Practica 12 preguntas de Introducción y Elementos Básicos de la OO de exames anteriores de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.",
+    "description": "Practica 12 preguntas de Introducción y Elementos Básicos de la OO de \"exames\" anteriores de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/deese/practice/intro-y-objetos",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -9663,7 +9663,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/practice/intro-y-objetos"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Introducción y Elementos Básicos de la OO: preguntas de Deseño de Software\",\"url\":\"https://pe.pablopl.dev/gl/deese/practice/intro-y-objetos\",\"inLanguage\":\"gl\",\"description\":\"Practica 12 preguntas de Introducción y Elementos Básicos de la OO de exames anteriores de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Introducción y Elementos Básicos de la OO\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/gl/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Introducción y Elementos Básicos de la OO\",\"item\":\"https://pe.pablopl.dev/gl/deese/practice/intro-y-objetos\"}],\"url\":\"https://pe.pablopl.dev/gl/deese/practice/intro-y-objetos\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Introducción y Elementos Básicos de la OO: preguntas de Deseño de Software\",\"url\":\"https://pe.pablopl.dev/gl/deese/practice/intro-y-objetos\",\"inLanguage\":\"gl\",\"description\":\"Practica 12 preguntas de Introducción y Elementos Básicos de la OO de \\\"exames\\\" anteriores de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Introducción y Elementos Básicos de la OO\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/gl/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Introducción y Elementos Básicos de la OO\",\"item\":\"https://pe.pablopl.dev/gl/deese/practice/intro-y-objetos\"}],\"url\":\"https://pe.pablopl.dev/gl/deese/practice/intro-y-objetos\"}]}"
   },
   {
     "url": "seo/gl/deese/practice/propiedades-oo.html",
@@ -9671,7 +9671,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/deese/practice/propiedades-oo",
     "title": "Propiedades Básicas de la OO: preguntas de Deseño de Software",
-    "description": "Practica 11 preguntas de Propiedades Básicas de la OO de exames anteriores de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.",
+    "description": "Practica 11 preguntas de Propiedades Básicas de la OO de \"exames\" anteriores de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/deese/practice/propiedades-oo",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -9695,7 +9695,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/practice/propiedades-oo"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Propiedades Básicas de la OO: preguntas de Deseño de Software\",\"url\":\"https://pe.pablopl.dev/gl/deese/practice/propiedades-oo\",\"inLanguage\":\"gl\",\"description\":\"Practica 11 preguntas de Propiedades Básicas de la OO de exames anteriores de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Propiedades Básicas de la OO\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/gl/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Propiedades Básicas de la OO\",\"item\":\"https://pe.pablopl.dev/gl/deese/practice/propiedades-oo\"}],\"url\":\"https://pe.pablopl.dev/gl/deese/practice/propiedades-oo\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Propiedades Básicas de la OO: preguntas de Deseño de Software\",\"url\":\"https://pe.pablopl.dev/gl/deese/practice/propiedades-oo\",\"inLanguage\":\"gl\",\"description\":\"Practica 11 preguntas de Propiedades Básicas de la OO de \\\"exames\\\" anteriores de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Propiedades Básicas de la OO\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/gl/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Propiedades Básicas de la OO\",\"item\":\"https://pe.pablopl.dev/gl/deese/practice/propiedades-oo\"}],\"url\":\"https://pe.pablopl.dev/gl/deese/practice/propiedades-oo\"}]}"
   },
   {
     "url": "seo/gl/deese/practice/uml.html",
@@ -9703,7 +9703,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/deese/practice/uml",
     "title": "UML: preguntas de Deseño de Software | Pásame Exámenes",
-    "description": "Practica 10 preguntas de UML de exames anteriores de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.",
+    "description": "Practica 10 preguntas de UML de \"exames\" anteriores de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/deese/practice/uml",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -9727,7 +9727,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/practice/uml"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"UML: preguntas de Deseño de Software | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/deese/practice/uml\",\"inLanguage\":\"gl\",\"description\":\"Practica 10 preguntas de UML de exames anteriores de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"UML\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/gl/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"UML\",\"item\":\"https://pe.pablopl.dev/gl/deese/practice/uml\"}],\"url\":\"https://pe.pablopl.dev/gl/deese/practice/uml\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"UML: preguntas de Deseño de Software | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/deese/practice/uml\",\"inLanguage\":\"gl\",\"description\":\"Practica 10 preguntas de UML de \\\"exames\\\" anteriores de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"UML\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/gl/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"UML\",\"item\":\"https://pe.pablopl.dev/gl/deese/practice/uml\"}],\"url\":\"https://pe.pablopl.dev/gl/deese/practice/uml\"}]}"
   },
   {
     "url": "seo/gl/deese/practice/principios-diseno.html",
@@ -9735,7 +9735,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/deese/practice/principios-diseno",
     "title": "Principios de Diseño: preguntas de Deseño de Software",
-    "description": "Practica 12 preguntas de Principios de Diseño de exames anteriores de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.",
+    "description": "Practica 12 preguntas de Principios de Diseño de \"exames\" anteriores de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/deese/practice/principios-diseno",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -9759,7 +9759,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/practice/principios-diseno"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Principios de Diseño: preguntas de Deseño de Software\",\"url\":\"https://pe.pablopl.dev/gl/deese/practice/principios-diseno\",\"inLanguage\":\"gl\",\"description\":\"Practica 12 preguntas de Principios de Diseño de exames anteriores de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Principios de Diseño\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/gl/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Principios de Diseño\",\"item\":\"https://pe.pablopl.dev/gl/deese/practice/principios-diseno\"}],\"url\":\"https://pe.pablopl.dev/gl/deese/practice/principios-diseno\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Principios de Diseño: preguntas de Deseño de Software\",\"url\":\"https://pe.pablopl.dev/gl/deese/practice/principios-diseno\",\"inLanguage\":\"gl\",\"description\":\"Practica 12 preguntas de Principios de Diseño de \\\"exames\\\" anteriores de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Principios de Diseño\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/gl/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Principios de Diseño\",\"item\":\"https://pe.pablopl.dev/gl/deese/practice/principios-diseno\"}],\"url\":\"https://pe.pablopl.dev/gl/deese/practice/principios-diseno\"}]}"
   },
   {
     "url": "seo/gl/deese/practice/patrones-diseno.html",
@@ -9767,7 +9767,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/deese/practice/patrones-diseno",
     "title": "Patrones de Diseño: preguntas de Deseño de Software",
-    "description": "Practica 10 preguntas de Patrones de Diseño de exames anteriores de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.",
+    "description": "Practica 10 preguntas de Patrones de Diseño de \"exames\" anteriores de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/deese/practice/patrones-diseno",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -9791,15 +9791,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/practice/patrones-diseno"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Patrones de Diseño: preguntas de Deseño de Software\",\"url\":\"https://pe.pablopl.dev/gl/deese/practice/patrones-diseno\",\"inLanguage\":\"gl\",\"description\":\"Practica 10 preguntas de Patrones de Diseño de exames anteriores de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Patrones de Diseño\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/gl/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Patrones de Diseño\",\"item\":\"https://pe.pablopl.dev/gl/deese/practice/patrones-diseno\"}],\"url\":\"https://pe.pablopl.dev/gl/deese/practice/patrones-diseno\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Patrones de Diseño: preguntas de Deseño de Software\",\"url\":\"https://pe.pablopl.dev/gl/deese/practice/patrones-diseno\",\"inLanguage\":\"gl\",\"description\":\"Practica 10 preguntas de Patrones de Diseño de \\\"exames\\\" anteriores de Deseño de Software, con respostas modelo e autocorrección. 202317, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Patrones de Diseño\"},{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/gl/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Patrones de Diseño\",\"item\":\"https://pe.pablopl.dev/gl/deese/practice/patrones-diseno\"}],\"url\":\"https://pe.pablopl.dev/gl/deese/practice/patrones-diseno\"}]}"
   },
   {
     "url": "seo/gl/deese/exam/2020-01.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/deese/exam/2020-01",
-    "title": "Enero 2020 de Deseño de Software: simulador | Pásame Exámenes",
-    "description": "Simula o exame Enero 2020 de Deseño de Software con 30 preguntas. 30 puntos, 150 minutos, respostas modelo e autocorrección.",
+    "title": "Posibles preguntas Enero 2020 de Deseño de Software: simulador",
+    "description": "Simula o exame Posibles preguntas Enero 2020 de Deseño de Software con 30 preguntas. 30 puntos, 150 minutos, respostas modelo e autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/deese/exam/2020-01",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -9823,15 +9823,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/exam/2020-01"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Enero 2020 de Deseño de Software: simulador | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/deese/exam/2020-01\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Enero 2020 de Deseño de Software con 30 preguntas. 30 puntos, 150 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/gl/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Enero 2020\",\"item\":\"https://pe.pablopl.dev/gl/deese/exam/2020-01\"}],\"url\":\"https://pe.pablopl.dev/gl/deese/exam/2020-01\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Enero 2020 de Deseño de Software: simulador\",\"url\":\"https://pe.pablopl.dev/gl/deese/exam/2020-01\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Posibles preguntas Enero 2020 de Deseño de Software con 30 preguntas. 30 puntos, 150 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/gl/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Enero 2020\",\"item\":\"https://pe.pablopl.dev/gl/deese/exam/2020-01\"}],\"url\":\"https://pe.pablopl.dev/gl/deese/exam/2020-01\"}]}"
   },
   {
     "url": "seo/gl/deese/exam/2022-01.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/deese/exam/2022-01",
-    "title": "Enero 2022 de Deseño de Software: simulador | Pásame Exámenes",
-    "description": "Simula o exame Enero 2022 de Deseño de Software con 25 preguntas. 25 puntos, 150 minutos, respostas modelo e autocorrección.",
+    "title": "Posibles preguntas Enero 2022 de Deseño de Software: simulador",
+    "description": "Simula o exame Posibles preguntas Enero 2022 de Deseño de Software con 25 preguntas. 25 puntos, 150 minutos, respostas modelo e autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/deese/exam/2022-01",
     "ogImage": "https://pe.pablopl.dev/og/deese.png",
@@ -9855,15 +9855,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/deese/exam/2022-01"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Enero 2022 de Deseño de Software: simulador | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/deese/exam/2022-01\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Enero 2022 de Deseño de Software con 25 preguntas. 25 puntos, 150 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/gl/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Enero 2022\",\"item\":\"https://pe.pablopl.dev/gl/deese/exam/2022-01\"}],\"url\":\"https://pe.pablopl.dev/gl/deese/exam/2022-01\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Enero 2022 de Deseño de Software: simulador\",\"url\":\"https://pe.pablopl.dev/gl/deese/exam/2022-01\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Posibles preguntas Enero 2022 de Deseño de Software con 25 preguntas. 25 puntos, 150 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Deseño de Software\",\"courseCode\":\"202317\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Deseño de Software\",\"item\":\"https://pe.pablopl.dev/gl/deese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Enero 2022\",\"item\":\"https://pe.pablopl.dev/gl/deese/exam/2022-01\"}],\"url\":\"https://pe.pablopl.dev/gl/deese/exam/2022-01\"}]}"
   },
   {
     "url": "seo/gl/ece.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/ece",
-    "title": "Estrutura de Computadores: exames e preguntas resoltas",
-    "description": "Practica 51 preguntas de Estrutura de Computadores de 11 exames anteriores con respostas modelo e autocorrección. 202314, Universidade da Coruña.",
+    "title": "Estrutura de Computadores: \"exames\" e preguntas resoltas",
+    "description": "Practica 51 preguntas de Estrutura de Computadores de 11 \"exames\" anteriores con respostas modelo e autocorrección. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/ece",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -9887,7 +9887,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Estrutura de Computadores: exames e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/ece\",\"inLanguage\":\"gl\",\"description\":\"Practica 51 preguntas de Estrutura de Computadores de 11 exames anteriores con respostas modelo e autocorrección. 202314, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/gl/ece\"}],\"url\":\"https://pe.pablopl.dev/gl/ece\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Estrutura de Computadores: \\\"exames\\\" e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/ece\",\"inLanguage\":\"gl\",\"description\":\"Practica 51 preguntas de Estrutura de Computadores de 11 \\\"exames\\\" anteriores con respostas modelo e autocorrección. 202314, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/gl/ece\"}],\"url\":\"https://pe.pablopl.dev/gl/ece\"}]}"
   },
   {
     "url": "seo/gl/ece/practice/rendimiento.html",
@@ -9895,7 +9895,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/ece/practice/rendimiento",
     "title": "Rendimiento: preguntas de Estrutura de Computadores",
-    "description": "Practica 7 preguntas de Rendimiento de exames anteriores de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.",
+    "description": "Practica 7 preguntas de Rendimiento de \"exames\" anteriores de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/ece/practice/rendimiento",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -9919,7 +9919,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece/practice/rendimiento"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Rendimiento: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/gl/ece/practice/rendimiento\",\"inLanguage\":\"gl\",\"description\":\"Practica 7 preguntas de Rendimiento de exames anteriores de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Rendimiento\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/gl/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Rendimiento\",\"item\":\"https://pe.pablopl.dev/gl/ece/practice/rendimiento\"}],\"url\":\"https://pe.pablopl.dev/gl/ece/practice/rendimiento\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Rendimiento: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/gl/ece/practice/rendimiento\",\"inLanguage\":\"gl\",\"description\":\"Practica 7 preguntas de Rendimiento de \\\"exames\\\" anteriores de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Rendimiento\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/gl/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Rendimiento\",\"item\":\"https://pe.pablopl.dev/gl/ece/practice/rendimiento\"}],\"url\":\"https://pe.pablopl.dev/gl/ece/practice/rendimiento\"}]}"
   },
   {
     "url": "seo/gl/ece/practice/segmentacion.html",
@@ -9927,7 +9927,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/ece/practice/segmentacion",
     "title": "Segmentación: preguntas de Estrutura de Computadores",
-    "description": "Practica 7 preguntas de Segmentación de exames anteriores de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.",
+    "description": "Practica 7 preguntas de Segmentación de \"exames\" anteriores de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/ece/practice/segmentacion",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -9951,7 +9951,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece/practice/segmentacion"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Segmentación: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/gl/ece/practice/segmentacion\",\"inLanguage\":\"gl\",\"description\":\"Practica 7 preguntas de Segmentación de exames anteriores de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Segmentación\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/gl/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Segmentación\",\"item\":\"https://pe.pablopl.dev/gl/ece/practice/segmentacion\"}],\"url\":\"https://pe.pablopl.dev/gl/ece/practice/segmentacion\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Segmentación: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/gl/ece/practice/segmentacion\",\"inLanguage\":\"gl\",\"description\":\"Practica 7 preguntas de Segmentación de \\\"exames\\\" anteriores de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Segmentación\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/gl/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Segmentación\",\"item\":\"https://pe.pablopl.dev/gl/ece/practice/segmentacion\"}],\"url\":\"https://pe.pablopl.dev/gl/ece/practice/segmentacion\"}]}"
   },
   {
     "url": "seo/gl/ece/practice/cache.html",
@@ -9959,7 +9959,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/ece/practice/cache",
     "title": "Memoria caché: preguntas de Estrutura de Computadores",
-    "description": "Practica 7 preguntas de Memoria caché de exames anteriores de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.",
+    "description": "Practica 7 preguntas de Memoria caché de \"exames\" anteriores de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/ece/practice/cache",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -9983,7 +9983,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece/practice/cache"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Memoria caché: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/gl/ece/practice/cache\",\"inLanguage\":\"gl\",\"description\":\"Practica 7 preguntas de Memoria caché de exames anteriores de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Memoria caché\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/gl/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Memoria caché\",\"item\":\"https://pe.pablopl.dev/gl/ece/practice/cache\"}],\"url\":\"https://pe.pablopl.dev/gl/ece/practice/cache\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Memoria caché: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/gl/ece/practice/cache\",\"inLanguage\":\"gl\",\"description\":\"Practica 7 preguntas de Memoria caché de \\\"exames\\\" anteriores de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Memoria caché\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/gl/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Memoria caché\",\"item\":\"https://pe.pablopl.dev/gl/ece/practice/cache\"}],\"url\":\"https://pe.pablopl.dev/gl/ece/practice/cache\"}]}"
   },
   {
     "url": "seo/gl/ece/practice/memoria-virtual.html",
@@ -9991,7 +9991,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/ece/practice/memoria-virtual",
     "title": "Memoria virtual: preguntas de Estrutura de Computadores",
-    "description": "Practica 11 preguntas de Memoria virtual de exames anteriores de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.",
+    "description": "Practica 11 preguntas de Memoria virtual de \"exames\" anteriores de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/ece/practice/memoria-virtual",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -10015,7 +10015,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece/practice/memoria-virtual"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Memoria virtual: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/gl/ece/practice/memoria-virtual\",\"inLanguage\":\"gl\",\"description\":\"Practica 11 preguntas de Memoria virtual de exames anteriores de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Memoria virtual\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/gl/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Memoria virtual\",\"item\":\"https://pe.pablopl.dev/gl/ece/practice/memoria-virtual\"}],\"url\":\"https://pe.pablopl.dev/gl/ece/practice/memoria-virtual\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Memoria virtual: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/gl/ece/practice/memoria-virtual\",\"inLanguage\":\"gl\",\"description\":\"Practica 11 preguntas de Memoria virtual de \\\"exames\\\" anteriores de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Memoria virtual\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/gl/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Memoria virtual\",\"item\":\"https://pe.pablopl.dev/gl/ece/practice/memoria-virtual\"}],\"url\":\"https://pe.pablopl.dev/gl/ece/practice/memoria-virtual\"}]}"
   },
   {
     "url": "seo/gl/ece/practice/buses.html",
@@ -10023,7 +10023,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/ece/practice/buses",
     "title": "Buses y E/S: preguntas de Estrutura de Computadores",
-    "description": "Practica 11 preguntas de Buses y E/S de exames anteriores de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.",
+    "description": "Practica 11 preguntas de Buses y E/S de \"exames\" anteriores de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/ece/practice/buses",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -10047,7 +10047,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece/practice/buses"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Buses y E/S: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/gl/ece/practice/buses\",\"inLanguage\":\"gl\",\"description\":\"Practica 11 preguntas de Buses y E/S de exames anteriores de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Buses y E/S\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/gl/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Buses y E/S\",\"item\":\"https://pe.pablopl.dev/gl/ece/practice/buses\"}],\"url\":\"https://pe.pablopl.dev/gl/ece/practice/buses\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Buses y E/S: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/gl/ece/practice/buses\",\"inLanguage\":\"gl\",\"description\":\"Practica 11 preguntas de Buses y E/S de \\\"exames\\\" anteriores de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Buses y E/S\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/gl/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Buses y E/S\",\"item\":\"https://pe.pablopl.dev/gl/ece/practice/buses\"}],\"url\":\"https://pe.pablopl.dev/gl/ece/practice/buses\"}]}"
   },
   {
     "url": "seo/gl/ece/practice/raid.html",
@@ -10055,7 +10055,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/ece/practice/raid",
     "title": "RAID y almacenamiento: preguntas de Estrutura de Computadores",
-    "description": "Practica 8 preguntas de RAID y almacenamiento de exames anteriores de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.",
+    "description": "Practica 8 preguntas de RAID y almacenamiento de \"exames\" anteriores de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/ece/practice/raid",
     "ogImage": "https://pe.pablopl.dev/og/ece.png",
@@ -10079,7 +10079,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/ece/practice/raid"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"RAID y almacenamiento: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/gl/ece/practice/raid\",\"inLanguage\":\"gl\",\"description\":\"Practica 8 preguntas de RAID y almacenamiento de exames anteriores de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"RAID y almacenamiento\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/gl/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"RAID y almacenamiento\",\"item\":\"https://pe.pablopl.dev/gl/ece/practice/raid\"}],\"url\":\"https://pe.pablopl.dev/gl/ece/practice/raid\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"RAID y almacenamiento: preguntas de Estrutura de Computadores\",\"url\":\"https://pe.pablopl.dev/gl/ece/practice/raid\",\"inLanguage\":\"gl\",\"description\":\"Practica 8 preguntas de RAID y almacenamiento de \\\"exames\\\" anteriores de Estrutura de Computadores, con respostas modelo e autocorrección. 202314, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"RAID y almacenamiento\"},{\"@type\":\"Course\",\"name\":\"Estrutura de Computadores\",\"courseCode\":\"202314\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Estrutura de Computadores\",\"item\":\"https://pe.pablopl.dev/gl/ece\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"RAID y almacenamiento\",\"item\":\"https://pe.pablopl.dev/gl/ece/practice/raid\"}],\"url\":\"https://pe.pablopl.dev/gl/ece/practice/raid\"}]}"
   },
   {
     "url": "seo/gl/ece/exam/2021-01.html",
@@ -10438,8 +10438,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/emeele",
-    "title": "Introduction to Machine Learning: exames e preguntas resoltas",
-    "description": "Practica 47 preguntas de Introduction to Machine Learning de 2 exames anteriores con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
+    "title": "Introduction to Machine Learning: \"exames\" e preguntas resoltas",
+    "description": "Practica 47 preguntas de Introduction to Machine Learning de 2 \"exames\" anteriores con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/emeele",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -10463,7 +10463,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Introduction to Machine Learning: exames e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/emeele\",\"inLanguage\":\"gl\",\"description\":\"Practica 47 preguntas de Introduction to Machine Learning de 2 exames anteriores con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Linnaeus University\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Introduction to Machine Learning: \\\"exames\\\" e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/emeele\",\"inLanguage\":\"gl\",\"description\":\"Practica 47 preguntas de Introduction to Machine Learning de 2 \\\"exames\\\" anteriores con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Linnaeus University\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele\"}]}"
   },
   {
     "url": "seo/gl/emeele/practice/kNN.html",
@@ -10471,7 +10471,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/emeele/practice/kNN",
     "title": "k-Nearest Neighbors: preguntas de Introduction to Machine Learning",
-    "description": "Practica 6 preguntas de k-Nearest Neighbors de exames anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
+    "description": "Practica 6 preguntas de k-Nearest Neighbors de \"exames\" anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/emeele/practice/kNN",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -10495,7 +10495,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/kNN"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"k-Nearest Neighbors: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/kNN\",\"inLanguage\":\"gl\",\"description\":\"Practica 6 preguntas de k-Nearest Neighbors de exames anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"k-Nearest Neighbors\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"k-Nearest Neighbors\",\"item\":\"https://pe.pablopl.dev/gl/emeele/practice/kNN\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/kNN\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"k-Nearest Neighbors: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/kNN\",\"inLanguage\":\"gl\",\"description\":\"Practica 6 preguntas de k-Nearest Neighbors de \\\"exames\\\" anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"k-Nearest Neighbors\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"k-Nearest Neighbors\",\"item\":\"https://pe.pablopl.dev/gl/emeele/practice/kNN\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/kNN\"}]}"
   },
   {
     "url": "seo/gl/emeele/practice/Bias-Variance.html",
@@ -10503,7 +10503,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/emeele/practice/Bias-Variance",
     "title": "Bias-Variance Tradeoff: preguntas de Introduction to Machine Learning",
-    "description": "Practica 5 preguntas de Bias-Variance Tradeoff de exames anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
+    "description": "Practica 5 preguntas de Bias-Variance Tradeoff de \"exames\" anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/emeele/practice/Bias-Variance",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -10527,7 +10527,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Bias-Variance"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Bias-Variance Tradeoff: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Bias-Variance\",\"inLanguage\":\"gl\",\"description\":\"Practica 5 preguntas de Bias-Variance Tradeoff de exames anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Bias-Variance Tradeoff\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Bias-Variance Tradeoff\",\"item\":\"https://pe.pablopl.dev/gl/emeele/practice/Bias-Variance\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Bias-Variance\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Bias-Variance Tradeoff: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Bias-Variance\",\"inLanguage\":\"gl\",\"description\":\"Practica 5 preguntas de Bias-Variance Tradeoff de \\\"exames\\\" anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Bias-Variance Tradeoff\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Bias-Variance Tradeoff\",\"item\":\"https://pe.pablopl.dev/gl/emeele/practice/Bias-Variance\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Bias-Variance\"}]}"
   },
   {
     "url": "seo/gl/emeele/practice/Linear%20%26%20Logistic%20Regression.html",
@@ -10535,7 +10535,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/emeele/practice/Linear & Logistic Regression",
     "title": "Linear & Logistic Regression: preguntas de Introduction to Machine Learning",
-    "description": "Practica 5 preguntas de Linear & Logistic Regression de exames anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
+    "description": "Practica 5 preguntas de Linear & Logistic Regression de \"exames\" anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/emeele/practice/Linear%20%26%20Logistic%20Regression",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -10559,7 +10559,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Linear%20%26%20Logistic%20Regression"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Linear & Logistic Regression: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Linear%20%26%20Logistic%20Regression\",\"inLanguage\":\"gl\",\"description\":\"Practica 5 preguntas de Linear & Logistic Regression de exames anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Linear & Logistic Regression\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Linear & Logistic Regression\",\"item\":\"https://pe.pablopl.dev/gl/emeele/practice/Linear%20%26%20Logistic%20Regression\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Linear%20%26%20Logistic%20Regression\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Linear & Logistic Regression: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Linear%20%26%20Logistic%20Regression\",\"inLanguage\":\"gl\",\"description\":\"Practica 5 preguntas de Linear & Logistic Regression de \\\"exames\\\" anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Linear & Logistic Regression\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Linear & Logistic Regression\",\"item\":\"https://pe.pablopl.dev/gl/emeele/practice/Linear%20%26%20Logistic%20Regression\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Linear%20%26%20Logistic%20Regression\"}]}"
   },
   {
     "url": "seo/gl/emeele/practice/Model%20Selection%20%26%20Regularization.html",
@@ -10567,7 +10567,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/emeele/practice/Model Selection & Regularization",
     "title": "Model Selection & Regularization: preguntas de Introduction to Machine Learning",
-    "description": "Practica 5 preguntas de Model Selection & Regularization de exames anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
+    "description": "Practica 5 preguntas de Model Selection & Regularization de \"exames\" anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/emeele/practice/Model%20Selection%20%26%20Regularization",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -10591,7 +10591,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Model%20Selection%20%26%20Regularization"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Model Selection & Regularization: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Model%20Selection%20%26%20Regularization\",\"inLanguage\":\"gl\",\"description\":\"Practica 5 preguntas de Model Selection & Regularization de exames anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Model Selection & Regularization\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Model Selection & Regularization\",\"item\":\"https://pe.pablopl.dev/gl/emeele/practice/Model%20Selection%20%26%20Regularization\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Model%20Selection%20%26%20Regularization\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Model Selection & Regularization: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Model%20Selection%20%26%20Regularization\",\"inLanguage\":\"gl\",\"description\":\"Practica 5 preguntas de Model Selection & Regularization de \\\"exames\\\" anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Model Selection & Regularization\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Model Selection & Regularization\",\"item\":\"https://pe.pablopl.dev/gl/emeele/practice/Model%20Selection%20%26%20Regularization\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Model%20Selection%20%26%20Regularization\"}]}"
   },
   {
     "url": "seo/gl/emeele/practice/Neural%20Networks.html",
@@ -10599,7 +10599,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/emeele/practice/Neural Networks",
     "title": "Neural Networks: preguntas de Introduction to Machine Learning",
-    "description": "Practica 6 preguntas de Neural Networks de exames anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
+    "description": "Practica 6 preguntas de Neural Networks de \"exames\" anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/emeele/practice/Neural%20Networks",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -10623,7 +10623,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Neural%20Networks"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Neural Networks: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Neural%20Networks\",\"inLanguage\":\"gl\",\"description\":\"Practica 6 preguntas de Neural Networks de exames anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Neural Networks\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Neural Networks\",\"item\":\"https://pe.pablopl.dev/gl/emeele/practice/Neural%20Networks\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Neural%20Networks\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Neural Networks: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Neural%20Networks\",\"inLanguage\":\"gl\",\"description\":\"Practica 6 preguntas de Neural Networks de \\\"exames\\\" anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Neural Networks\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Neural Networks\",\"item\":\"https://pe.pablopl.dev/gl/emeele/practice/Neural%20Networks\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Neural%20Networks\"}]}"
   },
   {
     "url": "seo/gl/emeele/practice/Decision%20Trees%20%26%20Ensembles.html",
@@ -10631,7 +10631,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/emeele/practice/Decision Trees & Ensembles",
     "title": "Decision Trees & Ensembles: preguntas de Introduction to Machine Learning",
-    "description": "Practica 4 preguntas de Decision Trees & Ensembles de exames anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
+    "description": "Practica 4 preguntas de Decision Trees & Ensembles de \"exames\" anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/emeele/practice/Decision%20Trees%20%26%20Ensembles",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -10655,7 +10655,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Decision%20Trees%20%26%20Ensembles"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Decision Trees & Ensembles: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Decision%20Trees%20%26%20Ensembles\",\"inLanguage\":\"gl\",\"description\":\"Practica 4 preguntas de Decision Trees & Ensembles de exames anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Decision Trees & Ensembles\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Decision Trees & Ensembles\",\"item\":\"https://pe.pablopl.dev/gl/emeele/practice/Decision%20Trees%20%26%20Ensembles\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Decision%20Trees%20%26%20Ensembles\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Decision Trees & Ensembles: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Decision%20Trees%20%26%20Ensembles\",\"inLanguage\":\"gl\",\"description\":\"Practica 4 preguntas de Decision Trees & Ensembles de \\\"exames\\\" anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Decision Trees & Ensembles\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Decision Trees & Ensembles\",\"item\":\"https://pe.pablopl.dev/gl/emeele/practice/Decision%20Trees%20%26%20Ensembles\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Decision%20Trees%20%26%20Ensembles\"}]}"
   },
   {
     "url": "seo/gl/emeele/practice/Support%20Vector%20Machines.html",
@@ -10663,7 +10663,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/emeele/practice/Support Vector Machines",
     "title": "Support Vector Machines: preguntas de Introduction to Machine Learning",
-    "description": "Practica 6 preguntas de Support Vector Machines de exames anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
+    "description": "Practica 6 preguntas de Support Vector Machines de \"exames\" anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/emeele/practice/Support%20Vector%20Machines",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -10687,7 +10687,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Support%20Vector%20Machines"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Support Vector Machines: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Support%20Vector%20Machines\",\"inLanguage\":\"gl\",\"description\":\"Practica 6 preguntas de Support Vector Machines de exames anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Support Vector Machines\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Support Vector Machines\",\"item\":\"https://pe.pablopl.dev/gl/emeele/practice/Support%20Vector%20Machines\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Support%20Vector%20Machines\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Support Vector Machines: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Support%20Vector%20Machines\",\"inLanguage\":\"gl\",\"description\":\"Practica 6 preguntas de Support Vector Machines de \\\"exames\\\" anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Support Vector Machines\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Support Vector Machines\",\"item\":\"https://pe.pablopl.dev/gl/emeele/practice/Support%20Vector%20Machines\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Support%20Vector%20Machines\"}]}"
   },
   {
     "url": "seo/gl/emeele/practice/Clustering.html",
@@ -10695,7 +10695,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/emeele/practice/Clustering",
     "title": "Clustering: preguntas de Introduction to Machine Learning",
-    "description": "Practica 6 preguntas de Clustering de exames anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
+    "description": "Practica 6 preguntas de Clustering de \"exames\" anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/emeele/practice/Clustering",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -10719,7 +10719,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Clustering"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Clustering: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Clustering\",\"inLanguage\":\"gl\",\"description\":\"Practica 6 preguntas de Clustering de exames anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Clustering\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Clustering\",\"item\":\"https://pe.pablopl.dev/gl/emeele/practice/Clustering\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Clustering\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Clustering: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Clustering\",\"inLanguage\":\"gl\",\"description\":\"Practica 6 preguntas de Clustering de \\\"exames\\\" anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Clustering\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Clustering\",\"item\":\"https://pe.pablopl.dev/gl/emeele/practice/Clustering\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Clustering\"}]}"
   },
   {
     "url": "seo/gl/emeele/practice/Dimensionality%20Reduction.html",
@@ -10727,7 +10727,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/emeele/practice/Dimensionality Reduction",
     "title": "Dimensionality Reduction: preguntas de Introduction to Machine Learning",
-    "description": "Practica 4 preguntas de Dimensionality Reduction de exames anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
+    "description": "Practica 4 preguntas de Dimensionality Reduction de \"exames\" anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/emeele/practice/Dimensionality%20Reduction",
     "ogImage": "https://pe.pablopl.dev/og/emeele.png",
@@ -10751,7 +10751,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/emeele/practice/Dimensionality%20Reduction"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Dimensionality Reduction: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Dimensionality%20Reduction\",\"inLanguage\":\"gl\",\"description\":\"Practica 4 preguntas de Dimensionality Reduction de exames anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Dimensionality Reduction\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Dimensionality Reduction\",\"item\":\"https://pe.pablopl.dev/gl/emeele/practice/Dimensionality%20Reduction\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Dimensionality%20Reduction\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Dimensionality Reduction: preguntas de Introduction to Machine Learning\",\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Dimensionality%20Reduction\",\"inLanguage\":\"gl\",\"description\":\"Practica 4 preguntas de Dimensionality Reduction de \\\"exames\\\" anteriores de Introduction to Machine Learning, con respostas modelo e autocorrección. 2DV516, Linnaeus University.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Dimensionality Reduction\"},{\"@type\":\"Course\",\"name\":\"Introduction to Machine Learning\",\"courseCode\":\"2DV516\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Introduction to Machine Learning\",\"item\":\"https://pe.pablopl.dev/gl/emeele\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Dimensionality Reduction\",\"item\":\"https://pe.pablopl.dev/gl/emeele/practice/Dimensionality%20Reduction\"}],\"url\":\"https://pe.pablopl.dev/gl/emeele/practice/Dimensionality%20Reduction\"}]}"
   },
   {
     "url": "seo/gl/emeele/exam/2024.html",
@@ -10822,8 +10822,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/equisi",
-    "title": "Xestión de Infraestruturas: exames e preguntas resoltas",
-    "description": "Practica 381 preguntas de Xestión de Infraestruturas de 4 exames anteriores con respostas modelo e autocorrección. 200190, Universidade da Coruña.",
+    "title": "Xestión de Infraestruturas: \"exames\" e preguntas resoltas",
+    "description": "Practica 381 preguntas de Xestión de Infraestruturas de 4 \"exames\" anteriores con respostas modelo e autocorrección. 200190, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/equisi",
     "ogImage": "https://pe.pablopl.dev/og/equisi.png",
@@ -10847,7 +10847,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equisi"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Xestión de Infraestruturas: exames e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/equisi\",\"inLanguage\":\"gl\",\"description\":\"Practica 381 preguntas de Xestión de Infraestruturas de 4 exames anteriores con respostas modelo e autocorrección. 200190, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/gl/equisi\"}],\"url\":\"https://pe.pablopl.dev/gl/equisi\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Xestión de Infraestruturas: \\\"exames\\\" e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/equisi\",\"inLanguage\":\"gl\",\"description\":\"Practica 381 preguntas de Xestión de Infraestruturas de 4 \\\"exames\\\" anteriores con respostas modelo e autocorrección. 200190, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/gl/equisi\"}],\"url\":\"https://pe.pablopl.dev/gl/equisi\"}]}"
   },
   {
     "url": "seo/gl/equisi/practice/modulo-i.html",
@@ -10855,7 +10855,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/equisi/practice/modulo-i",
     "title": "Módulo I: Sinais e Comunicacións: preguntas de Xestión de Infraestruturas",
-    "description": "Practica 130 preguntas de Módulo I: Sinais e Comunicacións de exames anteriores de Xestión de Infraestruturas, con respostas modelo e autocorrección. 200190, Universidade da Coruña.",
+    "description": "Practica 130 preguntas de Módulo I: Sinais e Comunicacións de \"exames\" anteriores de Xestión de Infraestruturas, con respostas modelo e autocorrección. 200190, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/equisi/practice/modulo-i",
     "ogImage": "https://pe.pablopl.dev/og/equisi.png",
@@ -10879,7 +10879,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equisi/practice/modulo-i"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Módulo I: Sinais e Comunicacións: preguntas de Xestión de Infraestruturas\",\"url\":\"https://pe.pablopl.dev/gl/equisi/practice/modulo-i\",\"inLanguage\":\"gl\",\"description\":\"Practica 130 preguntas de Módulo I: Sinais e Comunicacións de exames anteriores de Xestión de Infraestruturas, con respostas modelo e autocorrección. 200190, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Módulo I: Sinais e Comunicacións\"},{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/gl/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Módulo I: Sinais e Comunicacións\",\"item\":\"https://pe.pablopl.dev/gl/equisi/practice/modulo-i\"}],\"url\":\"https://pe.pablopl.dev/gl/equisi/practice/modulo-i\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Módulo I: Sinais e Comunicacións: preguntas de Xestión de Infraestruturas\",\"url\":\"https://pe.pablopl.dev/gl/equisi/practice/modulo-i\",\"inLanguage\":\"gl\",\"description\":\"Practica 130 preguntas de Módulo I: Sinais e Comunicacións de \\\"exames\\\" anteriores de Xestión de Infraestruturas, con respostas modelo e autocorrección. 200190, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Módulo I: Sinais e Comunicacións\"},{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/gl/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Módulo I: Sinais e Comunicacións\",\"item\":\"https://pe.pablopl.dev/gl/equisi/practice/modulo-i\"}],\"url\":\"https://pe.pablopl.dev/gl/equisi/practice/modulo-i\"}]}"
   },
   {
     "url": "seo/gl/equisi/practice/modulo-ii.html",
@@ -10887,7 +10887,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/equisi/practice/modulo-ii",
     "title": "Módulo II: Infraestruturas TI: preguntas de Xestión de Infraestruturas",
-    "description": "Practica 251 preguntas de Módulo II: Infraestruturas TI de exames anteriores de Xestión de Infraestruturas, con respostas modelo e autocorrección. 200190, Universidade da Coruña.",
+    "description": "Practica 251 preguntas de Módulo II: Infraestruturas TI de \"exames\" anteriores de Xestión de Infraestruturas, con respostas modelo e autocorrección. 200190, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/equisi/practice/modulo-ii",
     "ogImage": "https://pe.pablopl.dev/og/equisi.png",
@@ -10911,15 +10911,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equisi/practice/modulo-ii"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Módulo II: Infraestruturas TI: preguntas de Xestión de Infraestruturas\",\"url\":\"https://pe.pablopl.dev/gl/equisi/practice/modulo-ii\",\"inLanguage\":\"gl\",\"description\":\"Practica 251 preguntas de Módulo II: Infraestruturas TI de exames anteriores de Xestión de Infraestruturas, con respostas modelo e autocorrección. 200190, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Módulo II: Infraestruturas TI\"},{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/gl/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Módulo II: Infraestruturas TI\",\"item\":\"https://pe.pablopl.dev/gl/equisi/practice/modulo-ii\"}],\"url\":\"https://pe.pablopl.dev/gl/equisi/practice/modulo-ii\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Módulo II: Infraestruturas TI: preguntas de Xestión de Infraestruturas\",\"url\":\"https://pe.pablopl.dev/gl/equisi/practice/modulo-ii\",\"inLanguage\":\"gl\",\"description\":\"Practica 251 preguntas de Módulo II: Infraestruturas TI de \\\"exames\\\" anteriores de Xestión de Infraestruturas, con respostas modelo e autocorrección. 200190, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Módulo II: Infraestruturas TI\"},{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/gl/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Módulo II: Infraestruturas TI\",\"item\":\"https://pe.pablopl.dev/gl/equisi/practice/modulo-ii\"}],\"url\":\"https://pe.pablopl.dev/gl/equisi/practice/modulo-ii\"}]}"
   },
   {
     "url": "seo/gl/equisi/exam/2024-07.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/equisi/exam/2024-07",
-    "title": "Xullo 2024 de Xestión de Infraestruturas: simulador",
-    "description": "Simula o exame Xullo 2024 de Xestión de Infraestruturas con 20 preguntas. 10 puntos, 45 minutos, respostas modelo e autocorrección.",
+    "title": "Posibles preguntas Xullo 2024 de Xestión de Infraestruturas: simulador",
+    "description": "Simula o exame Posibles preguntas Xullo 2024 de Xestión de Infraestruturas con 20 preguntas. 10 puntos, 45 minutos, respostas modelo e autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/equisi/exam/2024-07",
     "ogImage": "https://pe.pablopl.dev/og/equisi.png",
@@ -10943,7 +10943,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equisi/exam/2024-07"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Xullo 2024 de Xestión de Infraestruturas: simulador\",\"url\":\"https://pe.pablopl.dev/gl/equisi/exam/2024-07\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Xullo 2024 de Xestión de Infraestruturas con 20 preguntas. 10 puntos, 45 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/gl/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Xullo 2024\",\"item\":\"https://pe.pablopl.dev/gl/equisi/exam/2024-07\"}],\"url\":\"https://pe.pablopl.dev/gl/equisi/exam/2024-07\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Xullo 2024 de Xestión de Infraestruturas: simulador\",\"url\":\"https://pe.pablopl.dev/gl/equisi/exam/2024-07\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Posibles preguntas Xullo 2024 de Xestión de Infraestruturas con 20 preguntas. 10 puntos, 45 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Infraestruturas\",\"courseCode\":\"200190\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Infraestruturas\",\"item\":\"https://pe.pablopl.dev/gl/equisi\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Xullo 2024\",\"item\":\"https://pe.pablopl.dev/gl/equisi/exam/2024-07\"}],\"url\":\"https://pe.pablopl.dev/gl/equisi/exam/2024-07\"}]}"
   },
   {
     "url": "seo/gl/equisi/exam/daypo-modulo-i.html",
@@ -11046,8 +11046,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/equispe",
-    "title": "Xestión de Proxectos: exames e preguntas resoltas",
-    "description": "Practica 175 preguntas de Xestión de Proxectos de 5 exames anteriores con respostas modelo e autocorrección. 202323, Universidade da Coruña.",
+    "title": "Xestión de Proxectos: \"exames\" e preguntas resoltas",
+    "description": "Practica 175 preguntas de Xestión de Proxectos de 5 \"exames\" anteriores con respostas modelo e autocorrección. 202323, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/equispe",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -11071,7 +11071,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Xestión de Proxectos: exames e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/equispe\",\"inLanguage\":\"gl\",\"description\":\"Practica 175 preguntas de Xestión de Proxectos de 5 exames anteriores con respostas modelo e autocorrección. 202323, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/gl/equispe\"}],\"url\":\"https://pe.pablopl.dev/gl/equispe\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Xestión de Proxectos: \\\"exames\\\" e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/equispe\",\"inLanguage\":\"gl\",\"description\":\"Practica 175 preguntas de Xestión de Proxectos de 5 \\\"exames\\\" anteriores con respostas modelo e autocorrección. 202323, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/gl/equispe\"}],\"url\":\"https://pe.pablopl.dev/gl/equispe\"}]}"
   },
   {
     "url": "seo/gl/equispe/practice/teoria.html",
@@ -11079,7 +11079,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/equispe/practice/teoria",
     "title": "Teoría: preguntas de Xestión de Proxectos | Pásame Exámenes",
-    "description": "Practica 107 preguntas de Teoría de exames anteriores de Xestión de Proxectos, con respostas modelo e autocorrección. 202323, Universidade da Coruña.",
+    "description": "Practica 107 preguntas de Teoría de \"exames\" anteriores de Xestión de Proxectos, con respostas modelo e autocorrección. 202323, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/equispe/practice/teoria",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -11103,7 +11103,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe/practice/teoria"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Teoría: preguntas de Xestión de Proxectos | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/equispe/practice/teoria\",\"inLanguage\":\"gl\",\"description\":\"Practica 107 preguntas de Teoría de exames anteriores de Xestión de Proxectos, con respostas modelo e autocorrección. 202323, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Teoría\"},{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/gl/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Teoría\",\"item\":\"https://pe.pablopl.dev/gl/equispe/practice/teoria\"}],\"url\":\"https://pe.pablopl.dev/gl/equispe/practice/teoria\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Teoría: preguntas de Xestión de Proxectos | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/equispe/practice/teoria\",\"inLanguage\":\"gl\",\"description\":\"Practica 107 preguntas de Teoría de \\\"exames\\\" anteriores de Xestión de Proxectos, con respostas modelo e autocorrección. 202323, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Teoría\"},{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/gl/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Teoría\",\"item\":\"https://pe.pablopl.dev/gl/equispe/practice/teoria\"}],\"url\":\"https://pe.pablopl.dev/gl/equispe/practice/teoria\"}]}"
   },
   {
     "url": "seo/gl/equispe/practice/practica.html",
@@ -11111,7 +11111,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/equispe/practice/practica",
     "title": "Práctica: preguntas de Xestión de Proxectos | Pásame Exámenes",
-    "description": "Practica 68 preguntas de Práctica de exames anteriores de Xestión de Proxectos, con respostas modelo e autocorrección. 202323, Universidade da Coruña.",
+    "description": "Practica 68 preguntas de Práctica de \"exames\" anteriores de Xestión de Proxectos, con respostas modelo e autocorrección. 202323, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/equispe/practice/practica",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -11135,15 +11135,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe/practice/practica"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Práctica: preguntas de Xestión de Proxectos | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/equispe/practice/practica\",\"inLanguage\":\"gl\",\"description\":\"Practica 68 preguntas de Práctica de exames anteriores de Xestión de Proxectos, con respostas modelo e autocorrección. 202323, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Práctica\"},{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/gl/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Práctica\",\"item\":\"https://pe.pablopl.dev/gl/equispe/practice/practica\"}],\"url\":\"https://pe.pablopl.dev/gl/equispe/practice/practica\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Práctica: preguntas de Xestión de Proxectos | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/equispe/practice/practica\",\"inLanguage\":\"gl\",\"description\":\"Practica 68 preguntas de Práctica de \\\"exames\\\" anteriores de Xestión de Proxectos, con respostas modelo e autocorrección. 202323, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Práctica\"},{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/gl/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Práctica\",\"item\":\"https://pe.pablopl.dev/gl/equispe/practice/practica\"}],\"url\":\"https://pe.pablopl.dev/gl/equispe/practice/practica\"}]}"
   },
   {
     "url": "seo/gl/equispe/exam/2024-01.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/equispe/exam/2024-01",
-    "title": "Xaneiro 2024 de Xestión de Proxectos: simulador",
-    "description": "Simula o exame Xaneiro 2024 de Xestión de Proxectos con 7 preguntas. 10 puntos, 120 minutos, respostas modelo e autocorrección.",
+    "title": "Posibles preguntas Xaneiro 2024 de Xestión de Proxectos: simulador",
+    "description": "Simula o exame Posibles preguntas Xaneiro 2024 de Xestión de Proxectos con 7 preguntas. 10 puntos, 120 minutos, respostas modelo e autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/equispe/exam/2024-01",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -11167,15 +11167,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe/exam/2024-01"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Xaneiro 2024 de Xestión de Proxectos: simulador\",\"url\":\"https://pe.pablopl.dev/gl/equispe/exam/2024-01\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Xaneiro 2024 de Xestión de Proxectos con 7 preguntas. 10 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/gl/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Xaneiro 2024\",\"item\":\"https://pe.pablopl.dev/gl/equispe/exam/2024-01\"}],\"url\":\"https://pe.pablopl.dev/gl/equispe/exam/2024-01\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Xaneiro 2024 de Xestión de Proxectos: simulador\",\"url\":\"https://pe.pablopl.dev/gl/equispe/exam/2024-01\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Posibles preguntas Xaneiro 2024 de Xestión de Proxectos con 7 preguntas. 10 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/gl/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Xaneiro 2024\",\"item\":\"https://pe.pablopl.dev/gl/equispe/exam/2024-01\"}],\"url\":\"https://pe.pablopl.dev/gl/equispe/exam/2024-01\"}]}"
   },
   {
     "url": "seo/gl/equispe/exam/2026-01.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/equispe/exam/2026-01",
-    "title": "Xaneiro 2026 de Xestión de Proxectos: simulador",
-    "description": "Simula o exame Xaneiro 2026 de Xestión de Proxectos con 13 preguntas. 25 puntos, 180 minutos, respostas modelo e autocorrección.",
+    "title": "Posibles preguntas Xaneiro 2026 de Xestión de Proxectos: simulador",
+    "description": "Simula o exame Posibles preguntas Xaneiro 2026 de Xestión de Proxectos con 13 preguntas. 25 puntos, 180 minutos, respostas modelo e autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/equispe/exam/2026-01",
     "ogImage": "https://pe.pablopl.dev/og/equispe.png",
@@ -11199,7 +11199,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/equispe/exam/2026-01"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Xaneiro 2026 de Xestión de Proxectos: simulador\",\"url\":\"https://pe.pablopl.dev/gl/equispe/exam/2026-01\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Xaneiro 2026 de Xestión de Proxectos con 13 preguntas. 25 puntos, 180 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/gl/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Xaneiro 2026\",\"item\":\"https://pe.pablopl.dev/gl/equispe/exam/2026-01\"}],\"url\":\"https://pe.pablopl.dev/gl/equispe/exam/2026-01\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Xaneiro 2026 de Xestión de Proxectos: simulador\",\"url\":\"https://pe.pablopl.dev/gl/equispe/exam/2026-01\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Posibles preguntas Xaneiro 2026 de Xestión de Proxectos con 13 preguntas. 25 puntos, 180 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Xestión de Proxectos\",\"courseCode\":\"202323\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Xestión de Proxectos\",\"item\":\"https://pe.pablopl.dev/gl/equispe\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Xaneiro 2026\",\"item\":\"https://pe.pablopl.dev/gl/equispe/exam/2026-01\"}],\"url\":\"https://pe.pablopl.dev/gl/equispe/exam/2026-01\"}]}"
   },
   {
     "url": "seo/gl/equispe/exam/daypo-tipo-udc.html",
@@ -11302,8 +11302,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/esei",
-    "title": "Sistemas Intelixentes: exames e preguntas resoltas",
-    "description": "Practica 234 preguntas de Sistemas Intelixentes de 5 exames anteriores con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
+    "title": "Sistemas Intelixentes: \"exames\" e preguntas resoltas",
+    "description": "Practica 234 preguntas de Sistemas Intelixentes de 5 \"exames\" anteriores con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/esei",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -11327,7 +11327,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Sistemas Intelixentes: exames e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/esei\",\"inLanguage\":\"gl\",\"description\":\"Practica 234 preguntas de Sistemas Intelixentes de 5 exames anteriores con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"}],\"url\":\"https://pe.pablopl.dev/gl/esei\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Sistemas Intelixentes: \\\"exames\\\" e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/esei\",\"inLanguage\":\"gl\",\"description\":\"Practica 234 preguntas de Sistemas Intelixentes de 5 \\\"exames\\\" anteriores con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"}],\"url\":\"https://pe.pablopl.dev/gl/esei\"}]}"
   },
   {
     "url": "seo/gl/esei/practice/t1.html",
@@ -11335,7 +11335,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/esei/practice/t1",
     "title": "Tema 1: Introducción: preguntas de Sistemas Intelixentes",
-    "description": "Practica 4 preguntas de Tema 1: Introducción de exames anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 4 preguntas de Tema 1: Introducción de \"exames\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/esei/practice/t1",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -11359,7 +11359,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t1"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 1: Introducción: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t1\",\"inLanguage\":\"gl\",\"description\":\"Practica 4 preguntas de Tema 1: Introducción de exames anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 1: Introducción\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 1: Introducción\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t1\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t1\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 1: Introducción: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t1\",\"inLanguage\":\"gl\",\"description\":\"Practica 4 preguntas de Tema 1: Introducción de \\\"exames\\\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 1: Introducción\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 1: Introducción\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t1\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t1\"}]}"
   },
   {
     "url": "seo/gl/esei/practice/t2.html",
@@ -11367,7 +11367,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/esei/practice/t2",
     "title": "Tema 2: Búsqueda: preguntas de Sistemas Intelixentes",
-    "description": "Practica 24 preguntas de Tema 2: Búsqueda de exames anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 24 preguntas de Tema 2: Búsqueda de \"exames\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/esei/practice/t2",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -11391,7 +11391,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t2"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 2: Búsqueda: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t2\",\"inLanguage\":\"gl\",\"description\":\"Practica 24 preguntas de Tema 2: Búsqueda de exames anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 2: Búsqueda\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 2: Búsqueda\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t2\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t2\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 2: Búsqueda: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t2\",\"inLanguage\":\"gl\",\"description\":\"Practica 24 preguntas de Tema 2: Búsqueda de \\\"exames\\\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 2: Búsqueda\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 2: Búsqueda\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t2\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t2\"}]}"
   },
   {
     "url": "seo/gl/esei/practice/t3.html",
@@ -11399,7 +11399,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/esei/practice/t3",
     "title": "Tema 3: Representación: preguntas de Sistemas Intelixentes",
-    "description": "Practica 17 preguntas de Tema 3: Representación de exames anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 17 preguntas de Tema 3: Representación de \"exames\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/esei/practice/t3",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -11423,7 +11423,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t3"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 3: Representación: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t3\",\"inLanguage\":\"gl\",\"description\":\"Practica 17 preguntas de Tema 3: Representación de exames anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 3: Representación\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 3: Representación\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t3\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t3\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 3: Representación: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t3\",\"inLanguage\":\"gl\",\"description\":\"Practica 17 preguntas de Tema 3: Representación de \\\"exames\\\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 3: Representación\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 3: Representación\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t3\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t3\"}]}"
   },
   {
     "url": "seo/gl/esei/practice/t4.html",
@@ -11431,7 +11431,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/esei/practice/t4",
     "title": "Tema 4: Razonamiento: preguntas de Sistemas Intelixentes",
-    "description": "Practica 12 preguntas de Tema 4: Razonamiento de exames anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 12 preguntas de Tema 4: Razonamiento de \"exames\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/esei/practice/t4",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -11455,7 +11455,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t4"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 4: Razonamiento: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t4\",\"inLanguage\":\"gl\",\"description\":\"Practica 12 preguntas de Tema 4: Razonamiento de exames anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 4: Razonamiento\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 4: Razonamiento\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t4\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t4\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 4: Razonamiento: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t4\",\"inLanguage\":\"gl\",\"description\":\"Practica 12 preguntas de Tema 4: Razonamiento de \\\"exames\\\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 4: Razonamiento\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 4: Razonamiento\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t4\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t4\"}]}"
   },
   {
     "url": "seo/gl/esei/practice/t5.html",
@@ -11463,7 +11463,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/esei/practice/t5",
     "title": "Tema 5: Planificación: preguntas de Sistemas Intelixentes",
-    "description": "Practica 2 preguntas de Tema 5: Planificación de exames anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 2 preguntas de Tema 5: Planificación de \"exames\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/esei/practice/t5",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -11487,7 +11487,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t5"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 5: Planificación: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t5\",\"inLanguage\":\"gl\",\"description\":\"Practica 2 preguntas de Tema 5: Planificación de exames anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 5: Planificación\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 5: Planificación\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t5\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t5\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 5: Planificación: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t5\",\"inLanguage\":\"gl\",\"description\":\"Practica 2 preguntas de Tema 5: Planificación de \\\"exames\\\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 5: Planificación\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 5: Planificación\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t5\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t5\"}]}"
   },
   {
     "url": "seo/gl/esei/practice/t6.html",
@@ -11495,7 +11495,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/esei/practice/t6",
     "title": "Tema 6: Introducción a los sistemas subsimbólicos: preguntas de Sistemas Intelixentes",
-    "description": "Practica 18 preguntas de Tema 6: Introducción a los sistemas subsimbólicos de exames anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 18 preguntas de Tema 6: Introducción a los sistemas subsimbólicos de \"exames\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/esei/practice/t6",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -11519,7 +11519,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t6"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 6: Introducción a los sistemas subsimbólicos: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t6\",\"inLanguage\":\"gl\",\"description\":\"Practica 18 preguntas de Tema 6: Introducción a los sistemas subsimbólicos de exames anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 6: Introducción a los sistemas subsimbólicos\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 6: Introducción a los sistemas subsimbólicos\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t6\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t6\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 6: Introducción a los sistemas subsimbólicos: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t6\",\"inLanguage\":\"gl\",\"description\":\"Practica 18 preguntas de Tema 6: Introducción a los sistemas subsimbólicos de \\\"exames\\\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 6: Introducción a los sistemas subsimbólicos\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 6: Introducción a los sistemas subsimbólicos\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t6\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t6\"}]}"
   },
   {
     "url": "seo/gl/esei/practice/t7.html",
@@ -11527,7 +11527,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/esei/practice/t7",
     "title": "Tema 7: Redes Neuronales Artificiales: modelos y características: preguntas de Sistemas Intelixentes",
-    "description": "Practica 40 preguntas de Tema 7: Redes Neuronales Artificiales: modelos y características de exames anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 40 preguntas de Tema 7: Redes Neuronales Artificiales: modelos y características de \"exames\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/esei/practice/t7",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -11551,7 +11551,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t7"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 7: Redes Neuronales Artificiales: modelos y características: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t7\",\"inLanguage\":\"gl\",\"description\":\"Practica 40 preguntas de Tema 7: Redes Neuronales Artificiales: modelos y características de exames anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 7: Redes Neuronales Artificiales: modelos y características\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 7: Redes Neuronales Artificiales: modelos y características\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t7\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t7\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 7: Redes Neuronales Artificiales: modelos y características: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t7\",\"inLanguage\":\"gl\",\"description\":\"Practica 40 preguntas de Tema 7: Redes Neuronales Artificiales: modelos y características de \\\"exames\\\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 7: Redes Neuronales Artificiales: modelos y características\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 7: Redes Neuronales Artificiales: modelos y características\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t7\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t7\"}]}"
   },
   {
     "url": "seo/gl/esei/practice/t8.html",
@@ -11559,7 +11559,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/esei/practice/t8",
     "title": "Tema 8: Entrenamiento de Redes Neuronales Artificiales: preguntas de Sistemas Intelixentes",
-    "description": "Practica 20 preguntas de Tema 8: Entrenamiento de Redes Neuronales Artificiales de exames anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 20 preguntas de Tema 8: Entrenamiento de Redes Neuronales Artificiales de \"exames\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/esei/practice/t8",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -11583,7 +11583,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t8"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 8: Entrenamiento de Redes Neuronales Artificiales: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t8\",\"inLanguage\":\"gl\",\"description\":\"Practica 20 preguntas de Tema 8: Entrenamiento de Redes Neuronales Artificiales de exames anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 8: Entrenamiento de Redes Neuronales Artificiales\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 8: Entrenamiento de Redes Neuronales Artificiales\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t8\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t8\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 8: Entrenamiento de Redes Neuronales Artificiales: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t8\",\"inLanguage\":\"gl\",\"description\":\"Practica 20 preguntas de Tema 8: Entrenamiento de Redes Neuronales Artificiales de \\\"exames\\\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 8: Entrenamiento de Redes Neuronales Artificiales\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 8: Entrenamiento de Redes Neuronales Artificiales\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t8\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t8\"}]}"
   },
   {
     "url": "seo/gl/esei/practice/t9.html",
@@ -11591,7 +11591,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/esei/practice/t9",
     "title": "Tema 9: Sistemas autoorganizativos: preguntas de Sistemas Intelixentes",
-    "description": "Practica 59 preguntas de Tema 9: Sistemas autoorganizativos de exames anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 59 preguntas de Tema 9: Sistemas autoorganizativos de \"exames\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/esei/practice/t9",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -11615,7 +11615,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t9"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 9: Sistemas autoorganizativos: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t9\",\"inLanguage\":\"gl\",\"description\":\"Practica 59 preguntas de Tema 9: Sistemas autoorganizativos de exames anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 9: Sistemas autoorganizativos\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 9: Sistemas autoorganizativos\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t9\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t9\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 9: Sistemas autoorganizativos: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t9\",\"inLanguage\":\"gl\",\"description\":\"Practica 59 preguntas de Tema 9: Sistemas autoorganizativos de \\\"exames\\\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 9: Sistemas autoorganizativos\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 9: Sistemas autoorganizativos\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t9\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t9\"}]}"
   },
   {
     "url": "seo/gl/esei/practice/t10.html",
@@ -11623,7 +11623,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/esei/practice/t10",
     "title": "Tema 10: Computación Evolutiva: preguntas de Sistemas Intelixentes",
-    "description": "Practica 38 preguntas de Tema 10: Computación Evolutiva de exames anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
+    "description": "Practica 38 preguntas de Tema 10: Computación Evolutiva de \"exames\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/esei/practice/t10",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -11647,15 +11647,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/practice/t10"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 10: Computación Evolutiva: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t10\",\"inLanguage\":\"gl\",\"description\":\"Practica 38 preguntas de Tema 10: Computación Evolutiva de exames anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 10: Computación Evolutiva\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 10: Computación Evolutiva\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t10\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t10\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 10: Computación Evolutiva: preguntas de Sistemas Intelixentes\",\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t10\",\"inLanguage\":\"gl\",\"description\":\"Practica 38 preguntas de Tema 10: Computación Evolutiva de \\\"exames\\\" anteriores de Sistemas Intelixentes, con respostas modelo e autocorrección. 202322, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 10: Computación Evolutiva\"},{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 10: Computación Evolutiva\",\"item\":\"https://pe.pablopl.dev/gl/esei/practice/t10\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/practice/t10\"}]}"
   },
   {
     "url": "seo/gl/esei/exam/2023.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/esei/exam/2023",
-    "title": "2023 de Sistemas Intelixentes: simulador | Pásame Exámenes",
-    "description": "Simula o exame 2023 de Sistemas Intelixentes con 45 preguntas. 45 puntos, 120 minutos, respostas modelo e autocorrección.",
+    "title": "Posibles preguntas 2023 de Sistemas Intelixentes: simulador",
+    "description": "Simula o exame Posibles preguntas 2023 de Sistemas Intelixentes con 45 preguntas. 45 puntos, 120 minutos, respostas modelo e autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/esei/exam/2023",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -11679,15 +11679,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/exam/2023"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"2023 de Sistemas Intelixentes: simulador | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2023\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame 2023 de Sistemas Intelixentes con 45 preguntas. 45 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"2023\",\"item\":\"https://pe.pablopl.dev/gl/esei/exam/2023\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2023\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas 2023 de Sistemas Intelixentes: simulador\",\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2023\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Posibles preguntas 2023 de Sistemas Intelixentes con 45 preguntas. 45 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas 2023\",\"item\":\"https://pe.pablopl.dev/gl/esei/exam/2023\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2023\"}]}"
   },
   {
     "url": "seo/gl/esei/exam/2024.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/esei/exam/2024",
-    "title": "2024 de Sistemas Intelixentes: simulador | Pásame Exámenes",
-    "description": "Simula o exame 2024 de Sistemas Intelixentes con 44 preguntas. 44 puntos, 120 minutos, respostas modelo e autocorrección.",
+    "title": "Posibles preguntas 2024 de Sistemas Intelixentes: simulador",
+    "description": "Simula o exame Posibles preguntas 2024 de Sistemas Intelixentes con 44 preguntas. 44 puntos, 120 minutos, respostas modelo e autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/esei/exam/2024",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -11711,15 +11711,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/exam/2024"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"2024 de Sistemas Intelixentes: simulador | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2024\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame 2024 de Sistemas Intelixentes con 44 preguntas. 44 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"2024\",\"item\":\"https://pe.pablopl.dev/gl/esei/exam/2024\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2024\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas 2024 de Sistemas Intelixentes: simulador\",\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2024\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Posibles preguntas 2024 de Sistemas Intelixentes con 44 preguntas. 44 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas 2024\",\"item\":\"https://pe.pablopl.dev/gl/esei/exam/2024\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2024\"}]}"
   },
   {
     "url": "seo/gl/esei/exam/2025-05.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/esei/exam/2025-05",
-    "title": "Mayo 2025 de Sistemas Intelixentes: simulador",
-    "description": "Simula o exame Mayo 2025 de Sistemas Intelixentes con 42 preguntas. 42 puntos, 120 minutos, respostas modelo e autocorrección.",
+    "title": "Posibles preguntas Mayo 2025 de Sistemas Intelixentes: simulador",
+    "description": "Simula o exame Posibles preguntas Mayo 2025 de Sistemas Intelixentes con 42 preguntas. 42 puntos, 120 minutos, respostas modelo e autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/esei/exam/2025-05",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -11743,15 +11743,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/exam/2025-05"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Mayo 2025 de Sistemas Intelixentes: simulador\",\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2025-05\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Mayo 2025 de Sistemas Intelixentes con 42 preguntas. 42 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Mayo 2025\",\"item\":\"https://pe.pablopl.dev/gl/esei/exam/2025-05\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2025-05\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Mayo 2025 de Sistemas Intelixentes: simulador\",\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2025-05\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Posibles preguntas Mayo 2025 de Sistemas Intelixentes con 42 preguntas. 42 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Mayo 2025\",\"item\":\"https://pe.pablopl.dev/gl/esei/exam/2025-05\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2025-05\"}]}"
   },
   {
     "url": "seo/gl/esei/exam/2025-07.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/esei/exam/2025-07",
-    "title": "Julio 2025 de Sistemas Intelixentes: simulador",
-    "description": "Simula o exame Julio 2025 de Sistemas Intelixentes con 47 preguntas. 47 puntos, 120 minutos, respostas modelo e autocorrección.",
+    "title": "Posibles preguntas Julio 2025 de Sistemas Intelixentes: simulador",
+    "description": "Simula o exame Posibles preguntas Julio 2025 de Sistemas Intelixentes con 47 preguntas. 47 puntos, 120 minutos, respostas modelo e autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/esei/exam/2025-07",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -11775,15 +11775,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/exam/2025-07"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Julio 2025 de Sistemas Intelixentes: simulador\",\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2025-07\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Julio 2025 de Sistemas Intelixentes con 47 preguntas. 47 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Julio 2025\",\"item\":\"https://pe.pablopl.dev/gl/esei/exam/2025-07\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2025-07\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Julio 2025 de Sistemas Intelixentes: simulador\",\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2025-07\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Posibles preguntas Julio 2025 de Sistemas Intelixentes con 47 preguntas. 47 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Julio 2025\",\"item\":\"https://pe.pablopl.dev/gl/esei/exam/2025-07\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2025-07\"}]}"
   },
   {
     "url": "seo/gl/esei/exam/2026-06.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/esei/exam/2026-06",
-    "title": "Junio 2026 de Sistemas Intelixentes: simulador",
-    "description": "Simula o exame Junio 2026 de Sistemas Intelixentes con 56 preguntas. 56 puntos, 120 minutos, respostas modelo e autocorrección.",
+    "title": "Posibles preguntas Junio 2026 de Sistemas Intelixentes: simulador",
+    "description": "Simula o exame Posibles preguntas Junio 2026 de Sistemas Intelixentes con 56 preguntas. 56 puntos, 120 minutos, respostas modelo e autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/esei/exam/2026-06",
     "ogImage": "https://pe.pablopl.dev/og/esei.png",
@@ -11807,15 +11807,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/esei/exam/2026-06"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Junio 2026 de Sistemas Intelixentes: simulador\",\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2026-06\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Junio 2026 de Sistemas Intelixentes con 56 preguntas. 56 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Junio 2026\",\"item\":\"https://pe.pablopl.dev/gl/esei/exam/2026-06\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2026-06\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Junio 2026 de Sistemas Intelixentes: simulador\",\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2026-06\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Posibles preguntas Junio 2026 de Sistemas Intelixentes con 56 preguntas. 56 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Intelixentes\",\"courseCode\":\"202322\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Intelixentes\",\"item\":\"https://pe.pablopl.dev/gl/esei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Junio 2026\",\"item\":\"https://pe.pablopl.dev/gl/esei/exam/2026-06\"}],\"url\":\"https://pe.pablopl.dev/gl/esei/exam/2026-06\"}]}"
   },
   {
     "url": "seo/gl/eseo.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/eseo",
-    "title": "Sistemas Operativos: exames e preguntas resoltas",
-    "description": "Practica 119 preguntas de Sistemas Operativos de 9 exames anteriores con respostas modelo e autocorrección. 202318, Universidade da Coruña.",
+    "title": "Sistemas Operativos: \"exames\" e preguntas resoltas",
+    "description": "Practica 119 preguntas de Sistemas Operativos de 9 \"exames\" anteriores con respostas modelo e autocorrección. 202318, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/eseo",
     "ogImage": "https://pe.pablopl.dev/og/eseo.png",
@@ -11839,7 +11839,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/eseo"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Sistemas Operativos: exames e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/eseo\",\"inLanguage\":\"gl\",\"description\":\"Practica 119 preguntas de Sistemas Operativos de 9 exames anteriores con respostas modelo e autocorrección. 202318, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/gl/eseo\"}],\"url\":\"https://pe.pablopl.dev/gl/eseo\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Sistemas Operativos: \\\"exames\\\" e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/eseo\",\"inLanguage\":\"gl\",\"description\":\"Practica 119 preguntas de Sistemas Operativos de 9 \\\"exames\\\" anteriores con respostas modelo e autocorrección. 202318, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/gl/eseo\"}],\"url\":\"https://pe.pablopl.dev/gl/eseo\"}]}"
   },
   {
     "url": "seo/gl/eseo/practice/sistema-ficheros.html",
@@ -11847,7 +11847,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/eseo/practice/sistema-ficheros",
     "title": "Sistema de Ficheros: preguntas de Sistemas Operativos",
-    "description": "Practica 36 preguntas de Sistema de Ficheros de exames anteriores de Sistemas Operativos, con respostas modelo e autocorrección. 202318, Universidade da Coruña.",
+    "description": "Practica 36 preguntas de Sistema de Ficheros de \"exames\" anteriores de Sistemas Operativos, con respostas modelo e autocorrección. 202318, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/eseo/practice/sistema-ficheros",
     "ogImage": "https://pe.pablopl.dev/og/eseo.png",
@@ -11871,7 +11871,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/eseo/practice/sistema-ficheros"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Sistema de Ficheros: preguntas de Sistemas Operativos\",\"url\":\"https://pe.pablopl.dev/gl/eseo/practice/sistema-ficheros\",\"inLanguage\":\"gl\",\"description\":\"Practica 36 preguntas de Sistema de Ficheros de exames anteriores de Sistemas Operativos, con respostas modelo e autocorrección. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Sistema de Ficheros\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/gl/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Sistema de Ficheros\",\"item\":\"https://pe.pablopl.dev/gl/eseo/practice/sistema-ficheros\"}],\"url\":\"https://pe.pablopl.dev/gl/eseo/practice/sistema-ficheros\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Sistema de Ficheros: preguntas de Sistemas Operativos\",\"url\":\"https://pe.pablopl.dev/gl/eseo/practice/sistema-ficheros\",\"inLanguage\":\"gl\",\"description\":\"Practica 36 preguntas de Sistema de Ficheros de \\\"exames\\\" anteriores de Sistemas Operativos, con respostas modelo e autocorrección. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Sistema de Ficheros\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/gl/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Sistema de Ficheros\",\"item\":\"https://pe.pablopl.dev/gl/eseo/practice/sistema-ficheros\"}],\"url\":\"https://pe.pablopl.dev/gl/eseo/practice/sistema-ficheros\"}]}"
   },
   {
     "url": "seo/gl/eseo/practice/memoria.html",
@@ -11879,7 +11879,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/eseo/practice/memoria",
     "title": "Gestión de Memoria: preguntas de Sistemas Operativos",
-    "description": "Practica 25 preguntas de Gestión de Memoria de exames anteriores de Sistemas Operativos, con respostas modelo e autocorrección. 202318, Universidade da Coruña.",
+    "description": "Practica 25 preguntas de Gestión de Memoria de \"exames\" anteriores de Sistemas Operativos, con respostas modelo e autocorrección. 202318, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/eseo/practice/memoria",
     "ogImage": "https://pe.pablopl.dev/og/eseo.png",
@@ -11903,7 +11903,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/eseo/practice/memoria"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Gestión de Memoria: preguntas de Sistemas Operativos\",\"url\":\"https://pe.pablopl.dev/gl/eseo/practice/memoria\",\"inLanguage\":\"gl\",\"description\":\"Practica 25 preguntas de Gestión de Memoria de exames anteriores de Sistemas Operativos, con respostas modelo e autocorrección. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Gestión de Memoria\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/gl/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Gestión de Memoria\",\"item\":\"https://pe.pablopl.dev/gl/eseo/practice/memoria\"}],\"url\":\"https://pe.pablopl.dev/gl/eseo/practice/memoria\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Gestión de Memoria: preguntas de Sistemas Operativos\",\"url\":\"https://pe.pablopl.dev/gl/eseo/practice/memoria\",\"inLanguage\":\"gl\",\"description\":\"Practica 25 preguntas de Gestión de Memoria de \\\"exames\\\" anteriores de Sistemas Operativos, con respostas modelo e autocorrección. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Gestión de Memoria\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/gl/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Gestión de Memoria\",\"item\":\"https://pe.pablopl.dev/gl/eseo/practice/memoria\"}],\"url\":\"https://pe.pablopl.dev/gl/eseo/practice/memoria\"}]}"
   },
   {
     "url": "seo/gl/eseo/practice/procesos.html",
@@ -11911,7 +11911,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/eseo/practice/procesos",
     "title": "Procesos e Hilos: preguntas de Sistemas Operativos",
-    "description": "Practica 30 preguntas de Procesos e Hilos de exames anteriores de Sistemas Operativos, con respostas modelo e autocorrección. 202318, Universidade da Coruña.",
+    "description": "Practica 30 preguntas de Procesos e Hilos de \"exames\" anteriores de Sistemas Operativos, con respostas modelo e autocorrección. 202318, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/eseo/practice/procesos",
     "ogImage": "https://pe.pablopl.dev/og/eseo.png",
@@ -11935,7 +11935,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/eseo/practice/procesos"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Procesos e Hilos: preguntas de Sistemas Operativos\",\"url\":\"https://pe.pablopl.dev/gl/eseo/practice/procesos\",\"inLanguage\":\"gl\",\"description\":\"Practica 30 preguntas de Procesos e Hilos de exames anteriores de Sistemas Operativos, con respostas modelo e autocorrección. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Procesos e Hilos\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/gl/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Procesos e Hilos\",\"item\":\"https://pe.pablopl.dev/gl/eseo/practice/procesos\"}],\"url\":\"https://pe.pablopl.dev/gl/eseo/practice/procesos\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Procesos e Hilos: preguntas de Sistemas Operativos\",\"url\":\"https://pe.pablopl.dev/gl/eseo/practice/procesos\",\"inLanguage\":\"gl\",\"description\":\"Practica 30 preguntas de Procesos e Hilos de \\\"exames\\\" anteriores de Sistemas Operativos, con respostas modelo e autocorrección. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Procesos e Hilos\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/gl/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Procesos e Hilos\",\"item\":\"https://pe.pablopl.dev/gl/eseo/practice/procesos\"}],\"url\":\"https://pe.pablopl.dev/gl/eseo/practice/procesos\"}]}"
   },
   {
     "url": "seo/gl/eseo/practice/entrada-salida.html",
@@ -11943,7 +11943,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/eseo/practice/entrada-salida",
     "title": "Entrada/Salida: preguntas de Sistemas Operativos",
-    "description": "Practica 28 preguntas de Entrada/Salida de exames anteriores de Sistemas Operativos, con respostas modelo e autocorrección. 202318, Universidade da Coruña.",
+    "description": "Practica 28 preguntas de Entrada/Salida de \"exames\" anteriores de Sistemas Operativos, con respostas modelo e autocorrección. 202318, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/eseo/practice/entrada-salida",
     "ogImage": "https://pe.pablopl.dev/og/eseo.png",
@@ -11967,7 +11967,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/eseo/practice/entrada-salida"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Entrada/Salida: preguntas de Sistemas Operativos\",\"url\":\"https://pe.pablopl.dev/gl/eseo/practice/entrada-salida\",\"inLanguage\":\"gl\",\"description\":\"Practica 28 preguntas de Entrada/Salida de exames anteriores de Sistemas Operativos, con respostas modelo e autocorrección. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Entrada/Salida\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/gl/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Entrada/Salida\",\"item\":\"https://pe.pablopl.dev/gl/eseo/practice/entrada-salida\"}],\"url\":\"https://pe.pablopl.dev/gl/eseo/practice/entrada-salida\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Entrada/Salida: preguntas de Sistemas Operativos\",\"url\":\"https://pe.pablopl.dev/gl/eseo/practice/entrada-salida\",\"inLanguage\":\"gl\",\"description\":\"Practica 28 preguntas de Entrada/Salida de \\\"exames\\\" anteriores de Sistemas Operativos, con respostas modelo e autocorrección. 202318, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Entrada/Salida\"},{\"@type\":\"Course\",\"name\":\"Sistemas Operativos\",\"courseCode\":\"202318\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Sistemas Operativos\",\"item\":\"https://pe.pablopl.dev/gl/eseo\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Entrada/Salida\",\"item\":\"https://pe.pablopl.dev/gl/eseo/practice/entrada-salida\"}],\"url\":\"https://pe.pablopl.dev/gl/eseo/practice/entrada-salida\"}]}"
   },
   {
     "url": "seo/gl/eseo/exam/2020-01.html",
@@ -12262,8 +12262,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/iesede",
-    "title": "Internet y Sistemas Distribuidos: exames e preguntas resoltas",
-    "description": "Practica 18 preguntas de Internet y Sistemas Distribuidos de 1 exames anteriores con respostas modelo e autocorrección. 200188, Universidade da Coruña.",
+    "title": "Internet y Sistemas Distribuidos: \"exames\" e preguntas resoltas",
+    "description": "Practica 18 preguntas de Internet y Sistemas Distribuidos de 1 \"exames\" anteriores con respostas modelo e autocorrección. 200188, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/iesede",
     "ogImage": "https://pe.pablopl.dev/og/iesede.png",
@@ -12287,7 +12287,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/iesede"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Internet y Sistemas Distribuidos: exames e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/iesede\",\"inLanguage\":\"gl\",\"description\":\"Practica 18 preguntas de Internet y Sistemas Distribuidos de 1 exames anteriores con respostas modelo e autocorrección. 200188, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Internet y Sistemas Distribuidos\",\"courseCode\":\"200188\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Internet y Sistemas Distribuidos\",\"item\":\"https://pe.pablopl.dev/gl/iesede\"}],\"url\":\"https://pe.pablopl.dev/gl/iesede\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Internet y Sistemas Distribuidos: \\\"exames\\\" e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/iesede\",\"inLanguage\":\"gl\",\"description\":\"Practica 18 preguntas de Internet y Sistemas Distribuidos de 1 \\\"exames\\\" anteriores con respostas modelo e autocorrección. 200188, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Internet y Sistemas Distribuidos\",\"courseCode\":\"200188\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Internet y Sistemas Distribuidos\",\"item\":\"https://pe.pablopl.dev/gl/iesede\"}],\"url\":\"https://pe.pablopl.dev/gl/iesede\"}]}"
   },
   {
     "url": "seo/gl/iesede/practice/general.html",
@@ -12295,7 +12295,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/iesede/practice/general",
     "title": "General: preguntas de Internet y Sistemas Distribuidos",
-    "description": "Practica 18 preguntas de General de exames anteriores de Internet y Sistemas Distribuidos, con respostas modelo e autocorrección. 200188, Universidade da Coruña.",
+    "description": "Practica 18 preguntas de General de \"exames\" anteriores de Internet y Sistemas Distribuidos, con respostas modelo e autocorrección. 200188, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/iesede/practice/general",
     "ogImage": "https://pe.pablopl.dev/og/iesede.png",
@@ -12319,15 +12319,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/iesede/practice/general"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"General: preguntas de Internet y Sistemas Distribuidos\",\"url\":\"https://pe.pablopl.dev/gl/iesede/practice/general\",\"inLanguage\":\"gl\",\"description\":\"Practica 18 preguntas de General de exames anteriores de Internet y Sistemas Distribuidos, con respostas modelo e autocorrección. 200188, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"General\"},{\"@type\":\"Course\",\"name\":\"Internet y Sistemas Distribuidos\",\"courseCode\":\"200188\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Internet y Sistemas Distribuidos\",\"item\":\"https://pe.pablopl.dev/gl/iesede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"General\",\"item\":\"https://pe.pablopl.dev/gl/iesede/practice/general\"}],\"url\":\"https://pe.pablopl.dev/gl/iesede/practice/general\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"General: preguntas de Internet y Sistemas Distribuidos\",\"url\":\"https://pe.pablopl.dev/gl/iesede/practice/general\",\"inLanguage\":\"gl\",\"description\":\"Practica 18 preguntas de General de \\\"exames\\\" anteriores de Internet y Sistemas Distribuidos, con respostas modelo e autocorrección. 200188, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"General\"},{\"@type\":\"Course\",\"name\":\"Internet y Sistemas Distribuidos\",\"courseCode\":\"200188\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Internet y Sistemas Distribuidos\",\"item\":\"https://pe.pablopl.dev/gl/iesede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"General\",\"item\":\"https://pe.pablopl.dev/gl/iesede/practice/general\"}],\"url\":\"https://pe.pablopl.dev/gl/iesede/practice/general\"}]}"
   },
   {
     "url": "seo/gl/iesede/exam/examen_recopilatorio.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/iesede/exam/examen_recopilatorio",
-    "title": "Examen Recopilatorio de Internet y Sistemas Distribuidos: simulador",
-    "description": "Simula o exame Examen Recopilatorio de Internet y Sistemas Distribuidos con 18 preguntas. 18 puntos, 120 minutos, respostas modelo e autocorrección.",
+    "title": "Recopilación de Internet y Sistemas Distribuidos: simulador",
+    "description": "Simula o exame Recopilación de Internet y Sistemas Distribuidos con 18 preguntas. 18 puntos, 120 minutos, respostas modelo e autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/iesede/exam/examen_recopilatorio",
     "ogImage": "https://pe.pablopl.dev/og/iesede.png",
@@ -12351,15 +12351,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/iesede/exam/examen_recopilatorio"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Examen Recopilatorio de Internet y Sistemas Distribuidos: simulador\",\"url\":\"https://pe.pablopl.dev/gl/iesede/exam/examen_recopilatorio\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Examen Recopilatorio de Internet y Sistemas Distribuidos con 18 preguntas. 18 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Internet y Sistemas Distribuidos\",\"courseCode\":\"200188\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Internet y Sistemas Distribuidos\",\"item\":\"https://pe.pablopl.dev/gl/iesede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Examen Recopilatorio\",\"item\":\"https://pe.pablopl.dev/gl/iesede/exam/examen_recopilatorio\"}],\"url\":\"https://pe.pablopl.dev/gl/iesede/exam/examen_recopilatorio\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Recopilación de Internet y Sistemas Distribuidos: simulador\",\"url\":\"https://pe.pablopl.dev/gl/iesede/exam/examen_recopilatorio\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Recopilación de Internet y Sistemas Distribuidos con 18 preguntas. 18 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Internet y Sistemas Distribuidos\",\"courseCode\":\"200188\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Internet y Sistemas Distribuidos\",\"item\":\"https://pe.pablopl.dev/gl/iesede\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Recopilación\",\"item\":\"https://pe.pablopl.dev/gl/iesede/exam/examen_recopilatorio\"}],\"url\":\"https://pe.pablopl.dev/gl/iesede/exam/examen_recopilatorio\"}]}"
   },
   {
     "url": "seo/gl/peese.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/peese",
-    "title": "Proceso Software: exames e preguntas resoltas",
-    "description": "Practica 17 preguntas de Proceso Software de 1 exames anteriores con respostas modelo e autocorrección. 202321, Universidade da Coruña.",
+    "title": "Proceso Software: \"exames\" e preguntas resoltas",
+    "description": "Practica 17 preguntas de Proceso Software de 1 \"exames\" anteriores con respostas modelo e autocorrección. 202321, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/peese",
     "ogImage": "https://pe.pablopl.dev/og/peese.png",
@@ -12383,7 +12383,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/peese"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Proceso Software: exames e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/peese\",\"inLanguage\":\"gl\",\"description\":\"Practica 17 preguntas de Proceso Software de 1 exames anteriores con respostas modelo e autocorrección. 202321, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Proceso Software\",\"courseCode\":\"202321\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Proceso Software\",\"item\":\"https://pe.pablopl.dev/gl/peese\"}],\"url\":\"https://pe.pablopl.dev/gl/peese\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Proceso Software: \\\"exames\\\" e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/peese\",\"inLanguage\":\"gl\",\"description\":\"Practica 17 preguntas de Proceso Software de 1 \\\"exames\\\" anteriores con respostas modelo e autocorrección. 202321, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Proceso Software\",\"courseCode\":\"202321\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Proceso Software\",\"item\":\"https://pe.pablopl.dev/gl/peese\"}],\"url\":\"https://pe.pablopl.dev/gl/peese\"}]}"
   },
   {
     "url": "seo/gl/peese/practice/teoria.html",
@@ -12391,7 +12391,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/peese/practice/teoria",
     "title": "Teoría: preguntas de Proceso Software | Pásame Exámenes",
-    "description": "Practica 17 preguntas de Teoría de exames anteriores de Proceso Software, con respostas modelo e autocorrección. 202321, Universidade da Coruña.",
+    "description": "Practica 17 preguntas de Teoría de \"exames\" anteriores de Proceso Software, con respostas modelo e autocorrección. 202321, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/peese/practice/teoria",
     "ogImage": "https://pe.pablopl.dev/og/peese.png",
@@ -12415,15 +12415,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/peese/practice/teoria"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Teoría: preguntas de Proceso Software | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/peese/practice/teoria\",\"inLanguage\":\"gl\",\"description\":\"Practica 17 preguntas de Teoría de exames anteriores de Proceso Software, con respostas modelo e autocorrección. 202321, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Teoría\"},{\"@type\":\"Course\",\"name\":\"Proceso Software\",\"courseCode\":\"202321\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Proceso Software\",\"item\":\"https://pe.pablopl.dev/gl/peese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Teoría\",\"item\":\"https://pe.pablopl.dev/gl/peese/practice/teoria\"}],\"url\":\"https://pe.pablopl.dev/gl/peese/practice/teoria\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Teoría: preguntas de Proceso Software | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/peese/practice/teoria\",\"inLanguage\":\"gl\",\"description\":\"Practica 17 preguntas de Teoría de \\\"exames\\\" anteriores de Proceso Software, con respostas modelo e autocorrección. 202321, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Teoría\"},{\"@type\":\"Course\",\"name\":\"Proceso Software\",\"courseCode\":\"202321\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Proceso Software\",\"item\":\"https://pe.pablopl.dev/gl/peese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Teoría\",\"item\":\"https://pe.pablopl.dev/gl/peese/practice/teoria\"}],\"url\":\"https://pe.pablopl.dev/gl/peese/practice/teoria\"}]}"
   },
   {
     "url": "seo/gl/peese/exam/2026-05.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/peese/exam/2026-05",
-    "title": "Mayo 2026 de Proceso Software: simulador | Pásame Exámenes",
-    "description": "Simula o exame Mayo 2026 de Proceso Software con 17 preguntas. 8.5 puntos, 120 minutos, respostas modelo e autocorrección.",
+    "title": "Posibles preguntas Mayo 2026 de Proceso Software: simulador",
+    "description": "Simula o exame Posibles preguntas Mayo 2026 de Proceso Software con 17 preguntas. 8.5 puntos, 120 minutos, respostas modelo e autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/peese/exam/2026-05",
     "ogImage": "https://pe.pablopl.dev/og/peese.png",
@@ -12447,15 +12447,15 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/peese/exam/2026-05"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Mayo 2026 de Proceso Software: simulador | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/peese/exam/2026-05\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Mayo 2026 de Proceso Software con 17 preguntas. 8.5 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Proceso Software\",\"courseCode\":\"202321\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Proceso Software\",\"item\":\"https://pe.pablopl.dev/gl/peese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Mayo 2026\",\"item\":\"https://pe.pablopl.dev/gl/peese/exam/2026-05\"}],\"url\":\"https://pe.pablopl.dev/gl/peese/exam/2026-05\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Mayo 2026 de Proceso Software: simulador\",\"url\":\"https://pe.pablopl.dev/gl/peese/exam/2026-05\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Posibles preguntas Mayo 2026 de Proceso Software con 17 preguntas. 8.5 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Proceso Software\",\"courseCode\":\"202321\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Proceso Software\",\"item\":\"https://pe.pablopl.dev/gl/peese\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Mayo 2026\",\"item\":\"https://pe.pablopl.dev/gl/peese/exam/2026-05\"}],\"url\":\"https://pe.pablopl.dev/gl/peese/exam/2026-05\"}]}"
   },
   {
     "url": "seo/gl/pei.html",
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/pei",
-    "title": "Programación Integrativa: exames e preguntas resoltas",
-    "description": "Practica 54 preguntas de Programación Integrativa de 1 exames anteriores con respostas modelo e autocorrección. 200214, Universidade da Coruña.",
+    "title": "Programación Integrativa: \"exames\" e preguntas resoltas",
+    "description": "Practica 54 preguntas de Programación Integrativa de 1 \"exames\" anteriores con respostas modelo e autocorrección. 200214, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/pei",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -12479,7 +12479,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Programación Integrativa: exames e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/pei\",\"inLanguage\":\"gl\",\"description\":\"Practica 54 preguntas de Programación Integrativa de 1 exames anteriores con respostas modelo e autocorrección. 200214, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/gl/pei\"}],\"url\":\"https://pe.pablopl.dev/gl/pei\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Programación Integrativa: \\\"exames\\\" e preguntas resoltas\",\"url\":\"https://pe.pablopl.dev/gl/pei\",\"inLanguage\":\"gl\",\"description\":\"Practica 54 preguntas de Programación Integrativa de 1 \\\"exames\\\" anteriores con respostas modelo e autocorrección. 200214, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/gl/pei\"}],\"url\":\"https://pe.pablopl.dev/gl/pei\"}]}"
   },
   {
     "url": "seo/gl/pei/practice/pandas.html",
@@ -12487,7 +12487,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/pei/practice/pandas",
     "title": "Pandas y Datos Estructurados: preguntas de Programación Integrativa",
-    "description": "Practica 8 preguntas de Pandas y Datos Estructurados de exames anteriores de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.",
+    "description": "Practica 8 preguntas de Pandas y Datos Estructurados de \"exames\" anteriores de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/pei/practice/pandas",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -12511,7 +12511,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei/practice/pandas"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Pandas y Datos Estructurados: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/gl/pei/practice/pandas\",\"inLanguage\":\"gl\",\"description\":\"Practica 8 preguntas de Pandas y Datos Estructurados de exames anteriores de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Pandas y Datos Estructurados\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/gl/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Pandas y Datos Estructurados\",\"item\":\"https://pe.pablopl.dev/gl/pei/practice/pandas\"}],\"url\":\"https://pe.pablopl.dev/gl/pei/practice/pandas\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Pandas y Datos Estructurados: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/gl/pei/practice/pandas\",\"inLanguage\":\"gl\",\"description\":\"Practica 8 preguntas de Pandas y Datos Estructurados de \\\"exames\\\" anteriores de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Pandas y Datos Estructurados\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/gl/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Pandas y Datos Estructurados\",\"item\":\"https://pe.pablopl.dev/gl/pei/practice/pandas\"}],\"url\":\"https://pe.pablopl.dev/gl/pei/practice/pandas\"}]}"
   },
   {
     "url": "seo/gl/pei/practice/poo.html",
@@ -12519,7 +12519,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/pei/practice/poo",
     "title": "POO en Python: preguntas de Programación Integrativa",
-    "description": "Practica 8 preguntas de POO en Python de exames anteriores de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.",
+    "description": "Practica 8 preguntas de POO en Python de \"exames\" anteriores de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/pei/practice/poo",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -12543,7 +12543,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei/practice/poo"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"POO en Python: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/gl/pei/practice/poo\",\"inLanguage\":\"gl\",\"description\":\"Practica 8 preguntas de POO en Python de exames anteriores de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"POO en Python\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/gl/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"POO en Python\",\"item\":\"https://pe.pablopl.dev/gl/pei/practice/poo\"}],\"url\":\"https://pe.pablopl.dev/gl/pei/practice/poo\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"POO en Python: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/gl/pei/practice/poo\",\"inLanguage\":\"gl\",\"description\":\"Practica 8 preguntas de POO en Python de \\\"exames\\\" anteriores de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"POO en Python\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/gl/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"POO en Python\",\"item\":\"https://pe.pablopl.dev/gl/pei/practice/poo\"}],\"url\":\"https://pe.pablopl.dev/gl/pei/practice/poo\"}]}"
   },
   {
     "url": "seo/gl/pei/practice/scripting.html",
@@ -12551,7 +12551,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/pei/practice/scripting",
     "title": "Scripting y Regex: preguntas de Programación Integrativa",
-    "description": "Practica 15 preguntas de Scripting y Regex de exames anteriores de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.",
+    "description": "Practica 15 preguntas de Scripting y Regex de \"exames\" anteriores de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/pei/practice/scripting",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -12575,7 +12575,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei/practice/scripting"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Scripting y Regex: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/gl/pei/practice/scripting\",\"inLanguage\":\"gl\",\"description\":\"Practica 15 preguntas de Scripting y Regex de exames anteriores de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Scripting y Regex\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/gl/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Scripting y Regex\",\"item\":\"https://pe.pablopl.dev/gl/pei/practice/scripting\"}],\"url\":\"https://pe.pablopl.dev/gl/pei/practice/scripting\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Scripting y Regex: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/gl/pei/practice/scripting\",\"inLanguage\":\"gl\",\"description\":\"Practica 15 preguntas de Scripting y Regex de \\\"exames\\\" anteriores de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Scripting y Regex\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/gl/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Scripting y Regex\",\"item\":\"https://pe.pablopl.dev/gl/pei/practice/scripting\"}],\"url\":\"https://pe.pablopl.dev/gl/pei/practice/scripting\"}]}"
   },
   {
     "url": "seo/gl/pei/practice/django-apis.html",
@@ -12583,7 +12583,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/pei/practice/django-apis",
     "title": "Django, APIs e Integración: preguntas de Programación Integrativa",
-    "description": "Practica 14 preguntas de Django, APIs e Integración de exames anteriores de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.",
+    "description": "Practica 14 preguntas de Django, APIs e Integración de \"exames\" anteriores de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/pei/practice/django-apis",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -12607,7 +12607,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei/practice/django-apis"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Django, APIs e Integración: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/gl/pei/practice/django-apis\",\"inLanguage\":\"gl\",\"description\":\"Practica 14 preguntas de Django, APIs e Integración de exames anteriores de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Django, APIs e Integración\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/gl/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Django, APIs e Integración\",\"item\":\"https://pe.pablopl.dev/gl/pei/practice/django-apis\"}],\"url\":\"https://pe.pablopl.dev/gl/pei/practice/django-apis\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Django, APIs e Integración: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/gl/pei/practice/django-apis\",\"inLanguage\":\"gl\",\"description\":\"Practica 14 preguntas de Django, APIs e Integración de \\\"exames\\\" anteriores de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Django, APIs e Integración\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/gl/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Django, APIs e Integración\",\"item\":\"https://pe.pablopl.dev/gl/pei/practice/django-apis\"}],\"url\":\"https://pe.pablopl.dev/gl/pei/practice/django-apis\"}]}"
   },
   {
     "url": "seo/gl/pei/practice/conceptos.html",
@@ -12615,7 +12615,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/pei/practice/conceptos",
     "title": "Conceptos y Test: preguntas de Programación Integrativa",
-    "description": "Practica 9 preguntas de Conceptos y Test de exames anteriores de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.",
+    "description": "Practica 9 preguntas de Conceptos y Test de \"exames\" anteriores de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/pei/practice/conceptos",
     "ogImage": "https://pe.pablopl.dev/og/pei.png",
@@ -12639,7 +12639,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/pei/practice/conceptos"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Conceptos y Test: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/gl/pei/practice/conceptos\",\"inLanguage\":\"gl\",\"description\":\"Practica 9 preguntas de Conceptos y Test de exames anteriores de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Conceptos y Test\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/gl/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Conceptos y Test\",\"item\":\"https://pe.pablopl.dev/gl/pei/practice/conceptos\"}],\"url\":\"https://pe.pablopl.dev/gl/pei/practice/conceptos\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Conceptos y Test: preguntas de Programación Integrativa\",\"url\":\"https://pe.pablopl.dev/gl/pei/practice/conceptos\",\"inLanguage\":\"gl\",\"description\":\"Practica 9 preguntas de Conceptos y Test de \\\"exames\\\" anteriores de Programación Integrativa, con respostas modelo e autocorrección. 200214, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Conceptos y Test\"},{\"@type\":\"Course\",\"name\":\"Programación Integrativa\",\"courseCode\":\"200214\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Programación Integrativa\",\"item\":\"https://pe.pablopl.dev/gl/pei\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Conceptos y Test\",\"item\":\"https://pe.pablopl.dev/gl/pei/practice/conceptos\"}],\"url\":\"https://pe.pablopl.dev/gl/pei/practice/conceptos\"}]}"
   },
   {
     "url": "seo/gl/pei/exam/recopilacion.html",
@@ -12678,8 +12678,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/redes",
-    "title": "Redes: exames e preguntas resoltas | Pásame Exámenes",
-    "description": "Practica 460 preguntas de Redes de 3 exames anteriores con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
+    "title": "Redes: \"exames\" e preguntas resoltas | Pásame Exámenes",
+    "description": "Practica 460 preguntas de Redes de 3 \"exames\" anteriores con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/redes",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -12703,7 +12703,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Redes: exames e preguntas resoltas | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/redes\",\"inLanguage\":\"gl\",\"description\":\"Practica 460 preguntas de Redes de 3 exames anteriores con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"}],\"url\":\"https://pe.pablopl.dev/gl/redes\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Redes: \\\"exames\\\" e preguntas resoltas | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/redes\",\"inLanguage\":\"gl\",\"description\":\"Practica 460 preguntas de Redes de 3 \\\"exames\\\" anteriores con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"}],\"url\":\"https://pe.pablopl.dev/gl/redes\"}]}"
   },
   {
     "url": "seo/gl/redes/practice/tema-1.html",
@@ -12711,7 +12711,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/redes/practice/tema-1",
     "title": "Tema 1. Redes de ordenadores e Internet: preguntas de Redes",
-    "description": "Practica 54 preguntas de Tema 1. Redes de ordenadores e Internet de exames anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 54 preguntas de Tema 1. Redes de ordenadores e Internet de \"exames\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/redes/practice/tema-1",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -12735,7 +12735,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-1"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 1. Redes de ordenadores e Internet: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-1\",\"inLanguage\":\"gl\",\"description\":\"Practica 54 preguntas de Tema 1. Redes de ordenadores e Internet de exames anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 1. Redes de ordenadores e Internet\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 1. Redes de ordenadores e Internet\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-1\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-1\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 1. Redes de ordenadores e Internet: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-1\",\"inLanguage\":\"gl\",\"description\":\"Practica 54 preguntas de Tema 1. Redes de ordenadores e Internet de \\\"exames\\\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 1. Redes de ordenadores e Internet\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 1. Redes de ordenadores e Internet\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-1\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-1\"}]}"
   },
   {
     "url": "seo/gl/redes/practice/tema-2.html",
@@ -12743,7 +12743,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/redes/practice/tema-2",
     "title": "Tema 2. Introducción a TCP/IP: preguntas de Redes",
-    "description": "Practica 19 preguntas de Tema 2. Introducción a TCP/IP de exames anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 19 preguntas de Tema 2. Introducción a TCP/IP de \"exames\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/redes/practice/tema-2",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -12767,7 +12767,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-2"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 2. Introducción a TCP/IP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-2\",\"inLanguage\":\"gl\",\"description\":\"Practica 19 preguntas de Tema 2. Introducción a TCP/IP de exames anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 2. Introducción a TCP/IP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 2. Introducción a TCP/IP\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-2\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-2\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 2. Introducción a TCP/IP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-2\",\"inLanguage\":\"gl\",\"description\":\"Practica 19 preguntas de Tema 2. Introducción a TCP/IP de \\\"exames\\\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 2. Introducción a TCP/IP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 2. Introducción a TCP/IP\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-2\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-2\"}]}"
   },
   {
     "url": "seo/gl/redes/practice/tema-3-4.html",
@@ -12775,7 +12775,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/redes/practice/tema-3-4",
     "title": "Tema 3-4. Protocolos nivel de aplicación: preguntas de Redes",
-    "description": "Practica 77 preguntas de Tema 3-4. Protocolos nivel de aplicación de exames anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 77 preguntas de Tema 3-4. Protocolos nivel de aplicación de \"exames\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/redes/practice/tema-3-4",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -12799,7 +12799,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-3-4"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 3-4. Protocolos nivel de aplicación: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-3-4\",\"inLanguage\":\"gl\",\"description\":\"Practica 77 preguntas de Tema 3-4. Protocolos nivel de aplicación de exames anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 3-4. Protocolos nivel de aplicación\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 3-4. Protocolos nivel de aplicación\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-3-4\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-3-4\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 3-4. Protocolos nivel de aplicación: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-3-4\",\"inLanguage\":\"gl\",\"description\":\"Practica 77 preguntas de Tema 3-4. Protocolos nivel de aplicación de \\\"exames\\\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 3-4. Protocolos nivel de aplicación\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 3-4. Protocolos nivel de aplicación\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-3-4\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-3-4\"}]}"
   },
   {
     "url": "seo/gl/redes/practice/tema-5.html",
@@ -12807,7 +12807,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/redes/practice/tema-5",
     "title": "Tema 5. Protocolos de transporte UDP y TCP: preguntas de Redes",
-    "description": "Practica 51 preguntas de Tema 5. Protocolos de transporte UDP y TCP de exames anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 51 preguntas de Tema 5. Protocolos de transporte UDP y TCP de \"exames\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/redes/practice/tema-5",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -12831,7 +12831,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-5"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 5. Protocolos de transporte UDP y TCP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-5\",\"inLanguage\":\"gl\",\"description\":\"Practica 51 preguntas de Tema 5. Protocolos de transporte UDP y TCP de exames anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 5. Protocolos de transporte UDP y TCP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 5. Protocolos de transporte UDP y TCP\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-5\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-5\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 5. Protocolos de transporte UDP y TCP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-5\",\"inLanguage\":\"gl\",\"description\":\"Practica 51 preguntas de Tema 5. Protocolos de transporte UDP y TCP de \\\"exames\\\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 5. Protocolos de transporte UDP y TCP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 5. Protocolos de transporte UDP y TCP\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-5\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-5\"}]}"
   },
   {
     "url": "seo/gl/redes/practice/tema-6.html",
@@ -12839,7 +12839,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/redes/practice/tema-6",
     "title": "Tema 6. Intercambio de datos TCP: preguntas de Redes",
-    "description": "Practica 48 preguntas de Tema 6. Intercambio de datos TCP de exames anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 48 preguntas de Tema 6. Intercambio de datos TCP de \"exames\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/redes/practice/tema-6",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -12863,7 +12863,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-6"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 6. Intercambio de datos TCP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-6\",\"inLanguage\":\"gl\",\"description\":\"Practica 48 preguntas de Tema 6. Intercambio de datos TCP de exames anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 6. Intercambio de datos TCP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 6. Intercambio de datos TCP\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-6\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-6\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 6. Intercambio de datos TCP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-6\",\"inLanguage\":\"gl\",\"description\":\"Practica 48 preguntas de Tema 6. Intercambio de datos TCP de \\\"exames\\\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 6. Intercambio de datos TCP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 6. Intercambio de datos TCP\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-6\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-6\"}]}"
   },
   {
     "url": "seo/gl/redes/practice/tema-7.html",
@@ -12871,7 +12871,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/redes/practice/tema-7",
     "title": "Tema 7. Nivel de red: protocolo IP: preguntas de Redes",
-    "description": "Practica 81 preguntas de Tema 7. Nivel de red: protocolo IP de exames anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 81 preguntas de Tema 7. Nivel de red: protocolo IP de \"exames\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/redes/practice/tema-7",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -12895,7 +12895,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-7"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 7. Nivel de red: protocolo IP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-7\",\"inLanguage\":\"gl\",\"description\":\"Practica 81 preguntas de Tema 7. Nivel de red: protocolo IP de exames anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 7. Nivel de red: protocolo IP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 7. Nivel de red: protocolo IP\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-7\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-7\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 7. Nivel de red: protocolo IP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-7\",\"inLanguage\":\"gl\",\"description\":\"Practica 81 preguntas de Tema 7. Nivel de red: protocolo IP de \\\"exames\\\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 7. Nivel de red: protocolo IP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 7. Nivel de red: protocolo IP\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-7\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-7\"}]}"
   },
   {
     "url": "seo/gl/redes/practice/tema-8.html",
@@ -12903,7 +12903,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/redes/practice/tema-8",
     "title": "Tema 8. Enrutamiento: preguntas de Redes | Pásame Exámenes",
-    "description": "Practica 22 preguntas de Tema 8. Enrutamiento de exames anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 22 preguntas de Tema 8. Enrutamiento de \"exames\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/redes/practice/tema-8",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -12927,7 +12927,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-8"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 8. Enrutamiento: preguntas de Redes | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-8\",\"inLanguage\":\"gl\",\"description\":\"Practica 22 preguntas de Tema 8. Enrutamiento de exames anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 8. Enrutamiento\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 8. Enrutamiento\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-8\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-8\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 8. Enrutamiento: preguntas de Redes | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-8\",\"inLanguage\":\"gl\",\"description\":\"Practica 22 preguntas de Tema 8. Enrutamiento de \\\"exames\\\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 8. Enrutamiento\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 8. Enrutamiento\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-8\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-8\"}]}"
   },
   {
     "url": "seo/gl/redes/practice/tema-9.html",
@@ -12935,7 +12935,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/redes/practice/tema-9",
     "title": "Tema 9. ICMP y fragmentación IP: preguntas de Redes",
-    "description": "Practica 24 preguntas de Tema 9. ICMP y fragmentación IP de exames anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 24 preguntas de Tema 9. ICMP y fragmentación IP de \"exames\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/redes/practice/tema-9",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -12959,7 +12959,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-9"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 9. ICMP y fragmentación IP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-9\",\"inLanguage\":\"gl\",\"description\":\"Practica 24 preguntas de Tema 9. ICMP y fragmentación IP de exames anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 9. ICMP y fragmentación IP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 9. ICMP y fragmentación IP\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-9\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-9\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 9. ICMP y fragmentación IP: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-9\",\"inLanguage\":\"gl\",\"description\":\"Practica 24 preguntas de Tema 9. ICMP y fragmentación IP de \\\"exames\\\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 9. ICMP y fragmentación IP\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 9. ICMP y fragmentación IP\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-9\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-9\"}]}"
   },
   {
     "url": "seo/gl/redes/practice/tema-10.html",
@@ -12967,7 +12967,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/redes/practice/tema-10",
     "title": "Tema 10. Protocolo IPv6: preguntas de Redes | Pásame Exámenes",
-    "description": "Practica 11 preguntas de Tema 10. Protocolo IPv6 de exames anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 11 preguntas de Tema 10. Protocolo IPv6 de \"exames\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/redes/practice/tema-10",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -12991,7 +12991,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-10"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 10. Protocolo IPv6: preguntas de Redes | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-10\",\"inLanguage\":\"gl\",\"description\":\"Practica 11 preguntas de Tema 10. Protocolo IPv6 de exames anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 10. Protocolo IPv6\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 10. Protocolo IPv6\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-10\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-10\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 10. Protocolo IPv6: preguntas de Redes | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-10\",\"inLanguage\":\"gl\",\"description\":\"Practica 11 preguntas de Tema 10. Protocolo IPv6 de \\\"exames\\\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 10. Protocolo IPv6\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 10. Protocolo IPv6\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-10\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-10\"}]}"
   },
   {
     "url": "seo/gl/redes/practice/tema-11.html",
@@ -12999,7 +12999,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/redes/practice/tema-11",
     "title": "Tema 11. TCP/IP y nivel de enlace: preguntas de Redes",
-    "description": "Practica 24 preguntas de Tema 11. TCP/IP y nivel de enlace de exames anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 24 preguntas de Tema 11. TCP/IP y nivel de enlace de \"exames\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/redes/practice/tema-11",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -13023,7 +13023,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-11"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 11. TCP/IP y nivel de enlace: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-11\",\"inLanguage\":\"gl\",\"description\":\"Practica 24 preguntas de Tema 11. TCP/IP y nivel de enlace de exames anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 11. TCP/IP y nivel de enlace\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 11. TCP/IP y nivel de enlace\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-11\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-11\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 11. TCP/IP y nivel de enlace: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-11\",\"inLanguage\":\"gl\",\"description\":\"Practica 24 preguntas de Tema 11. TCP/IP y nivel de enlace de \\\"exames\\\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 11. TCP/IP y nivel de enlace\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 11. TCP/IP y nivel de enlace\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-11\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-11\"}]}"
   },
   {
     "url": "seo/gl/redes/practice/tema-12.html",
@@ -13031,7 +13031,7 @@ export const pages = [
     "lang": "gl",
     "pathWithoutLang": "/redes/practice/tema-12",
     "title": "Tema 12. Tecnologías del nivel de enlace: preguntas de Redes",
-    "description": "Practica 49 preguntas de Tema 12. Tecnologías del nivel de enlace de exames anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
+    "description": "Practica 49 preguntas de Tema 12. Tecnologías del nivel de enlace de \"exames\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/redes/practice/tema-12",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -13055,7 +13055,7 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/practice/tema-12"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 12. Tecnologías del nivel de enlace: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-12\",\"inLanguage\":\"gl\",\"description\":\"Practica 49 preguntas de Tema 12. Tecnologías del nivel de enlace de exames anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 12. Tecnologías del nivel de enlace\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 12. Tecnologías del nivel de enlace\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-12\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-12\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"CollectionPage\",\"name\":\"Tema 12. Tecnologías del nivel de enlace: preguntas de Redes\",\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-12\",\"inLanguage\":\"gl\",\"description\":\"Practica 49 preguntas de Tema 12. Tecnologías del nivel de enlace de \\\"exames\\\" anteriores de Redes, con respostas modelo e autocorrección. 202319, Universidade da Coruña.\",\"about\":[{\"@type\":\"Thing\",\"name\":\"Tema 12. Tecnologías del nivel de enlace\"},{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\"}]},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Tema 12. Tecnologías del nivel de enlace\",\"item\":\"https://pe.pablopl.dev/gl/redes/practice/tema-12\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/practice/tema-12\"}]}"
   },
   {
     "url": "seo/gl/redes/exam/daypo-recopilatorio-lara.html",
@@ -13126,8 +13126,8 @@ export const pages = [
     "bundleEntryPoint": "/src/main.tsx",
     "lang": "gl",
     "pathWithoutLang": "/redes/exam/2025-05",
-    "title": "Mayo 2025 (incompl.) de Redes: simulador | Pásame Exámenes",
-    "description": "Simula o exame Mayo 2025 (incompl.) de Redes con 37 preguntas. 37 puntos, 120 minutos, respostas modelo e autocorrección.",
+    "title": "Posibles preguntas Mayo 2025 de Redes: simulador",
+    "description": "Simula o exame Posibles preguntas Mayo 2025 de Redes con 37 preguntas. 37 puntos, 120 minutos, respostas modelo e autocorrección.",
     "siteName": "Pásame Exámenes",
     "canonicalUrl": "https://pe.pablopl.dev/gl/redes/exam/2025-05",
     "ogImage": "https://pe.pablopl.dev/og/redes.png",
@@ -13151,6 +13151,6 @@ export const pages = [
         "href": "https://pe.pablopl.dev/es/redes/exam/2025-05"
       }
     ],
-    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Mayo 2025 (incompl.) de Redes: simulador | Pásame Exámenes\",\"url\":\"https://pe.pablopl.dev/gl/redes/exam/2025-05\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Mayo 2025 (incompl.) de Redes con 37 preguntas. 37 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Mayo 2025 (incompl.)\",\"item\":\"https://pe.pablopl.dev/gl/redes/exam/2025-05\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/exam/2025-05\"}]}"
+    "jsonLd": "{\"@context\":\"https://schema.org\",\"@graph\":[{\"@type\":\"WebPage\",\"name\":\"Posibles preguntas Mayo 2025 de Redes: simulador\",\"url\":\"https://pe.pablopl.dev/gl/redes/exam/2025-05\",\"inLanguage\":\"gl\",\"description\":\"Simula o exame Posibles preguntas Mayo 2025 de Redes con 37 preguntas. 37 puntos, 120 minutos, respostas modelo e autocorrección.\",\"about\":{\"@type\":\"Course\",\"name\":\"Redes\",\"courseCode\":\"202319\",\"provider\":{\"@type\":\"CollegeOrUniversity\",\"name\":\"Universidade da Coruña\"}}},{\"@type\":\"BreadcrumbList\",\"itemListElement\":[{\"@type\":\"ListItem\",\"position\":1,\"name\":\"Pásame Exámenes\",\"item\":\"https://pe.pablopl.dev/gl\"},{\"@type\":\"ListItem\",\"position\":2,\"name\":\"Redes\",\"item\":\"https://pe.pablopl.dev/gl/redes\"},{\"@type\":\"ListItem\",\"position\":3,\"name\":\"Posibles preguntas Mayo 2025\",\"item\":\"https://pe.pablopl.dev/gl/redes/exam/2025-05\"}],\"url\":\"https://pe.pablopl.dev/gl/redes/exam/2025-05\"}]}"
   }
 ] as const satisfies readonly PageMetaData[];

--- a/src/subjects/_template/meta.ts
+++ b/src/subjects/_template/meta.ts
@@ -6,6 +6,7 @@ export const meta: SubjectMeta = {
   university: "Template University",
   courseCode: "TMP101",
   icon: "📝",
+  contentPolicy: "community-practice",
   acknowledgments:
     "Questions provided by the Template Department. Answers by Prof. Example.",
   topics: [

--- a/src/subjects/_template/meta.ts
+++ b/src/subjects/_template/meta.ts
@@ -44,6 +44,17 @@ export const meta: SubjectMeta = {
       durationMinutes: 150,
       hasPdf: false,
     },
+    {
+      year: "2023",
+      title: "2023 Exam",
+      date: "2023",
+      description: "Removed for copyright reasons",
+      passPoints: 0,
+      totalPoints: 0,
+      durationMinutes: 0,
+      hasPdf: false,
+      deleteRights: true,
+    },
   ],
 };
 

--- a/src/subjects/bede/meta.ts
+++ b/src/subjects/bede/meta.ts
@@ -6,6 +6,7 @@ export const meta: SubjectMeta = {
   university: "Universidade da Coruña",
   courseCode: "202315",
   icon: "🗃️",
+  contentPolicy: "community-practice",
   acknowledgments:
     "Las preguntas y respuestas incluidas en esta plataforma son ejercicios originales creados por estudiantes a partir del temario oficial. No se reproducen exámenes oficiales, enunciados originales ni materiales docentes protegidos del profesorado o de la universidad. Si se detecta alguna coincidencia sustancial no autorizada, puede notificarse para su revisión y retirada.",
   topics: [

--- a/src/subjects/bede/meta.ts
+++ b/src/subjects/bede/meta.ts
@@ -7,7 +7,7 @@ export const meta: SubjectMeta = {
   courseCode: "202315",
   icon: "🗃️",
   acknowledgments:
-    "Recopilatorios proporcionados por el alumnado de la asignatura de forma anónima.",
+    "Las preguntas y respuestas incluidas en esta plataforma son ejercicios originales creados por estudiantes a partir del temario oficial. No se reproducen exámenes oficiales, enunciados originales ni materiales docentes protegidos del profesorado o de la universidad. Si se detecta alguna coincidencia sustancial no autorizada, puede notificarse para su revisión y retirada.",
   topics: [
     {
       key: "recuperacion-concurrencia",

--- a/src/subjects/cepe/meta.ts
+++ b/src/subjects/cepe/meta.ts
@@ -6,6 +6,7 @@ export const meta: SubjectMeta = {
   university: "Universidade da Coruña",
   courseCode: "202320",
   icon: "⚡",
+  contentPolicy: "authorized-exams",
   acknowledgments:
     "Exámenes y soluciones originales proporcionadas por el profesorado de la asignatura.",
   topics: [

--- a/src/subjects/deese/meta.ts
+++ b/src/subjects/deese/meta.ts
@@ -6,6 +6,7 @@ export const meta: SubjectMeta = {
   university: "Universidade da Coruña",
   courseCode: "202317",
   icon: "🎨",
+  contentPolicy: "community-practice",
   acknowledgments:
     "Las preguntas y respuestas incluidas en esta plataforma son ejercicios originales creados por estudiantes anónimos a partir del temario oficial. No se reproducen exámenes oficiales, enunciados originales ni materiales docentes protegidos del profesorado o de la universidad. Si se detecta alguna coincidencia sustancial no autorizada, puede notificarse para su revisión y retirada.",
   topics: [

--- a/src/subjects/deese/meta.ts
+++ b/src/subjects/deese/meta.ts
@@ -7,7 +7,7 @@ export const meta: SubjectMeta = {
   courseCode: "202317",
   icon: "🎨",
   acknowledgments:
-    "Exámenes originales proporcionados por el alumnado de la asignatura de forma anónima.",
+    "Las preguntas y respuestas incluidas en esta plataforma son ejercicios originales creados por estudiantes anónimos a partir del temario oficial. No se reproducen exámenes oficiales, enunciados originales ni materiales docentes protegidos del profesorado o de la universidad. Si se detecta alguna coincidencia sustancial no autorizada, puede notificarse para su revisión y retirada.",
   topics: [
     {
       key: "intro-y-objetos",
@@ -43,7 +43,7 @@ export const meta: SubjectMeta = {
   exams: [
     {
       year: "2020-01",
-      title: "Enero 2020",
+      title: "Posibles preguntas Enero 2020",
       date: "Enero 2020",
       description: "150 min · 30 preguntas",
       passPoints: 15,
@@ -53,7 +53,7 @@ export const meta: SubjectMeta = {
     },
     {
       year: "2022-01",
-      title: "Enero 2022",
+      title: "Posibles preguntas Enero 2022",
       date: "Enero 2022",
       description: "150 min · 25 preguntas",
       passPoints: 13,

--- a/src/subjects/ece/meta.ts
+++ b/src/subjects/ece/meta.ts
@@ -6,6 +6,7 @@ export const meta: SubjectMeta = {
   university: "Universidade da Coruña",
   courseCode: "202314",
   icon: "💻",
+  contentPolicy: "authorized-exams",
   acknowledgments:
     "Exámenes y soluciones originales proporcionadas por el profesorado de la asignatura.",
   topics: [

--- a/src/subjects/emeele/meta.ts
+++ b/src/subjects/emeele/meta.ts
@@ -6,6 +6,7 @@ export const meta: SubjectMeta = {
   university: "Linnaeus University",
   courseCode: "2DV516",
   icon: "🤖",
+  contentPolicy: "authorized-exams",
   topics: [
     { key: "kNN", label: "k-Nearest Neighbors", icon: "🎯", color: "blue" },
     {

--- a/src/subjects/equisi/meta.ts
+++ b/src/subjects/equisi/meta.ts
@@ -7,7 +7,7 @@ export const meta: SubjectMeta = {
   courseCode: "200190",
   icon: "🏗️",
   acknowledgments:
-    "Exámenes originales y recopilatorios proporcionados por el alumnado de la asignatura de forma anónima.",
+    "Las preguntas y respuestas incluidas en esta plataforma son ejercicios originales creados por estudiantes anónimos a partir del temario oficial. No se reproducen exámenes oficiales, enunciados originales ni materiales docentes protegidos del profesorado o de la universidad. Si se detecta alguna coincidencia sustancial no autorizada, puede notificarse para su revisión y retirada.",
   topics: [
     {
       key: "modulo-i",
@@ -25,7 +25,7 @@ export const meta: SubjectMeta = {
   exams: [
     {
       year: "2024-07",
-      title: "Xullo 2024",
+      title: "Posibles preguntas Xullo 2024",
       date: "Xullo 2024",
       description: "20 preguntas · 10 puntos",
       passPoints: 5,

--- a/src/subjects/equisi/meta.ts
+++ b/src/subjects/equisi/meta.ts
@@ -6,6 +6,7 @@ export const meta: SubjectMeta = {
   university: "Universidade da Coruña",
   courseCode: "200190",
   icon: "🏗️",
+  contentPolicy: "community-practice",
   acknowledgments:
     "Las preguntas y respuestas incluidas en esta plataforma son ejercicios originales creados por estudiantes anónimos a partir del temario oficial. No se reproducen exámenes oficiales, enunciados originales ni materiales docentes protegidos del profesorado o de la universidad. Si se detecta alguna coincidencia sustancial no autorizada, puede notificarse para su revisión y retirada.",
   topics: [

--- a/src/subjects/equispe/meta.ts
+++ b/src/subjects/equispe/meta.ts
@@ -7,7 +7,7 @@ export const meta: SubjectMeta = {
   courseCode: "202323",
   icon: "📋",
   acknowledgments:
-    "Exámenes originales y recopilatorios proporcionados por el alumnado de la asignatura de forma anónima.",
+    "Las preguntas y respuestas incluidas en esta plataforma son ejercicios originales creados por estudiantes anónimos a partir del temario oficial. No se reproducen exámenes oficiales, enunciados originales ni materiales docentes protegidos del profesorado o de la universidad. Si se detecta alguna coincidencia sustancial no autorizada, puede notificarse para su revisión y retirada.",
   topics: [
     {
       key: "teoria",
@@ -25,7 +25,7 @@ export const meta: SubjectMeta = {
   exams: [
     {
       year: "2024-01",
-      title: "Xaneiro 2024",
+      title: "Posibles preguntas Xaneiro 2024",
       date: "Xaneiro 2024",
       description: "16 preguntas · 10 puntos",
       passPoints: 5,
@@ -34,7 +34,7 @@ export const meta: SubjectMeta = {
     },
     {
       year: "2026-01",
-      title: "Xaneiro 2026",
+      title: "Posibles preguntas Xaneiro 2026",
       date: "Xaneiro 2026",
       description: "18 preguntas · 25 puntos",
       passPoints: 13,

--- a/src/subjects/equispe/meta.ts
+++ b/src/subjects/equispe/meta.ts
@@ -6,6 +6,7 @@ export const meta: SubjectMeta = {
   university: "Universidade da Coruña",
   courseCode: "202323",
   icon: "📋",
+  contentPolicy: "community-practice",
   acknowledgments:
     "Las preguntas y respuestas incluidas en esta plataforma son ejercicios originales creados por estudiantes anónimos a partir del temario oficial. No se reproducen exámenes oficiales, enunciados originales ni materiales docentes protegidos del profesorado o de la universidad. Si se detecta alguna coincidencia sustancial no autorizada, puede notificarse para su revisión y retirada.",
   topics: [

--- a/src/subjects/esei/meta.ts
+++ b/src/subjects/esei/meta.ts
@@ -7,7 +7,7 @@ export const meta: SubjectMeta = {
   courseCode: "202322",
   icon: "🧠",
   acknowledgments:
-    "Exámenes originales proporcionados por el alumnado de la asignatura de forma anónima.",
+    "Las preguntas y respuestas incluidas en esta plataforma son ejercicios originales creados por estudiantes anónimos a partir del temario oficial. No se reproducen exámenes oficiales, enunciados originales ni materiales docentes protegidos del profesorado o de la universidad. Si se detecta alguna coincidencia sustancial no autorizada, puede notificarse para su revisión y retirada.",
   topics: [
     {
       key: "t1",
@@ -85,7 +85,7 @@ export const meta: SubjectMeta = {
   exams: [
     {
       year: "2023",
-      title: "2023",
+      title: "Posibles preguntas 2023",
       date: "2023",
       description: "45 preguntas",
       passPoints: 22,
@@ -95,7 +95,7 @@ export const meta: SubjectMeta = {
     },
     {
       year: "2024",
-      title: "2024",
+      title: "Posibles preguntas 2024",
       date: "2024",
       description: "44 preguntas",
       passPoints: 22,
@@ -105,7 +105,7 @@ export const meta: SubjectMeta = {
     },
     {
       year: "2025-05",
-      title: "Mayo 2025",
+      title: "Posibles preguntas Mayo 2025",
       date: "Mayo 2025",
       description: "42 preguntas",
       passPoints: 21,
@@ -115,7 +115,7 @@ export const meta: SubjectMeta = {
     },
     {
       year: "2025-07",
-      title: "Julio 2025",
+      title: "Posibles preguntas Julio 2025",
       date: "Julio 2025",
       description: "47 preguntas",
       passPoints: 23,
@@ -125,7 +125,7 @@ export const meta: SubjectMeta = {
     },
     {
       year: "2026-06",
-      title: "Junio 2026",
+      title: "Posibles preguntas Junio 2026",
       date: "Junio 2026",
       description: "56 preguntas",
       passPoints: 28,

--- a/src/subjects/esei/meta.ts
+++ b/src/subjects/esei/meta.ts
@@ -6,6 +6,7 @@ export const meta: SubjectMeta = {
   university: "Universidade da Coruña",
   courseCode: "202322",
   icon: "🧠",
+  contentPolicy: "community-practice",
   acknowledgments:
     "Las preguntas y respuestas incluidas en esta plataforma son ejercicios originales creados por estudiantes anónimos a partir del temario oficial. No se reproducen exámenes oficiales, enunciados originales ni materiales docentes protegidos del profesorado o de la universidad. Si se detecta alguna coincidencia sustancial no autorizada, puede notificarse para su revisión y retirada.",
   topics: [

--- a/src/subjects/eseo/meta.ts
+++ b/src/subjects/eseo/meta.ts
@@ -6,6 +6,7 @@ export const meta: SubjectMeta = {
   university: "Universidade da Coruña",
   courseCode: "202318",
   icon: "💽",
+  contentPolicy: "authorized-exams",
   acknowledgments:
     "Exámenes y soluciones originales proporcionadas por el profesorado de la asignatura.",
   topics: [

--- a/src/subjects/iesede/meta.ts
+++ b/src/subjects/iesede/meta.ts
@@ -6,6 +6,7 @@ export const meta: SubjectMeta = {
   university: "Universidade da Coruña",
   courseCode: "200188",
   icon: "🌐",
+  contentPolicy: "community-practice",
   acknowledgments:
     "Las preguntas y respuestas incluidas en esta plataforma son ejercicios originales creados por estudiantes anónimos a partir del temario oficial. No se reproducen exámenes oficiales, enunciados originales ni materiales docentes protegidos del profesorado o de la universidad. Si se detecta alguna coincidencia sustancial no autorizada, puede notificarse para su revisión y retirada.",
   topics: [

--- a/src/subjects/iesede/meta.ts
+++ b/src/subjects/iesede/meta.ts
@@ -7,7 +7,7 @@ export const meta: SubjectMeta = {
   courseCode: "200188",
   icon: "🌐",
   acknowledgments:
-    "Examen original proporcionado por el alumnado de la asignatura de forma anónima.",
+    "Las preguntas y respuestas incluidas en esta plataforma son ejercicios originales creados por estudiantes anónimos a partir del temario oficial. No se reproducen exámenes oficiales, enunciados originales ni materiales docentes protegidos del profesorado o de la universidad. Si se detecta alguna coincidencia sustancial no autorizada, puede notificarse para su revisión y retirada.",
   topics: [
     {
       key: "general",
@@ -19,7 +19,7 @@ export const meta: SubjectMeta = {
   exams: [
     {
       year: "examen_recopilatorio",
-      title: "Examen Recopilatorio",
+      title: "Recopilación",
       description: "18 preguntas · 18 puntos",
       passPoints: 9,
       totalPoints: 18,

--- a/src/subjects/peese/meta.ts
+++ b/src/subjects/peese/meta.ts
@@ -7,12 +7,12 @@ export const meta: SubjectMeta = {
   courseCode: "202321",
   icon: "🗓️",
   acknowledgments:
-    "Examen original proporcionado por el alumnado de la asignatura de forma anónima.",
+    "Las preguntas y respuestas incluidas en esta plataforma son ejercicios originales creados por estudiantes anónimos a partir del temario oficial. No se reproducen exámenes oficiales, enunciados originales ni materiales docentes protegidos del profesorado o de la universidad. Si se detecta alguna coincidencia sustancial no autorizada, puede notificarse para su revisión y retirada.",
   topics: [{ key: "teoria", label: "Teoría", icon: "📖", color: "blue" }],
   exams: [
     {
       year: "2026-05",
-      title: "Mayo 2026",
+      title: "Posibles preguntas Mayo 2026",
       date: "Mayo 2026",
       description: "8.5 ptos · 17 preguntas",
       passPoints: 4.25,

--- a/src/subjects/peese/meta.ts
+++ b/src/subjects/peese/meta.ts
@@ -6,6 +6,7 @@ export const meta: SubjectMeta = {
   university: "Universidade da Coruña",
   courseCode: "202321",
   icon: "🗓️",
+  contentPolicy: "community-practice",
   acknowledgments:
     "Las preguntas y respuestas incluidas en esta plataforma son ejercicios originales creados por estudiantes anónimos a partir del temario oficial. No se reproducen exámenes oficiales, enunciados originales ni materiales docentes protegidos del profesorado o de la universidad. Si se detecta alguna coincidencia sustancial no autorizada, puede notificarse para su revisión y retirada.",
   topics: [{ key: "teoria", label: "Teoría", icon: "📖", color: "blue" }],

--- a/src/subjects/pei/meta.ts
+++ b/src/subjects/pei/meta.ts
@@ -6,6 +6,7 @@ export const meta: SubjectMeta = {
   university: "Universidade da Coruña",
   courseCode: "200214",
   icon: "🔗",
+  contentPolicy: "community-practice",
   acknowledgments:
     "Preguntas recopiladas por el alumnado de la asignatura de forma anónima.",
   topics: [

--- a/src/subjects/redes/meta.ts
+++ b/src/subjects/redes/meta.ts
@@ -6,6 +6,7 @@ export const meta: SubjectMeta = {
   university: "Universidade da Coruña",
   courseCode: "202319",
   icon: "🕸️",
+  contentPolicy: "community-practice",
   acknowledgments:
     "Las preguntas y respuestas incluidas en esta plataforma son ejercicios originales creados por estudiantes anónimos a partir del temario oficial. No se reproducen exámenes oficiales, enunciados originales ni materiales docentes protegidos del profesorado o de la universidad. Si se detecta alguna coincidencia sustancial no autorizada, puede notificarse para su revisión y retirada.",
   topics: [

--- a/src/subjects/redes/meta.ts
+++ b/src/subjects/redes/meta.ts
@@ -7,7 +7,7 @@ export const meta: SubjectMeta = {
   courseCode: "202319",
   icon: "🕸️",
   acknowledgments:
-    "Exámenes originales y recopilatorios proporcionados por el alumnado de la asignatura de forma anónima.",
+    "Las preguntas y respuestas incluidas en esta plataforma son ejercicios originales creados por estudiantes anónimos a partir del temario oficial. No se reproducen exámenes oficiales, enunciados originales ni materiales docentes protegidos del profesorado o de la universidad. Si se detecta alguna coincidencia sustancial no autorizada, puede notificarse para su revisión y retirada.",
   topics: [
     {
       key: "tema-1",
@@ -99,8 +99,8 @@ export const meta: SubjectMeta = {
     },
     {
       year: "2025-05",
-      title: "Mayo 2025 (incompl.)",
-      date: "2025-05",
+      title: "Posibles preguntas Mayo 2025",
+      date: "Mayo 2025",
       description: "37 preguntas · 37 puntos",
       passPoints: 19,
       totalPoints: 37,


### PR DESCRIPTION
## Summary
- Add content policy metadata to distinguish authorized exams from community practice materials
- Update UI, SEO, issue templates, and docs to reflect authorized vs community content
- Add content policy badges/icons in subject cards, subject pages, and generated OG images
- Add copyright reporting/removal affordances for protected material

## Verification
- pnpm build
- pnpm lint

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a `contentPolicy` metadata field (`"authorized-exams"` | `"community-practice"`) on `SubjectMeta` to distinguish officially-provided exam content from community-assembled practice sets, and threads that distinction throughout the UI, SEO layer, OG-image generator, and contribution workflows.

- **New `ContentPolicy` type and `hasAuthorizedExamContent` helper** gate all UI/SEO branching; subjects without the field default to `"community-practice"` (safe fallback).
- **`ContentPolicyIcon`**, **`CopyrightReportModal`**, and updated `SubjectCard`/`SubjectHome`/`ExamSimulation` surfaces display policy badges, context-aware labels, and a copyright removal affordance.
- **`generate-og-images.ts`** renders a per-policy badge inline on every subject OG image, and the `subjectsMeta` Record type now correctly declares `contentPolicy` so the emitted JSON is typed accurately.
- **All 14 `*/meta.ts` subject files** (plus the `_template`) are annotated with the correct `contentPolicy` value.
</details>


<h3>Confidence Score: 5/5</h3>

This PR is safe to merge; all changes are additive metadata and UI branching with no mutations to existing data paths.

The change adds an optional field with a safe undefined → community-practice fallback, propagates it consistently through UI, SEO, and the OG-image script, and touches no shared state or data-persistence logic. The drawCommunityIcon arc fix noted in the prior review thread is correctly present. No logic paths were removed or broken.

No files require special attention. The OG-image script runs outside the TypeScript project configs, but the subjectsMeta type now correctly includes contentPolicy, closing the gap flagged in the previous outside-diff comment.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/data/types.ts | Adds ContentPolicy union type and optional contentPolicy field to SubjectMeta; clean, minimal extension of the existing data model. |
| src/lib/content-policy.ts | New helper that centralises the 'is authorized?' predicate; subjects without contentPolicy default to community-practice (correct safe default). |
| src/components/ContentPolicyIcon.tsx | New icon component with correct aria-hidden/role/aria-label handling for both badge and svgOnly render modes. |
| src/components/CopyrightReportModal.tsx | New modal for copyright removal requests; email extracted to CONTACT_EMAIL constant resolving the previous two-location concern. |
| scripts/generate-og-images.ts | Adds contentPolicy-aware badge and label rendering to OG images; contentPolicy field now declared in the subjectsMeta type. OG image stats and labels are hardcoded in Spanish for all locales (single static image per subject by design). |
| src/pages/SubjectHome.tsx | Integrates content-policy throughout the subject page: section titles, descriptions, PDF/Daypo labels, and adds the new copyright-report modal alongside the existing add-exam modal. |
| src/seo/meta.ts | SEO title and description strings now branch on content policy for subject, topic, and exam pages across all three locales. |
| src/i18n/en.ts | Adds contentPolicy, copyrightReport, and addExam i18n keys; also adds practiceSets to subjectCard and communityDescription/practiceSimulations to subjectHome. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SubjectMeta.contentPolicy] -->|"authorized-exams"| B[hasAuthorizedExamContent = true]
    A -->|"community-practice" or undefined| C[hasAuthorizedExamContent = false]

    B --> D1[Badge: Verified exam materials]
    B --> D2[Section: Exams / Original Exam Documents]
    B --> D3[SEO: exam simulator / exams and solved questions]
    B --> D4[ExamSimulation: simulationNote]
    B --> D5[OG image: Exámenes verificados badge]

    C --> E1[Badge: Community practice materials]
    C --> E2[Section: Compilations / Source Materials]
    C --> E3[SEO: timed practice / compilations and solved questions]
    C --> E4[ExamSimulation: practiceNote]
    C --> E5[OG image: Recopilatorios comunitarios badge]

    A -->|All subjects| F[CopyrightReportModal always available]
    A -->|All subjects| G[AddExamModal always available]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[SubjectMeta.contentPolicy] -->|"authorized-exams"| B[hasAuthorizedExamContent = true]
    A -->|"community-practice" or undefined| C[hasAuthorizedExamContent = false]

    B --> D1[Badge: Verified exam materials]
    B --> D2[Section: Exams / Original Exam Documents]
    B --> D3[SEO: exam simulator / exams and solved questions]
    B --> D4[ExamSimulation: simulationNote]
    B --> D5[OG image: Exámenes verificados badge]

    C --> E1[Badge: Community practice materials]
    C --> E2[Section: Compilations / Source Materials]
    C --> E3[SEO: timed practice / compilations and solved questions]
    C --> E4[ExamSimulation: practiceNote]
    C --> E5[OG image: Recopilatorios comunitarios badge]

    A -->|All subjects| F[CopyrightReportModal always available]
    A -->|All subjects| G[AddExamModal always available]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `scripts/generate-og-images.ts`, line 257-318 ([link](https://github.com/teenbiscuits/pasame-examenes/blob/63c70bf1ffc656c240dd65f5f80c82a5f04d4a66/scripts/generate-og-images.ts#L257-L318)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`subjectsMeta` type missing `contentPolicy`**

   The `subjectsMeta` Record value type (lines 257–268) does not declare a `contentPolicy` field, but `contentPolicy` is included when each entry is written (line 316). Because `scripts/` is outside both `tsconfig.app.json` and `tsconfig.node.json`, this excess-property error is never caught by `pnpm build`. The emitted `public/subjects-meta.json` will carry `contentPolicy` in every entry regardless, but any future script or consumer typed against the declared shape will silently miss the field.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix: address PR review feedback"](https://github.com/teenbiscuits/pasame-examenes/commit/de60cd28dee7c12a27daefc4c127a62fa5aa1d1a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42237509)</sub>

<!-- /greptile_comment -->