### PR TITLE
feat: Hero redesign with floating emojis and larger title

### DIFF
--- a/src/components/FloatingEmoji.tsx
+++ b/src/components/FloatingEmoji.tsx
@@ -76,6 +76,8 @@ export default function FloatingEmoji({ emoji, style }: FloatingEmojiProps) {
       setFlying(true);
       setOffset({ x: 0, y: 0 });
       window.setTimeout(() => setFlying(false), SPRING_MS);
+    } else if (offset.x !== 0 || offset.y !== 0) {
+      setOffset({ x: 0, y: 0 });
     }
   }
 

--- a/src/components/FloatingEmoji.tsx
+++ b/src/components/FloatingEmoji.tsx
@@ -1,0 +1,114 @@
+import {
+  useRef,
+  useState,
+  type CSSProperties,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
+
+interface FloatingEmojiProps {
+  emoji: string;
+  style: CSSProperties;
+}
+
+interface DragState {
+  active: boolean;
+  moved: boolean;
+  startX: number;
+  startY: number;
+  offsetX: number;
+  offsetY: number;
+}
+
+const SPRING_MS = 800;
+const SPRING_EASING = "cubic-bezier(0.18, 0.89, 0.32, 1.28)";
+
+export default function FloatingEmoji({ emoji, style }: FloatingEmojiProps) {
+  const drag = useRef<DragState>({
+    active: false,
+    moved: false,
+    startX: 0,
+    startY: 0,
+    offsetX: 0,
+    offsetY: 0,
+  });
+  const [offset, setOffset] = useState({ x: 0, y: 0 });
+  const [flying, setFlying] = useState(false);
+  const [pressed, setPressed] = useState(false);
+  const baseTransform = style.transform as string | undefined;
+
+  function handlePointerDown(e: ReactPointerEvent<HTMLSpanElement>) {
+    drag.current = {
+      active: true,
+      moved: false,
+      startX: e.clientX,
+      startY: e.clientY,
+      offsetX: 0,
+      offsetY: 0,
+    };
+    setFlying(false);
+    setPressed(true);
+    try {
+      e.currentTarget.setPointerCapture(e.pointerId);
+    } catch {
+      /* noop */
+    }
+  }
+
+  function handlePointerMove(e: ReactPointerEvent<HTMLSpanElement>) {
+    if (!drag.current.active) return;
+    const dx = e.clientX - drag.current.startX;
+    const dy = e.clientY - drag.current.startY;
+    if (Math.abs(dx) > 3 || Math.abs(dy) > 3) drag.current.moved = true;
+    drag.current.offsetX = dx;
+    drag.current.offsetY = dy;
+    setOffset({ x: dx, y: dy });
+  }
+
+  function endDrag(e: ReactPointerEvent<HTMLSpanElement>) {
+    try {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    } catch {
+      /* noop */
+    }
+    drag.current.active = false;
+    setPressed(false);
+    if (drag.current.moved) {
+      setFlying(true);
+      setOffset({ x: 0, y: 0 });
+      window.setTimeout(() => setFlying(false), SPRING_MS);
+    }
+  }
+
+  const dragging = offset.x !== 0 || offset.y !== 0;
+
+  let transform = baseTransform ?? "";
+  if (dragging) {
+    transform = `translate(${offset.x}px, ${offset.y}px) ${baseTransform ?? ""}`;
+  }
+  if (pressed) {
+    transform += " scale(1.18)";
+  }
+
+  return (
+    <span
+      className="floating-emoji-mark floating-emoji-interactive cursor-grab touch-none select-none active:cursor-grabbing"
+      style={{
+        ...style,
+        transform,
+        transition: flying
+          ? `transform ${SPRING_MS}ms ${SPRING_EASING}`
+          : pressed && !dragging
+            ? "transform 0.15s ease-out"
+            : undefined,
+        animationPlayState: dragging || flying ? "paused" : undefined,
+        willChange: "transform, translate",
+      }}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={endDrag}
+      onPointerCancel={endDrag}
+    >
+      {emoji}
+    </span>
+  );
+}

--- a/src/components/FloatingEmoji.tsx
+++ b/src/components/FloatingEmoji.tsx
@@ -103,7 +103,7 @@ export default function FloatingEmoji({ emoji, style }: FloatingEmojiProps) {
             ? "transform 0.15s ease-out"
             : undefined,
         animationPlayState: dragging || flying ? "paused" : undefined,
-        willChange: "transform, translate",
+        willChange: pressed || dragging || flying ? "transform" : undefined,
       }}
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -17,6 +17,12 @@ const langLabel: Record<Lang, string> = {
   gl: "🧜🏻‍♀️ GL",
 };
 
+const langFlag: Record<Lang, string> = {
+  en: "🇬🇧",
+  es: "🇪🇸",
+  gl: "🧜🏻‍♀️ GL",
+};
+
 function acronym(name: string): string {
   const letters = name.replace(/[^A-Z]/g, "");
   return letters || name.charAt(0).toUpperCase();
@@ -33,12 +39,14 @@ export default function Header() {
 
   const abbr = subject ? acronym(subject.name) : "";
 
-  const subjectLinkClasses = `px-3 py-1.5 rounded-md focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none transition-colors ${
+  const subjectLinkBase = `rounded-md focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none transition-colors ${
     location.pathname === `/${subjectId}` ||
     location.pathname.startsWith(`/${subjectId}/`)
       ? "bg-accent-light text-accent-fg"
       : "text-fg-secondary hover:text-fg"
   }`;
+  const acronymLinkClasses = `px-1.5 py-1 sm:px-3 sm:py-1.5 ${subjectLinkBase}`;
+  const subjectLinkClasses = `px-3 py-1.5 ${subjectLinkBase}`;
 
   return (
     <header className="bg-surface-alt border-b border-border sticky top-0 z-50">
@@ -61,12 +69,12 @@ export default function Header() {
           />
           {t.home.title}
         </Link>
-        <div className="flex items-center gap-2 sm:gap-3 text-sm">
+        <div className="flex items-center gap-1 sm:gap-3 text-sm">
           {subject && (
             <>
               <Link
                 to={`/${subjectId}`}
-                className={`sm:hidden ${subjectLinkClasses}`}
+                className={`sm:hidden ${acronymLinkClasses}`}
                 onClick={() => {
                   triggerLight();
                   track("nav_click", {
@@ -111,7 +119,8 @@ export default function Header() {
             }}
             aria-label={langLabel[lang]}
           >
-            {langLabel[lang]}
+            <span className="sm:hidden">{langFlag[lang]}</span>
+            <span className="hidden sm:inline">{langLabel[lang]}</span>
           </button>
         </div>
       </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -53,7 +53,7 @@ export default function Header() {
       <div className="max-w-6xl mx-auto px-4 h-14 flex items-center justify-between">
         <Link
           to="/"
-          className="font-bold text-lg text-fg hover:text-accent focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none rounded-md transition-colors flex items-center gap-2.5"
+          className="font-bold text-lg text-fg hover:text-accent focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none rounded-md transition-colors flex items-center gap-2"
           onClick={() => {
             triggerLight();
             track("nav_click", { target: "home" });

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,4 +1,5 @@
 import { type CSSProperties, type ReactNode } from "react";
+import FloatingEmoji from "./FloatingEmoji";
 
 function pseudo(i: number, salt: number, seed: number): number {
   const x = Math.sin(i * 9301 + salt * 49297 + seed * 8347) * 233280;
@@ -136,19 +137,17 @@ export default function Hero({
   return (
     <section className={`relative w-full overflow-hidden ${className}`}>
       <div
-        className="pointer-events-none absolute inset-y-0 left-1/2 z-0 hidden w-full max-w-6xl -translate-x-1/2 md:block"
+        className="absolute inset-y-0 left-1/2 z-0 hidden w-full max-w-6xl -translate-x-1/2 md:block"
         aria-hidden="true"
       >
         {emojis.map((emoji, i) => {
           const slot = (i + placementOffset) % emojis.length;
           return (
-            <span
+            <FloatingEmoji
               key={`${emoji}-${i}`}
-              className="floating-emoji-mark select-none"
+              emoji={emoji}
               style={buildDesktopStyle(slot, emojis.length, compact, seed)}
-            >
-              {emoji}
-            </span>
+            />
           );
         })}
       </div>
@@ -169,7 +168,9 @@ export default function Hero({
           );
         })}
       </div>
-      <div className={`relative z-10 mx-auto max-w-6xl px-4 text-center ${spacing}`}>
+      <div
+        className={`pointer-events-none relative z-10 mx-auto max-w-6xl px-4 text-center ${spacing}`}
+      >
         {children}
       </div>
     </section>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,0 +1,177 @@
+import { type CSSProperties, type ReactNode } from "react";
+
+function pseudo(i: number, salt: number, seed: number): number {
+  const x = Math.sin(i * 9301 + salt * 49297 + seed * 8347) * 233280;
+  return x - Math.floor(x);
+}
+
+interface HeroProps {
+  emojis: string[];
+  children: ReactNode;
+  className?: string;
+  compact?: boolean;
+}
+
+function buildDesktopStyle(
+  i: number,
+  count: number,
+  compact: boolean,
+  seed: number,
+): CSSProperties {
+  const perZone = Math.max(1, Math.ceil(count / 4));
+  const zone = i % 4;
+  const zoneIndex = Math.floor(i / 4);
+  const progress = perZone > 1 ? zoneIndex / (perZone - 1) : 0.5;
+  let left: number;
+  let top: number;
+
+  if (zone === 0) {
+    left = 8 + progress * 84 + (pseudo(i, 1, seed) - 0.5) * 3;
+    top = 6 + pseudo(i, 2, seed) * 14;
+  } else if (zone === 1) {
+    left = 3 + pseudo(i, 1, seed) * 14;
+    top = 24 + progress * 40 + (pseudo(i, 2, seed) - 0.5) * 3;
+  } else if (zone === 2) {
+    left = 83 + pseudo(i, 1, seed) * 14;
+    top = 24 + progress * 40 + (pseudo(i, 2, seed) - 0.5) * 3;
+  } else {
+    left = 8 + progress * 84 + (pseudo(i, 1, seed) - 0.5) * 3;
+    top = compact
+      ? 54 + pseudo(i, 2, seed) * 8
+      : 66 + pseudo(i, 2, seed) * 12;
+  }
+
+  const rotation = (pseudo(i, 3, seed) - 0.5) * 44;
+  const delay = -(pseudo(i, 4, seed) * 8);
+  const fontRem = compact
+    ? 3 + pseudo(i, 5, seed) * 2.6
+    : 3.4 + pseudo(i, 5, seed) * 3.2;
+
+  return {
+    left: `${left.toFixed(2)}%`,
+    top: `${top.toFixed(2)}%`,
+    transform: `rotate(${rotation.toFixed(1)}deg)`,
+    animationDelay: `${delay.toFixed(2)}s`,
+    fontSize: `clamp(3rem, 4.4vw, ${fontRem.toFixed(2)}rem)`,
+    opacity: 0.9,
+  };
+}
+
+function buildMobileStyle(
+  i: number,
+  count: number,
+  seed: number,
+  compact: boolean,
+): CSSProperties {
+  if (!compact) {
+    const perZone = Math.max(1, Math.ceil(count / 4));
+    const zone = i % 4;
+    const zoneIndex = Math.floor(i / 4);
+    const progress = perZone > 1 ? zoneIndex / (perZone - 1) : 0.5;
+    let left: number;
+    let top: number;
+
+    if (zone === 0) {
+      left = 6 + progress * 88 + (pseudo(i, 6, seed) - 0.5) * 4;
+      top = 6 + pseudo(i, 7, seed) * 12;
+    } else if (zone === 1) {
+      left = 3 + pseudo(i, 6, seed) * 12;
+      top = 22 + progress * 42 + (pseudo(i, 7, seed) - 0.5) * 4;
+    } else if (zone === 2) {
+      left = 85 + pseudo(i, 6, seed) * 12;
+      top = 22 + progress * 42 + (pseudo(i, 7, seed) - 0.5) * 4;
+    } else {
+      left = 6 + progress * 88 + (pseudo(i, 6, seed) - 0.5) * 4;
+      top = 66 + pseudo(i, 7, seed) * 10;
+    }
+
+    const rotation = (pseudo(i, 8, seed) - 0.5) * 38;
+    const delay = -(pseudo(i, 9, seed) * 8);
+    const fontRem = 1.95 + pseudo(i, 10, seed) * 1.55;
+
+    return {
+      left: `${left.toFixed(2)}%`,
+      top: `${top.toFixed(2)}%`,
+      transform: `rotate(${rotation.toFixed(1)}deg)`,
+      animationDelay: `${delay.toFixed(2)}s`,
+      fontSize: `clamp(1.65rem, 8.8vw, ${fontRem.toFixed(2)}rem)`,
+      opacity: 0.78,
+    };
+  }
+
+  const columns = Math.min(3, Math.max(1, count));
+  const rows = Math.max(1, Math.ceil(count / columns));
+  const col = i % columns;
+  const row = Math.floor(i / columns);
+  const colStep = columns > 1 ? 78 / (columns - 1) : 0;
+  const rowStep = rows > 1 ? 56 / (rows - 1) : 0;
+  const left = 11 + col * colStep + (pseudo(i, 6, seed) - 0.5) * 6;
+  const top = 14 + row * rowStep + (pseudo(i, 7, seed) - 0.5) * 4;
+  const rotation = (pseudo(i, 8, seed) - 0.5) * 38;
+  const delay = -(pseudo(i, 9, seed) * 8);
+  const fontRem = 1.95 + pseudo(i, 10, seed) * 1.55;
+
+  return {
+    left: `${Math.min(88, Math.max(4, left)).toFixed(2)}%`,
+    top: `${Math.min(76, Math.max(8, top)).toFixed(2)}%`,
+    transform: `rotate(${rotation.toFixed(1)}deg)`,
+    animationDelay: `${delay.toFixed(2)}s`,
+    fontSize: `clamp(1.65rem, 8.8vw, ${fontRem.toFixed(2)}rem)`,
+    opacity: 0.78,
+  };
+}
+
+export default function Hero({
+  emojis,
+  children,
+  className = "",
+  compact = false,
+}: HeroProps) {
+  const seed = 0;
+
+  const placementOffset =
+    emojis.length > 0 ? Math.floor(pseudo(0, 11, seed) * emojis.length) : 0;
+  const spacing = compact ? "py-16 md:py-[50px]" : "py-24 sm:py-28 lg:py-32";
+
+  return (
+    <section className={`relative w-full overflow-hidden ${className}`}>
+      <div
+        className="pointer-events-none absolute inset-y-0 left-1/2 z-0 hidden w-full max-w-6xl -translate-x-1/2 md:block"
+        aria-hidden="true"
+      >
+        {emojis.map((emoji, i) => {
+          const slot = (i + placementOffset) % emojis.length;
+          return (
+            <span
+              key={`${emoji}-${i}`}
+              className="floating-emoji-mark select-none"
+              style={buildDesktopStyle(slot, emojis.length, compact, seed)}
+            >
+              {emoji}
+            </span>
+          );
+        })}
+      </div>
+      <div
+        className="pointer-events-none absolute inset-y-0 left-1/2 z-0 w-full max-w-6xl -translate-x-1/2 md:hidden"
+        aria-hidden="true"
+      >
+        {emojis.map((emoji, i) => {
+          const slot = (i + placementOffset) % emojis.length;
+          return (
+            <span
+              key={`${emoji}-${i}-mobile`}
+              className="floating-emoji-mark select-none"
+              style={buildMobileStyle(slot, emojis.length, seed, compact)}
+            >
+              {emoji}
+            </span>
+          );
+        })}
+      </div>
+      <div className={`relative z-10 mx-auto max-w-6xl px-4 text-center ${spacing}`}>
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/src/components/SubjectCard.tsx
+++ b/src/components/SubjectCard.tsx
@@ -46,8 +46,8 @@ export default function SubjectCard({ subject }: SubjectCardProps) {
         recordSubjectClick(subject.id);
       }}
     >
-      <div className="flex items-start justify-between mb-3">
-        <span className="text-2xl" aria-hidden="true">
+      <div className="flex items-start justify-between mb-2">
+        <span className="text-4xl leading-none" aria-hidden="true">
           {subject.icon}
         </span>
         <div className="flex items-center gap-2">
@@ -57,8 +57,8 @@ export default function SubjectCard({ subject }: SubjectCardProps) {
           </span>
         </div>
       </div>
-      <h2 className="font-semibold text-fg text-base mb-1">{subject.name}</h2>
-      <p className="text-sm text-fg-muted mb-4">{subject.university}</p>
+      <h2 className="font-semibold text-fg text-base mb-0.5">{subject.name}</h2>
+      <p className="text-sm text-fg-muted mb-2">{subject.university}</p>
       <div className="text-xs text-fg-muted flex items-center gap-2">
         <span>
           {questionCount !== null ? questionCount : "..."}{" "}

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -6,6 +6,7 @@ export const en = {
     addSubject: "Add Subject?",
     recentlyVisited: "Recently visited",
     clearRecent: "Clear recent subjects",
+    quote: "Exams don't repeat, but they rhyme.",
   },
   subjectHome: {
     notFound: "Subject Not Found",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -8,6 +8,7 @@ export const es: Translations = {
     addSubject: "¿Añadir asignatura?",
     recentlyVisited: "Visitadas recientemente",
     clearRecent: "Limpiar asignaturas recientes",
+    quote: "Los exámenes no se repiten, pero riman",
   },
   subjectHome: {
     notFound: "Asignatura no encontrada",

--- a/src/i18n/gl.ts
+++ b/src/i18n/gl.ts
@@ -8,6 +8,7 @@ export const gl: Translations = {
     addSubject: "Engadir materia?",
     recentlyVisited: "Visitadas recentemente",
     clearRecent: "Limpar materias recentes",
+    quote: "Os exames non se repiten, pero riman.",
   },
   subjectHome: {
     notFound: "Materia non atopada",

--- a/src/index.css
+++ b/src/index.css
@@ -257,6 +257,13 @@ html[data-theme="catppuccin"] {
   filter: drop-shadow(0 6px 10px rgb(0 0 0 / 0.18));
   animation: 9s ease-in-out infinite floatDrift;
   will-change: translate;
+  user-select: none;
+}
+
+.floating-emoji-interactive {
+  pointer-events: auto;
+  touch-action: none;
+  -webkit-user-select: none;
 }
 
 /* ── View transition animation ── */

--- a/src/index.css
+++ b/src/index.css
@@ -239,6 +239,26 @@ html[data-theme="catppuccin"] {
   }
 }
 
+/* ── Floating hero emojis ── */
+@keyframes floatDrift {
+  0%,
+  to {
+    translate: 0;
+  }
+  50% {
+    translate: 0 -10px;
+  }
+}
+
+.floating-emoji-mark {
+  position: absolute;
+  display: block;
+  line-height: 1;
+  filter: drop-shadow(0 6px 10px rgb(0 0 0 / 0.18));
+  animation: 9s ease-in-out infinite floatDrift;
+  will-change: translate;
+}
+
 /* ── View transition animation ── */
 ::view-transition-old(root),
 ::view-transition-new(root) {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -190,6 +190,10 @@ export default function Home() {
         </div>
       </div>
 
+      <blockquote className="mx-auto mt-14 max-w-2xl border-y border-border py-8 text-center text-xl font-medium italic text-fg-secondary sm:text-2xl">
+        “{t.home.quote}”
+      </blockquote>
+
       <AddSubjectModal ref={modalRef} onClose={() => {}} />
       </div>
     </>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useRef, useState } from "react";
 import { subjects } from "../subjects";
 import SubjectCard from "../components/SubjectCard";
+import Hero from "../components/Hero";
 import AddSubjectModal, {
   type AddSubjectModalHandle,
 } from "../components/AddSubjectModal";
@@ -95,13 +96,20 @@ export default function Home() {
   });
 
   return (
-    <div className="max-w-6xl mx-auto px-4 py-8 text-center animate-fade-in animate-duration-fast">
-      <h1 className="text-3xl font-semibold text-fg mb-3">{t.home.title}</h1>
-      <p className="text-fg-secondary max-w-xl mx-auto mb-10">
-        {t.home.subtitle}
-      </p>
-
-      {recentSubjects.length > 0 && (
+    <>
+      <Hero
+        emojis={subjects.map((s) => s.icon)}
+        className="animate-fade-in animate-duration-fast"
+      >
+        <h1 className="text-4xl font-semibold text-fg mb-3 sm:text-5xl lg:text-6xl">
+          {t.home.title}
+        </h1>
+        <p className="mx-auto max-w-2xl text-base text-fg-secondary sm:text-lg lg:text-xl">
+          {t.home.subtitle}
+        </p>
+      </Hero>
+      <div className="max-w-6xl mx-auto px-4 pb-8 text-center animate-fade-in animate-duration-fast">
+        {recentSubjects.length > 0 && (
         <div className="mb-10 text-left" key={recentKey}>
           <div className="flex items-center justify-between mb-3">
             <h2 className="text-sm font-semibold text-fg-muted uppercase tracking-wide">
@@ -183,6 +191,7 @@ export default function Home() {
       </div>
 
       <AddSubjectModal ref={modalRef} onClose={() => {}} />
-    </div>
+      </div>
+    </>
   );
 }

--- a/src/pages/SubjectHome.tsx
+++ b/src/pages/SubjectHome.tsx
@@ -11,6 +11,7 @@ import CopyrightReportModal, {
   type CopyrightReportModalHandle,
 } from "../components/CopyrightReportModal";
 import ContentPolicyIcon from "../components/ContentPolicyIcon";
+import Hero from "../components/Hero";
 import type { Question, SubjectMeta, Topic } from "../data/types";
 import { useLang, useT } from "../i18n/hooks";
 import { track } from "../lib/umami";
@@ -87,39 +88,44 @@ export default function SubjectHome() {
     .replace("{exams}", String(availableExams.length));
 
   return (
-    <div className="max-w-6xl mx-auto px-4 py-8 animate-fade-in animate-duration-fast">
+    <div className="animate-fade-in animate-duration-fast">
       <SubjectHeader subject={subject} description={description} />
-      <TopicsSection
-        subject={subject}
-        questions={allQuestions}
-        progress={progress}
-      />
-      <ExamSimulationsSection
-        subject={subject}
-        hasAuthorizedExams={hasAuthorizedExams}
-        onAddExam={() => examModalRef.current?.open()}
-        onReportCopyright={() => copyrightModalRef.current?.open()}
-      />
+      <div className="mx-auto max-w-6xl px-4 pb-8">
+        <TopicsSection
+          subject={subject}
+          questions={allQuestions}
+          progress={progress}
+        />
+        <ExamSimulationsSection
+          subject={subject}
+          hasAuthorizedExams={hasAuthorizedExams}
+          onAddExam={() => examModalRef.current?.open()}
+          onReportCopyright={() => copyrightModalRef.current?.open()}
+        />
 
-      <AddExamModal
-        ref={examModalRef}
-        onClose={() => {}}
-        subjectId={subject.id}
-        subjectName={subject.name}
-      />
-      <CopyrightReportModal
-        ref={copyrightModalRef}
-        onClose={() => {}}
-        subjectId={subject.id}
-        subjectName={subject.name}
-      />
+        <AddExamModal
+          ref={examModalRef}
+          onClose={() => {}}
+          subjectId={subject.id}
+          subjectName={subject.name}
+        />
+        <CopyrightReportModal
+          ref={copyrightModalRef}
+          onClose={() => {}}
+          subjectId={subject.id}
+          subjectName={subject.name}
+        />
 
-      <PdfLinksSection subject={subject} hasAuthorizedExams={hasAuthorizedExams} />
-      <DaypoLinksSection
-        subject={subject}
-        hasAuthorizedExams={hasAuthorizedExams}
-      />
-      <ContentNotes subject={subject} />
+        <PdfLinksSection
+          subject={subject}
+          hasAuthorizedExams={hasAuthorizedExams}
+        />
+        <DaypoLinksSection
+          subject={subject}
+          hasAuthorizedExams={hasAuthorizedExams}
+        />
+        <ContentNotes subject={subject} />
+      </div>
     </div>
   );
 }
@@ -154,16 +160,20 @@ function SubjectHeader({
   description: string;
 }) {
   return (
-    <div className="text-center mb-10">
+    <Hero emojis={subject.topics.map((tp) => tp.icon)} compact>
       <p className="flex items-center justify-center gap-2 text-xs font-mono uppercase tracking-widest text-fg-muted mb-3">
         <ContentPolicyIcon subject={subject} className="size-4" svgOnly />
         <span>
           {subject.courseCode} &middot; {subject.university}
         </span>
       </p>
-      <h1 className="text-3xl font-semibold text-fg mb-3">{subject.name}</h1>
-      <p className="text-fg-secondary max-w-xl mx-auto">{description}</p>
-    </div>
+      <h1 className="text-4xl font-semibold text-fg mb-3 sm:text-5xl lg:text-6xl">
+        {subject.name}
+      </h1>
+      <p className="mx-auto max-w-2xl text-base text-fg-secondary sm:text-lg lg:text-xl">
+        {description}
+      </p>
+    </Hero>
   );
 }
 


### PR DESCRIPTION
## Summary

- Add `Hero` component with floating emoji decorations around the title area
- **Home page**: emojis = all subject icons, floating in zones around the title/subtitle
- **Subject pages**: emojis = topic icons, same floating layout with compact spacing
- Emojis avoid the central title area on desktop (ring layout) and are distributed homogeneously
- Mobile shows emojis around the title too, smaller and behind the text

## Detail

- **Title/subtitle**: larger typography (text-4xl → text-6xl) and wider subtitle
- **SubjectCard**: bigger emoji (text-2xl → text-4xl), tightened 3-line text spacing to keep card height
- **Header**: hide language code label (ES/EN/GL) on mobile, tighten subject acronym padding to free title space

## Files

- `src/components/Hero.tsx` (new)
- `src/components/Header.tsx`
- `src/components/SubjectCard.tsx`
- `src/index.css`
- `src/pages/Home.tsx`
- `src/pages/SubjectHome.tsx`

## Verification

- `pnpm build` passes
- `pnpm lint` passes

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a `Hero` section component with floating, draggable emoji decorations for both the home page and subject pages, alongside typography scaling, a header mobile tweak, and a new i18n `quote` key.

- **`Hero` + `FloatingEmoji` components**: A new `Hero` wrapper places emojis in a deterministic ring layout around the title area; desktop emojis are interactive (`FloatingEmoji` with spring-back drag), mobile emojis are decorative-only spans. The pseudo-random placement uses a fixed `seed = 0`, giving a consistent layout across renders.
- **Visual updates**: Title bumped from `text-3xl` to `text-6xl` (responsive), `SubjectCard` emoji enlarged from `text-2xl` to `text-4xl` with matching margin reductions, and the header hides the language code label on mobile in favour of a flag emoji.
- **i18n + blockquote**: A `quote` key is added in all three locales (EN/ES/GL) and rendered as a styled `blockquote` at the bottom of the home page.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are purely visual/interactive with no data, routing, or auth logic touched.

All modifications are UI layer: new presentational components, Tailwind class adjustments, and i18n string additions. The build and lint are confirmed passing. The one notable quirk (pointer-events-none inheriting to Hero children) only matters if interactive children are added later, which is not the case in this PR.

No files require special attention; Hero.tsx and FloatingEmoji.tsx are the most complex additions but are well-scoped to the hero section.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/FloatingEmoji.tsx | New interactive drag component for desktop emojis; stale-closure issue on sub-3px taps (flagged in previous thread) is the main concern |
| src/components/Hero.tsx | New Hero section with deterministic emoji ring layout; content wrapper uses pointer-events-none which inherits to all children |
| src/components/Header.tsx | Adds mobile-only flag emoji display, tightens nav padding for small screens — clean change |
| src/components/SubjectCard.tsx | Emoji bumped from text-2xl to text-4xl with compensating margin reductions to preserve card height — straightforward visual adjustment |
| src/pages/Home.tsx | Wraps hero section in new Hero component, adds blockquote; indentation inconsistency in the recent-subjects block noted in a prior thread |
| src/pages/SubjectHome.tsx | SubjectHeader now renders inside Hero with compact layout; content restructured into a max-w-6xl wrapper — no logic changes |
| src/i18n/en.ts | Adds quote key to the home translations shape; matched in es.ts and gl.ts |
| src/index.css | Adds floatDrift keyframe animation and utility classes for floating emojis — well-scoped CSS additions |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Home["Home.tsx"] -->|renders| Hero["Hero (emojis = all subject icons)"]
    SubjectHome["SubjectHome.tsx"] -->|renders via SubjectHeader| HeroCompact["Hero compact (emojis = topic icons)"]

    Hero -->|desktop md:block| DesktopLayer["Desktop emoji layer (z-0, absolute)"]
    Hero -->|mobile md:hidden| MobileLayer["Mobile emoji layer (z-0, pointer-events-none)"]
    Hero -->|z-10 content| ContentDiv["Content div (pointer-events-none)"]

    DesktopLayer -->|map| FloatingEmoji["FloatingEmoji\n(draggable, spring-back)"]
    MobileLayer -->|map| StaticSpan["span.floating-emoji-mark\n(decorative only)"]

    FloatingEmoji -->|buildDesktopStyle| PseudoRNG["pseudo() deterministic\nlayout — seed=0"]
    StaticSpan -->|buildMobileStyle| PseudoRNG

    ContentDiv -->|children| Title["h1 title + p subtitle\n(current Hero children)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    Home["Home.tsx"] -->|renders| Hero["Hero (emojis = all subject icons)"]
    SubjectHome["SubjectHome.tsx"] -->|renders via SubjectHeader| HeroCompact["Hero compact (emojis = topic icons)"]

    Hero -->|desktop md:block| DesktopLayer["Desktop emoji layer (z-0, absolute)"]
    Hero -->|mobile md:hidden| MobileLayer["Mobile emoji layer (z-0, pointer-events-none)"]
    Hero -->|z-10 content| ContentDiv["Content div (pointer-events-none)"]

    DesktopLayer -->|map| FloatingEmoji["FloatingEmoji\n(draggable, spring-back)"]
    MobileLayer -->|map| StaticSpan["span.floating-emoji-mark\n(decorative only)"]

    FloatingEmoji -->|buildDesktopStyle| PseudoRNG["pseudo() deterministic\nlayout — seed=0"]
    StaticSpan -->|buildMobileStyle| PseudoRNG

    ContentDiv -->|children| Title["h1 title + p subtitle\n(current Hero children)"]
```

</a>
</details>

<sub>Reviews (6): Last reviewed commit: ["fix: in iPhone SE title now dont clips :..."](https://github.com/teenbiscuits/pasame-examenes/commit/7ab02230604b47dee5082f9e27057ac40ed8205f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42757296)</sub>

<!-- /greptile_comment -->