### PR TITLE
feat: new icons and some ui changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
   "dependencies": {
     "@fontsource-variable/cascadia-code": "^5.2.2",
     "@fontsource-variable/onest": "^5.2.11",
+    "@hugeicons/core-free-icons": "^4.2.2",
+    "@hugeicons/react": "^1.1.9",
     "driver.js": "^1.6.0",
     "katex": "^0.16.47",
     "react": "^19.2.6",
@@ -22,6 +24,7 @@
     "react-router-dom": "^7.18.1",
     "react-syntax-highlighter": "^16.1.1",
     "rehype-katex": "^7.0.1",
+    "reicon-react": "^1.1.2",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
     "tailwind-animations": "^1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,12 @@ importers:
       '@fontsource-variable/onest':
         specifier: ^5.2.11
         version: 5.2.11
+      '@hugeicons/core-free-icons':
+        specifier: ^4.2.2
+        version: 4.2.2
+      '@hugeicons/react':
+        specifier: ^1.1.9
+        version: 1.1.9(react@19.2.7)
       driver.js:
         specifier: ^1.6.0
         version: 1.6.0
@@ -38,6 +44,9 @@ importers:
       rehype-katex:
         specifier: ^7.0.1
         version: 7.0.1
+      reicon-react:
+        specifier: ^1.1.2
+        version: 1.1.2(react@19.2.7)
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -406,6 +415,14 @@ packages:
 
   '@fontsource-variable/onest@5.2.11':
     resolution: {integrity: sha512-knJww1KxK4g66+qu90q3CPBvl4zhL5oDRi3/JMkYMmlhW3OgyRgT4MMfgd6jg2lvho7bLPAXfsYPh59h0yzwUA==}
+
+  '@hugeicons/core-free-icons@4.2.2':
+    resolution: {integrity: sha512-fjQW3p6cwoJmwK3oCnV8Z3PC5sHihDvr2jkAHax8cxqp62GaV/D7B/Rnao+JwicW8fmLZUQ6QrzWfoyMFOEQlQ==}
+
+  '@hugeicons/react@1.1.9':
+    resolution: {integrity: sha512-O+lWSWjbijoAvMCxn4K2bQWCGN5+mP1y5j+X99j23mXMj+s0X25fs71T6t9YJLaBodwmZdaewD27dzS/PiboQw==}
+    peerDependencies:
+      react: '>=16.0.0'
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -1902,6 +1919,11 @@ packages:
   rehype-katex@7.0.1:
     resolution: {integrity: sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==}
 
+  reicon-react@1.1.2:
+    resolution: {integrity: sha512-dbp1CPEPKFjWfG41lGRMWi74YKfKJlb2JcB/TRBAUQF6jalZYW1dRZisRPCpze5TfQwRBD30p40qnoY+oYi7MQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
 
@@ -2444,6 +2466,12 @@ snapshots:
   '@fontsource-variable/cascadia-code@5.2.2': {}
 
   '@fontsource-variable/onest@5.2.11': {}
+
+  '@hugeicons/core-free-icons@4.2.2': {}
+
+  '@hugeicons/react@1.1.9(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -3991,6 +4019,10 @@ snapshots:
       katex: 0.16.47
       unist-util-visit-parents: 6.0.2
       vfile: 6.0.3
+
+  reicon-react@1.1.2(react@19.2.7):
+    dependencies:
+      react: 19.2.7
 
   remark-gfm@4.0.1:
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,14 @@ import type { Lang } from "./i18n/context";
 import { track, identify, setSessionData, getDistinctId } from "./lib/umami";
 import { buildLangPath } from "./lib/lang-link-utils";
 import { useTheme } from "./theme/hooks";
+import {
+  CloseSquare2,
+  MemoCheck,
+  ShieldCheck,
+  ArrowRightUp,
+} from "reicon-react";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Github01Icon } from "@hugeicons/core-free-icons";
 
 const Home = lazy(() => import("./pages/Home"));
 const SubjectHome = lazy(() => import("./pages/SubjectHome"));
@@ -141,80 +149,19 @@ function CreativeCommonsIcons() {
 }
 
 function CloseIcon() {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      className="size-5"
-      viewBox="0 0 20 20"
-      fill="currentColor"
-      aria-hidden="true"
-    >
-      <path
-        fillRule="evenodd"
-        d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
-        clipRule="evenodd"
-      />
-    </svg>
-  );
+  return <CloseSquare2 className="size-5" />;
 }
 
 function LicenseIcon() {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className="size-4"
-      aria-hidden="true"
-    >
-      <path d="M6 3h9l3 3v15H6z" />
-      <path d="M14 3v4h4" />
-      <path d="M9 12h6" />
-      <path d="M9 16h4" />
-    </svg>
-  );
+  return <MemoCheck className="size-4" />;
 }
 
 function PrivacyIcon() {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className="size-4"
-      aria-hidden="true"
-    >
-      <path d="M12 3 5 6v5c0 4.5 3 8.5 7 10 4-1.5 7-5.5 7-10V6z" />
-      <path d="M9.5 12.5 11 14l3.5-4" />
-    </svg>
-  );
+  return <ShieldCheck className="size-4" />;
 }
 
 function ExternalLinkIcon() {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className="size-3.5"
-      aria-hidden="true"
-    >
-      <path d="M7 17 17 7" />
-      <path d="M9 7h8v8" />
-    </svg>
-  );
+  return <ArrowRightUp weight="Filled" className="size-3.5" />;
 }
 
 function ModalShell({
@@ -475,7 +422,7 @@ function Footer() {
           </p>
           <nav
             aria-label={t.footer.linksLabel}
-            className="flex flex-wrap items-center gap-x-2 gap-y-1 md:justify-end"
+            className="flex flex-wrap items-center justify-center gap-x-2 gap-y-1 md:justify-end"
           >
             <button
               type="button"
@@ -510,20 +457,7 @@ function Footer() {
               className={footerTextLinkClass}
               onClick={() => track("external_link_click", { target: "github" })}
             >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                className="size-4"
-                aria-hidden="true"
-              >
-                <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4" />
-                <path d="M9 18c-4.51 2-5-2-7-2" />
-              </svg>
+              <HugeiconsIcon icon={Github01Icon} className="size-4" />
               <span>{t.footer.github}</span>
             </a>
           </nav>

--- a/src/components/AddExamModal.tsx
+++ b/src/components/AddExamModal.tsx
@@ -1,6 +1,9 @@
 import { useImperativeHandle, useEffect, useRef, type Ref } from "react";
 import { useT } from "../i18n/hooks";
 import { track } from "../lib/umami";
+import { CloseSquare2 } from "reicon-react";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { DashboardSquareAddIcon } from "@hugeicons/core-free-icons";
 
 export interface AddExamModalHandle {
   open: () => void;
@@ -69,7 +72,14 @@ function AddExamModal({
       <div>
         <div className="mb-5 flex items-center justify-between">
           <h2 id="add-exam-title" className="text-fg text-lg font-semibold">
-            {t.addExam.title}
+            <span className="inline-flex items-center gap-2">
+              <HugeiconsIcon
+                icon={DashboardSquareAddIcon}
+                size={24}
+                strokeWidth={2}
+              />{" "}
+              {t.addExam.title}
+            </span>
           </h2>
           <button
             type="button"
@@ -80,18 +90,7 @@ function AddExamModal({
             className="text-fg-muted hover:text-fg-secondary cursor-pointer transition-colors"
             aria-label={t.addExam.close}
           >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              className="size-5"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-            >
-              <path
-                fillRule="evenodd"
-                d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
-                clipRule="evenodd"
-              />
-            </svg>
+            <CloseSquare2 className="size-5" />
           </button>
         </div>
 

--- a/src/components/AddSubjectModal.tsx
+++ b/src/components/AddSubjectModal.tsx
@@ -1,6 +1,9 @@
 import { useImperativeHandle, useEffect, useRef, type Ref } from "react";
 import { useT } from "../i18n/hooks";
 import { track } from "../lib/umami";
+import { CloseSquare2 } from "reicon-react";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { DashboardSquareAddIcon } from "@hugeicons/core-free-icons";
 
 export interface AddSubjectModalHandle {
   open: () => void;
@@ -59,7 +62,14 @@ function AddSubjectModal({ onClose, ref }: AddSubjectModalProps) {
       <div>
         <div className="mb-5 flex items-center justify-between">
           <h2 id="add-subject-title" className="text-fg text-lg font-semibold">
-            {t.addSubject.title}
+            <span className="inline-flex items-center gap-2">
+              <HugeiconsIcon
+                icon={DashboardSquareAddIcon}
+                size={24}
+                strokeWidth={2}
+              />{" "}
+              {t.addSubject.title}
+            </span>
           </h2>
           <button
             type="button"
@@ -70,18 +80,7 @@ function AddSubjectModal({ onClose, ref }: AddSubjectModalProps) {
             className="text-fg-muted hover:text-fg-secondary cursor-pointer transition-colors"
             aria-label={t.addSubject.close}
           >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              className="size-5"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-            >
-              <path
-                fillRule="evenodd"
-                d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
-                clipRule="evenodd"
-              />
-            </svg>
+            <CloseSquare2 className="size-5" />
           </button>
         </div>
 

--- a/src/components/ContentPolicyIcon.tsx
+++ b/src/components/ContentPolicyIcon.tsx
@@ -1,6 +1,7 @@
 import type { SubjectMeta } from "../data/types";
 import { useT } from "../i18n/hooks";
 import { hasAuthorizedExamContent } from "../lib/content-policy";
+import { Users3, GraduationCap } from "reicon-react";
 
 interface ContentPolicyIconProps {
   subject: SubjectMeta;
@@ -19,28 +20,20 @@ export default function ContentPolicyIcon({
     ? t.contentPolicy.authorized
     : t.contentPolicy.community;
   const icon = isAuthorized ? (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 20 20"
-      fill="currentColor"
+    <GraduationCap
+      size={24}
+      weight="Filled"
       className={svgOnly ? className : "size-4"}
       role="img"
       aria-label={label}
-    >
-      <path d="M10 3.25a1 1 0 00-.447.106l-7 3.5a1 1 0 000 1.788l7 3.5a1 1 0 00.894 0l5.553-2.776V13a1 1 0 102 0V7.75a1 1 0 00-.553-.894l-7-3.5A1 1 0 0010 3.25z" />
-      <path d="M5 10.35v2.15c0 1.933 2.239 3.5 5 3.5s5-1.567 5-3.5v-2.15l-3.658 1.829a3 3 0 01-2.684 0L5 10.35z" />
-    </svg>
+    />
   ) : (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 20 20"
-      fill="currentColor"
+    <Users3
       className={svgOnly ? className : "size-4"}
       role="img"
+      weight="Filled"
       aria-label={label}
-    >
-      <path d="M7 8a3 3 0 100-6 3 3 0 000 6zM13 9a2.5 2.5 0 100-5 2.5 2.5 0 000 5zM7 10c-2.761 0-5 1.79-5 4v1a1 1 0 001 1h8a1 1 0 001-1v-1c0-2.21-2.239-4-5-4zM13.5 11c-.587 0-1.146.104-1.657.293A4.78 4.78 0 0114 15v1h3a1 1 0 001-1v-.5c0-1.933-2.015-3.5-4.5-3.5z" />
-    </svg>
+    />
   );
 
   if (svgOnly) {

--- a/src/components/CopyrightReportModal.tsx
+++ b/src/components/CopyrightReportModal.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useImperativeHandle, useRef, type Ref } from "react";
 import { useT } from "../i18n/hooks";
 import { track } from "../lib/umami";
+import { CloseSquare2 } from "reicon-react";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { LegalHammerIcon } from "@hugeicons/core-free-icons";
 
 const CONTACT_EMAIL = "pablo.portas@udc.es";
 
@@ -81,7 +84,10 @@ function CopyrightReportModal({
             id="copyright-report-title"
             className="text-fg text-lg font-semibold"
           >
-            {t.copyrightReport.title}
+            <span className="inline-flex items-center gap-2">
+              <HugeiconsIcon icon={LegalHammerIcon} size={24} strokeWidth={2} />
+              {t.copyrightReport.title}{" "}
+            </span>
           </h2>
           <button
             type="button"
@@ -92,18 +98,7 @@ function CopyrightReportModal({
             className="text-fg-muted hover:text-fg-secondary cursor-pointer transition-colors"
             aria-label={t.copyrightReport.close}
           >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              className="size-5"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-            >
-              <path
-                fillRule="evenodd"
-                d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
-                clipRule="evenodd"
-              />
-            </svg>
+            <CloseSquare2 className="size-5" />
           </button>
         </div>
 

--- a/src/components/Disclaimer.tsx
+++ b/src/components/Disclaimer.tsx
@@ -1,6 +1,7 @@
 import { useT } from "../i18n/hooks";
 import { track } from "../lib/umami";
 import { triggerLight } from "../lib/haptics";
+import { TriangleWarning } from "reicon-react";
 
 import type { QuestionType } from "../data/types";
 
@@ -54,21 +55,7 @@ export default function Disclaimer({
             });
           }}
         >
-          <svg
-            width="12"
-            height="12"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden="true"
-          >
-            <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
-            <line x1="12" y1="9" x2="12" y2="13" />
-            <line x1="12" y1="17" x2="12.01" y2="17" />
-          </svg>
+          <TriangleWarning size={12} aria-hidden="true" />
           {t.disclaimer.reportLink}
         </a>
         {t.disclaimer.postLinkText}

--- a/src/components/GitHubStarButton.tsx
+++ b/src/components/GitHubStarButton.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { Star } from "reicon-react";
 import { track } from "../lib/umami";
 
 const REPO = "TeenBiscuits/Pasame-Examenes";
@@ -75,16 +76,13 @@ function formatCount(n: number): string {
 
 function StarIcon({ className }: { className?: string }) {
   return (
-    <svg
-      width="16"
-      height="16"
-      viewBox="0 0 16 16"
-      fill="currentColor"
-      className={className}
+    <Star
+      size={16}
+      weight="Filled"
       aria-hidden="true"
-    >
-      <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z" />
-    </svg>
+      className={className}
+      color=""
+    />
   );
 }
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -20,7 +20,7 @@ const langLabel: Record<Lang, string> = {
 const langFlag: Record<Lang, string> = {
   en: "🇬🇧",
   es: "🇪🇸",
-  gl: "🧜🏻‍♀️ GL",
+  gl: "🧜🏻‍♀️",
 };
 
 function acronym(name: string): string {
@@ -67,7 +67,7 @@ export default function Header() {
             className="h-8 w-7"
             aria-hidden="true"
           />
-          {t.home.title}
+          <p className="text-sm sm:text-lg">{t.home.title}</p>
         </Link>
         <div className="flex items-center gap-1 text-sm sm:gap-3">
           {subject && (

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -11,6 +11,7 @@ import {
   triggerError,
   triggerSelection,
 } from "../lib/haptics";
+import { TriangleWarning } from "reicon-react";
 
 function QuestionImage({
   image,
@@ -660,21 +661,7 @@ export default function QuestionCard(props: QuestionCardProps) {
             });
           }}
         >
-          <svg
-            width="12"
-            height="12"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden="true"
-          >
-            <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
-            <line x1="12" y1="9" x2="12" y2="13" />
-            <line x1="12" y1="17" x2="12.01" y2="17" />
-          </svg>
+          <TriangleWarning size={16} aria-hidden="true" />
           {t.questionCard.reportIssue}
         </a>
       </div>

--- a/src/components/StarPopup.tsx
+++ b/src/components/StarPopup.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef } from "react";
 import { useT } from "../i18n/hooks";
 import { track } from "../lib/umami";
+import { StarSparkle } from "reicon-react";
 
 const STORAGE_KEY_DISMISSED = "star_popup_dismissed";
 const STORAGE_KEY_VISITS = "star_popup_visits";
@@ -35,17 +36,7 @@ function writeDismissed() {
 }
 
 function StarIcon() {
-  return (
-    <svg
-      width="20"
-      height="20"
-      viewBox="0 0 16 16"
-      fill="currentColor"
-      aria-hidden="true"
-    >
-      <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z" />
-    </svg>
-  );
+  return <StarSparkle size={20} weight="Filled" aria-hidden="true" />;
 }
 
 export default function StarPopup() {

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -15,7 +15,7 @@ export const en = {
       "Practice {count} questions{repeated} from {exams} exams with model answers and self-grading.",
     communityDescription:
       "Practice {count} questions{repeated} from {exams} compilations with model answers and self-grading.",
-    practiceByTopic: "Practice by Topic",
+    practiceByTopic: "Topics",
     examSimulations: "Exams",
     practiceSimulations: "Compilations",
     originalExams: "Original Exam Documents",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -17,7 +17,7 @@ export const es: Translations = {
       "Practica {count} preguntas{repeated} de {exams} exámenes con respuestas modelo y autocorrección.",
     communityDescription:
       "Practica {count} preguntas{repeated} de {exams} recopilatorios con respuestas modelo y autocorrección.",
-    practiceByTopic: "Practicar por tema",
+    practiceByTopic: "Temas",
     examSimulations: "Exámenes",
     practiceSimulations: "Recopilatorios",
     originalExams: "Documentos originales de examen",

--- a/src/i18n/gl.ts
+++ b/src/i18n/gl.ts
@@ -17,7 +17,7 @@ export const gl: Translations = {
       "Practica {count} preguntas{repeated} de {exams} exames con respostas modelo e autocorrección.",
     communityDescription:
       "Practica {count} preguntas{repeated} de {exams} recompilacións con respostas modelo e autocorrección.",
-    practiceByTopic: "Practicar por tema",
+    practiceByTopic: "Temas",
     examSimulations: "Exames",
     practiceSimulations: "Recompilacións",
     originalExams: "Documentos orixinais de exame",

--- a/src/pages/ExamSimulation.tsx
+++ b/src/pages/ExamSimulation.tsx
@@ -22,6 +22,9 @@ import { useKeyboardNav } from "../hooks/useKeyboardNav";
 import { startExamTour } from "../lib/tour";
 import { hasAuthorizedExamContent } from "../lib/content-policy";
 import { formatPoints, roundPoints } from "../lib/points";
+import { ArrowSquareLeft2, ArrowSquareRight2 } from "reicon-react";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { CheckmarkBadge02Icon } from "@hugeicons/core-free-icons";
 
 function formatTime(seconds: number) {
   const h = Math.floor(seconds / 3600);
@@ -49,6 +52,7 @@ function ExamStartScreen({
   const simulationNote = hasAuthorizedExamContent(subject)
     ? t.exam.simulationNote
     : t.exam.practiceNote;
+  const isAuthorized = hasAuthorizedExamContent(subject);
   return (
     <div className="animate-fade-in animate-duration-fast mx-auto max-w-2xl px-4 py-16">
       <div className="mb-6">
@@ -67,8 +71,21 @@ function ExamStartScreen({
         </Link>
       </div>
       <div className="text-center">
-        <h1 className="text-fg mb-2 text-3xl font-semibold">
+        <h1 className="text-fg mb-2 inline-flex items-center justify-center gap-2 text-3xl font-semibold">
           {examInfo.title}
+          {isAuthorized && (
+            <span
+              className="border-t-amber-border bg-t-amber-bg text-t-amber-hover inline-flex size-6 shrink-0 items-center justify-center rounded border"
+              title={t.contentPolicy.authorized}
+            >
+              <HugeiconsIcon
+                icon={CheckmarkBadge02Icon}
+                className="size-4"
+                role="img"
+                aria-label={t.contentPolicy.authorized}
+              />
+            </span>
+          )}
         </h1>
         <p className="text-fg-muted mb-8">
           {subject.name} ({subject.courseCode})
@@ -162,6 +179,7 @@ function ExamPlayer({
   const currentTopic = subject.topics.find(
     (tp) => tp.key === currentQuestion.topic,
   );
+  const isAuthorized = hasAuthorizedExamContent(subject);
 
   const getScore = () => {
     let score = 0;
@@ -222,9 +240,24 @@ function ExamPlayer({
         className="bg-surface border-border sticky top-14 z-40 -mx-4 mb-6 flex items-center justify-between border-b px-4 py-3"
         data-tour="exam-header"
       >
-        <div>
-          <span className="text-fg text-lg font-bold">{examInfo.title}</span>
-          <span className="text-fg-muted ml-3 text-sm">
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+          <span className="inline-flex items-center gap-2">
+            <span className="text-fg text-lg font-bold">{examInfo.title}</span>
+            {isAuthorized && (
+              <span
+                className="border-t-amber-border bg-t-amber-bg text-t-amber-hover inline-flex size-5 shrink-0 items-center justify-center rounded border"
+                title={t.contentPolicy.authorized}
+              >
+                <HugeiconsIcon
+                  icon={CheckmarkBadge02Icon}
+                  className="size-3.5"
+                  role="img"
+                  aria-label={t.contentPolicy.authorized}
+                />
+              </span>
+            )}
+          </span>
+          <span className="text-fg-muted text-sm">
             {formatPoints(totalPoints)}p {t.exam.total}
           </span>
         </div>
@@ -323,23 +356,7 @@ function ExamPlayer({
           disabled={currentIndex === 0}
         >
           <span className="flex items-center gap-1.5">
-            <svg
-              viewBox="0 0 24 24"
-              width="18"
-              height="18"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.5"
-              aria-hidden="true"
-            >
-              <rect x="2.5" y="2.5" width="19" height="19" rx="5" />
-              <path
-                d="M14 8l-4 4 4 4"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
+            <ArrowSquareLeft2 size={18} aria-hidden="true" />
             {t.exam.previous}
           </span>
         </button>
@@ -379,23 +396,7 @@ function ExamPlayer({
         >
           <span className="flex items-center gap-1.5">
             {t.exam.next}
-            <svg
-              viewBox="0 0 24 24"
-              width="18"
-              height="18"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.5"
-              aria-hidden="true"
-            >
-              <rect x="2.5" y="2.5" width="19" height="19" rx="5" />
-              <path
-                d="M10 8l4 4-4 4"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
+            <ArrowSquareRight2 size={18} aria-hidden="true" />
           </span>
         </button>
       </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -16,28 +16,14 @@ import {
   recordSubjectClick,
   clearRecentSubjects,
 } from "../lib/recent";
+import { Trash5 } from "reicon-react";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { DashboardSquareAddIcon } from "@hugeicons/core-free-icons";
 
 const MAX_SLOTS = 3;
 
 function TrashIcon() {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={1.5}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className="size-4"
-    >
-      <path d="M3 6h18" />
-      <path d="M8 6V4a2 2 0 012-2h4a2 2 0 012 2v2" />
-      <path d="M10 11v6" />
-      <path d="M14 11v6" />
-      <path d="M5 6l1 14a2 2 0 002 2h8a2 2 0 002-2l1-14" />
-    </svg>
-  );
+  return <Trash5 className="size-4" weight="Filled" />;
 }
 
 function PlaceholderCard() {
@@ -185,7 +171,9 @@ export default function Home() {
               className="border-border text-fg-muted hover:text-accent hover:border-accent hover:bg-accent-light/30 block w-full cursor-pointer rounded-xl border-2 border-dashed p-5 transition-colors transition-transform duration-200 hover:scale-[1.02]"
             >
               <div className="flex h-full min-h-[120px] flex-col items-center justify-center gap-2">
-                <span className="text-4xl leading-none font-light">+</span>
+                <span className="text-4xl leading-none font-light">
+                  <HugeiconsIcon icon={DashboardSquareAddIcon} size={35} />
+                </span>
                 <span className="text-sm font-medium">{t.home.addSubject}</span>
               </div>
             </button>

--- a/src/pages/PracticeTopic.tsx
+++ b/src/pages/PracticeTopic.tsx
@@ -21,6 +21,7 @@ import { usePracticeSession } from "../hooks/usePracticeSession";
 import { useKeyboardNav } from "../hooks/useKeyboardNav";
 import { startPracticeTour } from "../lib/tour";
 import { formatPoints, roundPoints } from "../lib/points";
+import { ArrowSquareLeft2, ArrowSquareRight2 } from "reicon-react";
 
 interface PracticePlayerProps {
   subject: NonNullable<ReturnType<typeof getSubject>>;
@@ -217,23 +218,7 @@ function PracticePlayer({
           disabled={currentIndex === 0}
         >
           <span className="flex items-center gap-1.5">
-            <svg
-              viewBox="0 0 24 24"
-              width="18"
-              height="18"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.5"
-              aria-hidden="true"
-            >
-              <rect x="2.5" y="2.5" width="19" height="19" rx="5" />
-              <path
-                d="M14 8l-4 4 4 4"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
+            <ArrowSquareLeft2 size={18} aria-hidden="true" />
             {t.practice.previous}
           </span>
         </button>
@@ -301,23 +286,7 @@ function PracticePlayer({
         >
           <span className="flex items-center gap-1.5">
             {t.practice.next}
-            <svg
-              viewBox="0 0 24 24"
-              width="18"
-              height="18"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.5"
-              aria-hidden="true"
-            >
-              <rect x="2.5" y="2.5" width="19" height="19" rx="5" />
-              <path
-                d="M10 8l4 4-4 4"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
+            <ArrowSquareRight2 size={18} aria-hidden="true" />
           </span>
         </button>
       </div>

--- a/src/pages/SubjectHome.tsx
+++ b/src/pages/SubjectHome.tsx
@@ -20,6 +20,14 @@ import { useDocumentTitle } from "../lib/title";
 import { useSeoHead } from "../lib/seo";
 import { buildSubjectMeta } from "../seo/meta";
 import { hasAuthorizedExamContent } from "../lib/content-policy";
+import { ArrowRightUp } from "reicon-react";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  CheckmarkBadge02Icon,
+  LegalHammerIcon,
+  Legal01Icon,
+  DashboardSquareAddIcon,
+} from "@hugeicons/core-free-icons";
 
 export default function SubjectHome() {
   const { subjectId } = useParams<{ subjectId: string }>();
@@ -315,7 +323,7 @@ function RemovedExamCard({ title }: { title: string }) {
   return (
     <div className="border-t-red-border bg-t-red-bg/70 block rounded-xl border-2 border-dashed p-6">
       <div className="text-t-red-hover mb-2 text-2xl" aria-hidden="true">
-        !
+        <HugeiconsIcon icon={Legal01Icon} />
       </div>
       <h2 className="text-fg font-semibold">{title}</h2>
       <p className="text-fg-secondary mt-2 text-sm font-medium">
@@ -332,6 +340,9 @@ function ExamCard({
   subject: SubjectMeta;
   exam: SubjectMeta["exams"][number];
 }) {
+  const t = useT();
+  const isAuthorized = hasAuthorizedExamContent(subject);
+
   return (
     <Link
       to={`/${subject.id}/exam/${exam.year}`}
@@ -344,8 +355,23 @@ function ExamCard({
         });
       }}
     >
-      <div className="mb-2 text-2xl" aria-hidden="true">
-        📝
+      <div className="mb-2 flex items-start justify-between">
+        <div className="text-2xl" aria-hidden="true">
+          📝
+        </div>
+        {isAuthorized && (
+          <span
+            className="border-t-amber-border bg-t-amber-bg text-t-amber-hover inline-flex size-6 shrink-0 items-center justify-center rounded border"
+            title={t.contentPolicy.authorized}
+          >
+            <HugeiconsIcon
+              icon={CheckmarkBadge02Icon}
+              className="size-4"
+              role="img"
+              aria-label={t.contentPolicy.authorized}
+            />
+          </span>
+        )}
       </div>
       <h2 className="text-fg font-semibold">{exam.title}</h2>
       <p className="text-fg-muted mt-1 text-sm">{exam.description}</p>
@@ -376,7 +402,9 @@ function ExamActionButtons({
         className="border-border text-fg-muted hover:text-accent hover:border-accent hover:bg-accent-light/30 block w-full rounded-xl border-2 border-dashed p-4 transition-colors transition-transform duration-200 hover:scale-[1.02] hover:shadow-md"
       >
         <div className="flex h-full min-h-28 flex-col items-center justify-center gap-2">
-          <span className="text-4xl leading-none font-light">+</span>
+          <span className="text-4xl leading-none font-light">
+            <HugeiconsIcon icon={DashboardSquareAddIcon} size={35} />
+          </span>
           <span className="text-sm font-medium">{t.subjectHome.addExam}</span>
         </div>
       </button>
@@ -391,7 +419,7 @@ function ExamActionButtons({
       >
         <div className="flex h-full min-h-28 flex-col items-center justify-center gap-2">
           <span className="text-t-red-hover text-4xl leading-none font-light">
-            !
+            <HugeiconsIcon icon={LegalHammerIcon} size={35} />
           </span>
           <span className="text-sm font-medium">
             {t.subjectHome.reportCopyright}
@@ -445,7 +473,8 @@ function PdfLinksSection({
             });
           }}
         >
-          <span aria-hidden="true">📄</span> {exam.title} {t.subjectHome.pdf}
+          <span aria-hidden="true">📄</span> {exam.title} {t.subjectHome.pdf}{" "}
+          <ArrowRightUp weight="Filled" className="size-3.5" />
         </a>
       ))}
     </ResourceLinksShell>
@@ -494,7 +523,8 @@ function DaypoLinksSection({
             });
           }}
         >
-          <span aria-hidden="true">🌐</span> {exam.title} {t.subjectHome.daypo}
+          <span aria-hidden="true">🌐</span> {exam.title} {t.subjectHome.daypo}{" "}
+          <ArrowRightUp weight="Filled" className="size-3.5" />
         </a>
       ))}
     </ResourceLinksShell>

--- a/src/theme/ThemeToggle.tsx
+++ b/src/theme/ThemeToggle.tsx
@@ -2,98 +2,61 @@ import { useTheme } from "./hooks";
 import { themeLabels, themeOrder } from "./types";
 import type { Theme } from "./types";
 import { track } from "../lib/umami";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  Sun03Icon,
+  CrownIcon,
+  Coffee03Icon,
+  Moon02Icon,
+  ComputerIcon,
+} from "@hugeicons/core-free-icons";
 
 function ThemeIcon({ theme }: { theme: Theme }) {
   switch (theme) {
     case "system":
       return (
-        <svg
-          width="18"
-          height="18"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <rect x="2" y="3" width="20" height="14" rx="2" ry="2" />
-          <line x1="8" y1="21" x2="16" y2="21" />
-          <line x1="12" y1="17" x2="12" y2="21" />
-        </svg>
+        <HugeiconsIcon
+          icon={ComputerIcon}
+          size={16}
+          color="currentColor"
+          strokeWidth={2}
+        />
       );
     case "light":
       return (
-        <svg
-          width="18"
-          height="18"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <circle cx="12" cy="12" r="4" />
-          <path d="M12 2v2" />
-          <path d="M12 20v2" />
-          <path d="m4.93 4.93 1.41 1.41" />
-          <path d="m17.66 17.66 1.41 1.41" />
-          <path d="M2 12h2" />
-          <path d="M20 12h2" />
-          <path d="m6.34 17.66-1.41 1.41" />
-          <path d="m19.07 4.93-1.41 1.41" />
-        </svg>
+        <HugeiconsIcon
+          icon={Sun03Icon}
+          size={16}
+          color="currentColor"
+          strokeWidth={2}
+        />
       );
     case "dark":
       return (
-        <svg
-          width="18"
-          height="18"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
-        </svg>
+        <HugeiconsIcon
+          icon={Moon02Icon}
+          size={16}
+          color="currentColor"
+          strokeWidth={2}
+        />
       );
     case "pink":
       return (
-        <svg
-          width="18"
-          height="18"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <path d="M2 4l3 12h14l3-12-6 7-4-7-4 7-6-7z" />
-          <path d="M2 17h20" />
-        </svg>
+        <HugeiconsIcon
+          icon={CrownIcon}
+          size={16}
+          color="currentColor"
+          strokeWidth={2}
+        />
       );
     case "catppuccin":
       return (
-        <svg
-          width="18"
-          height="18"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <path d="M17 8h1a4 4 0 1 1 0 8h-1" />
-          <path d="M3 8h14v9a4 4 0 0 1-4 4H7a4 4 0 0 1-4-4Z" />
-          <line x1="6" y1="2" x2="6" y2="4" />
-          <line x1="10" y1="2" x2="10" y2="4" />
-          <line x1="14" y1="2" x2="14" y2="4" />
-        </svg>
+        <HugeiconsIcon
+          icon={Coffee03Icon}
+          size={16}
+          color="currentColor"
+          strokeWidth={2}
+        />
       );
   }
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces all hand-rolled inline SVGs across the codebase with components from two new icon libraries (`reicon-react` and `@hugeicons/react`), and makes several small UI improvements alongside the icon swap.

- **Icon migration** — every inline SVG helper (close buttons, nav icons, theme toggles, prev/next arrows, content-policy indicators, etc.) is replaced with library components; the two libraries use different APIs (`<Icon />` with props vs `<HugeiconsIcon icon={…} />`).
- **UI additions** — an authorization badge (`CheckmarkBadge02Icon`) is surfaced on exam cards, the exam start screen, and the exam player header; the "Practice by Topic" label is shortened to "Topics" across all three locales; the Galician flag entry drops the redundant ` GL` text; `!` placeholders in removed/report-copyright card slots are replaced with proper icons.
- **Layout tweak** — the footer nav gains `justify-center` for small screens, and the header title gets responsive text sizing via a new wrapper element.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; all changes are visual/cosmetic and no data or routing logic is touched.

The refactor is straightforward and low-risk. A few footer icons that previously had aria-hidden lost that attribute during the migration, and color='' on the Star component is an unusual pattern worth confirming. Neither issue affects functionality.

src/App.tsx (footer icon accessibility) and src/components/GitHubStarButton.tsx (color='' prop).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/App.tsx | Replaces inline SVG icon helpers with reicon-react/@hugeicons/react components; footer nav icons lose their aria-hidden='true' attribute in the process, which is a minor accessibility regression. |
| src/components/GitHubStarButton.tsx | Swaps the inline star SVG for <Star> from reicon-react; passes color='' which is an unusual prop value that may not correctly inherit currentColor across all reicon-react versions. |
| src/components/Header.tsx | Removes the ' GL' suffix from the Galician flag emoji and wraps the site title in a <p> element (should be <span>) for responsive typography. |
| src/components/ContentPolicyIcon.tsx | Replaces inline SVGs with GraduationCap and Users3 from reicon-react; passes role='img' and aria-label for accessible icon semantics, matching the original approach. |
| src/pages/SubjectHome.tsx | Adds an authorization badge to exam cards, replaces '!' placeholder with LegalHammerIcon, and adds ArrowRightUp indicators to PDF/Daypo external links. |
| src/pages/ExamSimulation.tsx | Replaces prev/next navigation SVGs with ArrowSquareLeft2/ArrowSquareRight2 and adds an authorization badge (CheckmarkBadge02Icon) to the exam title and header, with correct aria-label on the badge. |
| src/theme/ThemeToggle.tsx | Replaces all five theme-mode SVG icons with HugeiconsIcon wrappers; uses color='currentColor' and strokeWidth={2} consistently across all cases. |
| package.json | Adds three new runtime dependencies: @hugeicons/core-free-icons, @hugeicons/react, and reicon-react to support the icon refactor. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Icon Usage Site] --> B{Library}
    B -->|reicon-react| C[IconName with size/weight/className]
    B -->|hugeicons-react| D[HugeiconsIcon with icon const]
    C --> E[Renders SVG]
    D --> E
    E --> F{Purpose}
    F -->|Decorative next to text label| G[needs aria-hidden true]
    F -->|Semantic badge or indicator| H[needs role img and aria-label]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Icon Usage Site] --> B{Library}
    B -->|reicon-react| C[IconName with size/weight/className]
    B -->|hugeicons-react| D[HugeiconsIcon with icon const]
    C --> E[Renders SVG]
    D --> E
    E --> F{Purpose}
    F -->|Decorative next to text label| G[needs aria-hidden true]
    F -->|Semantic badge or indicator| H[needs role img and aria-label]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: new icons and some ui changes"](https://github.com/teenbiscuits/pasame-examenes/commit/606b3a739c2abafdbe9c036797ecc653dad6250b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43039802)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->