### PR TITLE
feat: filter topic questions by exam source

### DIFF
--- a/src/components/ExamSourceSelector.tsx
+++ b/src/components/ExamSourceSelector.tsx
@@ -1,0 +1,140 @@
+import { useEffect, type RefObject } from "react";
+import type { Exam, SubjectMeta } from "../data/types";
+import { useT } from "../i18n/hooks";
+import { ChecklistAlt, CloseSquare2, Filter } from "reicon-react";
+
+interface ExamSourceSelectorProps {
+  subject: SubjectMeta;
+  selectedExamYears: string[];
+  onChange: (years: string[]) => void;
+  dialogRef: RefObject<HTMLDialogElement | null>;
+}
+
+export default function ExamSourceSelector({
+  subject,
+  selectedExamYears,
+  onChange,
+  dialogRef,
+}: ExamSourceSelectorProps) {
+  const t = useT();
+  const exams = subject.exams.filter((exam) => !exam.deleteRights);
+  const selected = new Set(selectedExamYears);
+  const allSelected = selected.size === exams.length;
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    const handleBackdropClick = (event: MouseEvent) => {
+      if (event.target !== dialog) return;
+
+      const rect = dialog.getBoundingClientRect();
+      const insideDialog =
+        event.clientX >= rect.left &&
+        event.clientX <= rect.right &&
+        event.clientY >= rect.top &&
+        event.clientY <= rect.bottom;
+      if (!insideDialog) dialog.close();
+    };
+
+    dialog.addEventListener("click", handleBackdropClick);
+    return () => dialog.removeEventListener("click", handleBackdropClick);
+  }, [dialogRef]);
+
+  function toggleExam(exam: Exam) {
+    const next = new Set(selected);
+    if (next.has(exam.year)) {
+      next.delete(exam.year);
+    } else {
+      next.add(exam.year);
+    }
+    onChange([...next]);
+  }
+
+  return (
+    <dialog
+      ref={dialogRef}
+      closedby="any"
+      className="animate-dialog bg-surface-alt m-auto max-h-[86svh] w-[min(92vw,42rem)] overflow-hidden rounded-2xl p-6 shadow-2xl backdrop:bg-black/50 backdrop:transition-[background-color,overlay,display] backdrop:duration-200"
+      aria-labelledby="question-sources-title"
+    >
+      <div className="border-border mb-5 flex items-center justify-between gap-4 border-b pb-4">
+        <h2
+          id="question-sources-title"
+          className="text-fg inline-flex items-center gap-2 text-lg font-semibold"
+        >
+          <Filter
+            className="size-5 shrink-0"
+            weight={allSelected ? "Outline" : "Filled"}
+            aria-hidden="true"
+          />
+          {t.subjectHome.questionSources}
+        </h2>
+        <button
+          type="button"
+          data-cuelume-press
+          onClick={() => dialogRef.current?.close()}
+          className="text-fg-muted hover:text-fg-secondary focus-visible:ring-accent shrink-0 cursor-pointer rounded transition-colors focus-visible:ring-2 focus-visible:outline-none"
+          aria-label={t.footer.close}
+        >
+          <CloseSquare2 className="size-5" />
+        </button>
+      </div>
+      <div className="max-h-[calc(86svh-7rem)] overflow-y-auto pr-1">
+        <p className="text-fg-secondary mb-4 text-sm">
+          {t.subjectHome.questionSourcesDescription}
+        </p>
+        <fieldset aria-labelledby="question-sources-selection-label">
+          <div className="mb-3 flex min-w-0 items-center justify-between gap-2 sm:gap-3">
+            <span
+              id="question-sources-selection-label"
+              className="text-fg-muted min-w-0 text-[0.625rem] leading-4 font-medium whitespace-nowrap sm:text-xs"
+            >
+              {t.subjectHome.selectedSources
+                .replace("{selected}", String(selected.size))
+                .replace("{total}", String(exams.length))}
+            </span>
+            <button
+              type="button"
+              data-cuelume-press
+              className="text-accent hover:text-accent-hover focus-visible:ring-accent inline-flex shrink-0 items-center gap-1 rounded-md px-1 py-1 text-[0.625rem] leading-4 font-medium whitespace-nowrap underline-offset-2 hover:underline focus-visible:ring-2 focus-visible:outline-none disabled:opacity-40 sm:gap-1.5 sm:px-2 sm:text-sm"
+              onClick={() => onChange(exams.map((exam) => exam.year))}
+              disabled={allSelected}
+            >
+              <ChecklistAlt
+                className="size-3.5 shrink-0 sm:size-4"
+                aria-hidden="true"
+              />
+              {t.subjectHome.selectAllSources}
+            </button>
+          </div>
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+            {exams.map((exam) => (
+              <label
+                key={exam.year}
+                className="border-border hover:bg-surface-alt has-[:focus-visible]:ring-accent flex cursor-pointer items-start gap-3 rounded-lg border p-3 transition-colors has-[:focus-visible]:ring-2"
+              >
+                <input
+                  type="checkbox"
+                  className="accent-accent mt-0.5 size-4 shrink-0"
+                  data-cuelume-toggle
+                  checked={selected.has(exam.year)}
+                  onChange={() => toggleExam(exam)}
+                  disabled={selected.size === 1 && selected.has(exam.year)}
+                />
+                <span className="min-w-0">
+                  <span className="text-fg block text-sm font-medium">
+                    {exam.title}
+                  </span>
+                  <span className="text-fg-muted mt-0.5 block text-xs">
+                    {exam.description}
+                  </span>
+                </span>
+              </label>
+            ))}
+          </div>
+        </fieldset>
+      </div>
+    </dialog>
+  );
+}

--- a/src/hooks/useExamSelection.ts
+++ b/src/hooks/useExamSelection.ts
@@ -4,9 +4,11 @@ import type { Question, SubjectMeta } from "../data/types";
 const STORAGE_PREFIX = "exam-sources:v1:";
 
 function getAvailableExamYears(subject: SubjectMeta): string[] {
-  return subject.exams
-    .filter((exam) => !exam.deleteRights)
-    .map((exam) => exam.year);
+  const years: string[] = [];
+  for (const exam of subject.exams) {
+    if (!exam.deleteRights) years.push(exam.year);
+  }
+  return years;
 }
 
 function readSelectedExamYears(

--- a/src/hooks/useExamSelection.ts
+++ b/src/hooks/useExamSelection.ts
@@ -1,0 +1,114 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { Question, SubjectMeta } from "../data/types";
+
+const STORAGE_PREFIX = "exam-sources:v1:";
+
+function getAvailableExamYears(subject: SubjectMeta): string[] {
+  return subject.exams
+    .filter((exam) => !exam.deleteRights)
+    .map((exam) => exam.year);
+}
+
+function readSelectedExamYears(
+  subjectId: string,
+  availableExamYears: string[],
+): string[] {
+  try {
+    const stored = localStorage.getItem(`${STORAGE_PREFIX}${subjectId}`);
+    if (!stored) return availableExamYears;
+
+    const parsed: unknown = JSON.parse(stored);
+    if (!Array.isArray(parsed)) return availableExamYears;
+
+    const storedYears = new Set(
+      parsed.filter((year): year is string => typeof year === "string"),
+    );
+    const selected = availableExamYears.filter((year) => storedYears.has(year));
+    return selected.length > 0 ? selected : availableExamYears;
+  } catch {
+    return availableExamYears;
+  }
+}
+
+export function filterQuestionsByExamSelection(
+  questions: Question[],
+  selectedExamYears: string[],
+): Question[] {
+  const selected = new Set(selectedExamYears);
+  return questions.filter(
+    (question) => question.exam === "both" || selected.has(question.exam),
+  );
+}
+
+export function useExamSelection(subject: SubjectMeta | undefined) {
+  const subjectId = subject?.id;
+  const availableExamYears = useMemo(
+    () => (subject ? getAvailableExamYears(subject) : []),
+    [subject],
+  );
+  const availableExamYearsKey = availableExamYears.join(",");
+  const storageKey = subjectId ? `${STORAGE_PREFIX}${subjectId}` : null;
+  const selectionKey = subjectId
+    ? `${subjectId}:${availableExamYearsKey}`
+    : null;
+  const [selectionState, setSelectionState] = useState<{
+    key: string | null;
+    years: string[];
+  }>(() => ({
+    key: selectionKey,
+    years: subject ? readSelectedExamYears(subject.id, availableExamYears) : [],
+  }));
+  const selectedExamYears = useMemo(
+    () =>
+      selectionState.key === selectionKey
+        ? selectionState.years
+        : subject
+          ? readSelectedExamYears(subject.id, availableExamYears)
+          : [],
+    [
+      availableExamYears,
+      selectionKey,
+      selectionState.key,
+      selectionState.years,
+      subject,
+    ],
+  );
+
+  useEffect(() => {
+    if (!storageKey) return;
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key !== storageKey || !subject) return;
+      setSelectionState({
+        key: selectionKey,
+        years: readSelectedExamYears(subject.id, availableExamYears),
+      });
+    };
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
+  }, [storageKey, subject, availableExamYears, selectionKey]);
+
+  const updateSelectedExamYears = useCallback(
+    (years: string[]) => {
+      if (!subjectId) return;
+
+      const requested = new Set(years);
+      const next = availableExamYears.filter((year) => requested.has(year));
+      if (next.length === 0) return;
+
+      setSelectionState({ key: selectionKey, years: next });
+      try {
+        localStorage.setItem(storageKey!, JSON.stringify(next));
+      } catch {
+        /* localStorage unavailable */
+      }
+    },
+    [availableExamYears, selectionKey, subjectId, storageKey],
+  );
+
+  return {
+    availableExamYears,
+    selectedExamYears,
+    setSelectedExamYears: updateSelectedExamYears,
+  };
+}

--- a/src/hooks/usePracticeSession.ts
+++ b/src/hooks/usePracticeSession.ts
@@ -94,8 +94,12 @@ export function usePracticeSession(
   const attemptIdRef = useRef("");
 
   const setCurrentIndex = useCallback(
-    (index: number) => dispatch({ type: "SET_CURRENT_INDEX", index }),
-    [],
+    (index: number) =>
+      dispatch({
+        type: "SET_CURRENT_INDEX",
+        index: Math.max(0, Math.min(index, Math.max(0, questions.length - 1))),
+      }),
+    [questions.length],
   );
 
   const handleAnswer = useCallback((questionId: string, answer: string) => {
@@ -184,8 +188,15 @@ export function usePracticeSession(
     [subjectId, topic, questions, state.answers],
   );
 
+  // A source change in another tab can shrink the list while the session is open.
+  const currentIndex = Math.max(
+    0,
+    Math.min(state.currentIndex, Math.max(0, questions.length - 1)),
+  );
+
   return {
     ...state,
+    currentIndex,
     setCurrentIndex,
     handleAnswer,
     handleSubmit,

--- a/src/hooks/usePracticeSession.ts
+++ b/src/hooks/usePracticeSession.ts
@@ -1,4 +1,4 @@
-import { useReducer, useCallback, useRef } from "react";
+import { useReducer, useCallback, useEffect, useRef } from "react";
 import type { Question } from "../data/types";
 import { saveAttempt } from "../data/store";
 import { track } from "../lib/umami";
@@ -17,6 +17,7 @@ interface PracticeState {
 
 type PracticeAction =
   | { type: "SET_CURRENT_INDEX"; index: number }
+  | { type: "SYNC_CURRENT_INDEX"; maxIndex: number }
   | { type: "ANSWER"; questionId: string; answer: string }
   | { type: "SELF_GRADE"; questionId: string; grade: "correct" | "incorrect" }
   | { type: "SUBMIT" }
@@ -26,6 +27,12 @@ function reducer(state: PracticeState, action: PracticeAction): PracticeState {
   switch (action.type) {
     case "SET_CURRENT_INDEX":
       return { ...state, currentIndex: action.index };
+    case "SYNC_CURRENT_INDEX": {
+      const currentIndex = Math.min(state.currentIndex, action.maxIndex);
+      return currentIndex === state.currentIndex
+        ? state
+        : { ...state, currentIndex };
+    }
     case "ANSWER":
       return {
         ...state,
@@ -92,6 +99,13 @@ export function usePracticeSession(
   });
 
   const attemptIdRef = useRef("");
+
+  useEffect(() => {
+    dispatch({
+      type: "SYNC_CURRENT_INDEX",
+      maxIndex: Math.max(0, questions.length - 1),
+    });
+  }, [questions.length]);
 
   const setCurrentIndex = useCallback(
     (index: number) =>

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -15,6 +15,11 @@ export const en = {
       "Practice {count} questions{repeated} from {exams} exams with model answers and self-grading.",
     communityDescription:
       "Practice {count} questions{repeated} from {exams} compilations with model answers and self-grading.",
+    questionSources: "Question sources",
+    questionSourcesDescription:
+      "Choose which exams or compilations provide questions for your topics. You can change this at any time.",
+    selectedSources: "{selected} of {total} sources selected",
+    selectAllSources: "Select all",
     practiceByTopic: "Topics",
     resetTopicProgress: "Reset topic progress",
     resetTopicProgressConfirm:
@@ -88,7 +93,7 @@ export const en = {
         ],
         items: [
           "Technical data: IP address, browser, device, requested URL, referrer, language, date and time, and similar server or CDN logs.",
-          "Local preferences: selected language, selected theme, viewed tours, GitHub star popup state, and recently visited subjects.",
+          "Local preferences: selected language, selected theme, selected question sources, viewed tours, GitHub star popup state, and recently visited subjects.",
           "Study progress stored locally: attempts, scores, topics, and subject progress saved in your browser.",
           "Analytics data: page views, interaction events, performance data, approximate device/browser information, and an anonymous local identifier for Umami.",
           "Session replays and heatmaps in the self-hosted Umami instance, enabled with a random 30% sample rate.",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -17,6 +17,11 @@ export const es: Translations = {
       "Practica {count} preguntas{repeated} de {exams} exámenes con respuestas modelo y autocorrección.",
     communityDescription:
       "Practica {count} preguntas{repeated} de {exams} recopilatorios con respuestas modelo y autocorrección.",
+    questionSources: "Fuentes de las preguntas",
+    questionSourcesDescription:
+      "Elige de qué exámenes o recopilatorios salen las preguntas de tus temas. Puedes cambiarlo cuando quieras.",
+    selectedSources: "{selected} de {total} fuentes seleccionadas",
+    selectAllSources: "Seleccionar todas",
     practiceByTopic: "Temas",
     resetTopicProgress: "Restablecer progreso de los temas",
     resetTopicProgressConfirm:
@@ -90,7 +95,7 @@ export const es: Translations = {
         ],
         items: [
           "Datos técnicos: dirección IP, navegador, dispositivo, URL solicitada, referrer, idioma, fecha y hora, y registros similares de servidor o CDN.",
-          "Preferencias locales: idioma seleccionado, tema seleccionado, tours vistos, estado del popup de GitHub y asignaturas visitadas recientemente.",
+          "Preferencias locales: idioma seleccionado, tema seleccionado, fuentes de preguntas seleccionadas, tours vistos, estado del popup de GitHub y asignaturas visitadas recientemente.",
           "Progreso de estudio almacenado localmente: intentos, puntuaciones, temas y progreso por asignatura guardados en tu navegador.",
           "Datos de analítica: páginas vistas, eventos de interacción, rendimiento, información aproximada de dispositivo/navegador y un identificador anónimo local para Umami.",
           "Replays de sesión y heatmaps en la instancia self-hosted de Umami, activados con un muestreo aleatorio del 30%.",

--- a/src/i18n/gl.ts
+++ b/src/i18n/gl.ts
@@ -17,6 +17,11 @@ export const gl: Translations = {
       "Practica {count} preguntas{repeated} de {exams} exames con respostas modelo e autocorrección.",
     communityDescription:
       "Practica {count} preguntas{repeated} de {exams} recompilacións con respostas modelo e autocorrección.",
+    questionSources: "Fontes das preguntas",
+    questionSourcesDescription:
+      "Elixe de que exames ou recompilacións saen as preguntas dos teus temas. Podes cambialo cando queiras.",
+    selectedSources: "{selected} de {total} fontes seleccionadas",
+    selectAllSources: "Seleccionar todas",
     practiceByTopic: "Temas",
     resetTopicProgress: "Restablecer o progreso dos temas",
     resetTopicProgressConfirm:
@@ -90,7 +95,7 @@ export const gl: Translations = {
         ],
         items: [
           "Datos técnicos: enderezo IP, navegador, dispositivo, URL solicitada, referrer, idioma, data e hora, e rexistros similares de servidor ou CDN.",
-          "Preferencias locais: idioma seleccionado, tema seleccionado, tours vistos, estado do popup de GitHub e materias visitadas recentemente.",
+          "Preferencias locais: idioma seleccionado, tema seleccionado, fontes de preguntas seleccionadas, tours vistos, estado do popup de GitHub e materias visitadas recentemente.",
           "Progreso de estudo almacenado localmente: intentos, puntuacións, temas e progreso por materia gardados no teu navegador.",
           "Datos de analítica: páxinas vistas, eventos de interacción, rendemento, información aproximada de dispositivo/navegador e un identificador anónimo local para Umami.",
           "Replays de sesión e heatmaps na instancia self-hosted de Umami, activados cunha mostraxe aleatoria do 30%.",

--- a/src/pages/PracticeTopic.tsx
+++ b/src/pages/PracticeTopic.tsx
@@ -18,6 +18,10 @@ import { useDocumentTitle } from "../lib/title";
 import { useSeoHead } from "../lib/seo";
 import { buildTopicMeta } from "../seo/meta";
 import { usePracticeSession } from "../hooks/usePracticeSession";
+import {
+  filterQuestionsByExamSelection,
+  useExamSelection,
+} from "../hooks/useExamSelection";
 import { useKeyboardNav } from "../hooks/useKeyboardNav";
 import { startPracticeTour } from "../lib/tour";
 import { formatPoints, roundPoints } from "../lib/points";
@@ -506,7 +510,9 @@ function PracticePlayer({
     window.scrollTo({
       top: Math.max(
         0,
-        anchor.getBoundingClientRect().top + window.scrollY - desktopHeaderOffset,
+        anchor.getBoundingClientRect().top +
+          window.scrollY -
+          desktopHeaderOffset,
       ),
     });
   }, []);
@@ -723,7 +729,8 @@ export default function PracticeTopic() {
   const langTo = useLangTo();
 
   const subject = subjectId ? getSubject(subjectId) : undefined;
-  const [questions, setQuestions] = useState<Question[]>([]);
+  const { selectedExamYears } = useExamSelection(subject);
+  const [allTopicQuestions, setAllTopicQuestions] = useState<Question[]>([]);
   const [questionsLoadedFor, setQuestionsLoadedFor] = useState<string | null>(
     null,
   );
@@ -732,10 +739,14 @@ export default function PracticeTopic() {
     () => subject?.topics.find((tp) => tp.key === topic),
     [subject, topic],
   );
+  const questions = useMemo(
+    () => filterQuestionsByExamSelection(allTopicQuestions, selectedExamYears),
+    [allTopicQuestions, selectedExamYears],
+  );
   useEffect(() => {
     if (subject && topic) {
       getQuestionsByTopic(subject.id, topic).then((topicQuestions) => {
-        setQuestions(topicQuestions);
+        setAllTopicQuestions(topicQuestions);
         setQuestionsLoadedFor(`${subject.id}/${topic}`);
       });
       getTopicMegaTopicLabel(subject.id, topic).then(setMegatopicLabel);

--- a/src/pages/SubjectHome.tsx
+++ b/src/pages/SubjectHome.tsx
@@ -328,8 +328,11 @@ function TopicsSection({
   onResetProgress: () => void;
 }) {
   const t = useT();
+  const topicKeysWithQuestions = new Set(
+    questions.map((question) => question.topic),
+  );
   const topicsWithQuestions = subject.topics.filter((topic) =>
-    questions.some((question) => question.topic === topic.key),
+    topicKeysWithQuestions.has(topic.key),
   );
   const renderTopicCard = (topic: Topic) => {
     const topicQuestions = questions.filter((q) => q.topic === topic.key);
@@ -387,9 +390,12 @@ function TopicsSection({
       {subject.megatopics ? (
         <>
           {subject.megatopics.map((megatopic) => {
-            const megatopicTopics = subject.topics
-              .filter((topic) => megatopic.topics.includes(topic.key))
-              .filter((topic) => topicsWithQuestions.includes(topic));
+            const megatopicKeys = new Set(megatopic.topics);
+            const megatopicTopics = subject.topics.filter(
+              (topic) =>
+                megatopicKeys.has(topic.key) &&
+                topicKeysWithQuestions.has(topic.key),
+            );
             if (megatopicTopics.length === 0) return null;
             return (
               <div key={megatopic.key} className="mb-8">

--- a/src/pages/SubjectHome.tsx
+++ b/src/pages/SubjectHome.tsx
@@ -11,6 +11,7 @@ import { LangLink as Link } from "../lib/lang-link";
 import { getSubject, getAllQuestions } from "../subjects";
 import { clearTopicProgress, getTopicProgress } from "../data/store";
 import TopicCard from "../components/TopicCard";
+import ExamSourceSelector from "../components/ExamSourceSelector";
 import AddExamModal, {
   type AddExamModalHandle,
 } from "../components/AddExamModal";
@@ -27,7 +28,11 @@ import { useDocumentTitle } from "../lib/title";
 import { useSeoHead } from "../lib/seo";
 import { buildSubjectMeta } from "../seo/meta";
 import { hasAuthorizedExamContent } from "../lib/content-policy";
-import { ArrowRightUp, CloseSquare2, Restart } from "reicon-react";
+import {
+  filterQuestionsByExamSelection,
+  useExamSelection,
+} from "../hooks/useExamSelection";
+import { ArrowRightUp, CloseSquare2, Filter, Restart } from "reicon-react";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
   CheckmarkBadge02Icon,
@@ -43,23 +48,34 @@ export default function SubjectHome() {
   const examModalRef = useRef<AddExamModalHandle>(null);
   const copyrightModalRef = useRef<CopyrightReportModalHandle>(null);
   const resetProgressDialogRef = useRef<HTMLDialogElement>(null);
+  const examSourceDialogRef = useRef<HTMLDialogElement>(null);
   const subject = subjectId ? getSubject(subjectId) : undefined;
+  const { selectedExamYears, setSelectedExamYears } = useExamSelection(subject);
   const [allQuestions, setAllQuestions] = useState<Question[]>([]);
   const [questionsLoadedFor, setQuestionsLoadedFor] = useState<string | null>(
     null,
   );
-  const [progress, setProgress] = useState<ReturnType<typeof getTopicProgress>>(
-    {},
-  );
   const questionsLoaded = !!subject && questionsLoadedFor === subject.id;
+  const [, setProgressRevision] = useState(0);
+  const selectedQuestions = useMemo(
+    () => filterQuestionsByExamSelection(allQuestions, selectedExamYears),
+    [allQuestions, selectedExamYears],
+  );
+  const progress =
+    subject && questionsLoaded
+      ? getTopicProgress(
+          subject.id,
+          selectedQuestions.map((q) => ({ topic: q.topic, points: q.points })),
+        )
+      : {};
   const seoMeta = useMemo(
     () =>
       subject
         ? buildSubjectMeta(lang, subject, {
-            questionCount: allQuestions.length,
+            questionCount: selectedQuestions.length,
           })
         : undefined,
-    [subject, lang, allQuestions.length],
+    [subject, lang, selectedQuestions.length],
   );
   useDocumentTitle(seoMeta?.title ?? t.home.title);
 
@@ -67,12 +83,6 @@ export default function SubjectHome() {
     if (subject) {
       getAllQuestions(subject.id).then((questions) => {
         setAllQuestions(questions);
-        setProgress(
-          getTopicProgress(
-            subject.id,
-            questions.map((q) => ({ topic: q.topic, points: q.points })),
-          ),
-        );
         setQuestionsLoadedFor(subject.id);
       });
     }
@@ -91,10 +101,12 @@ export default function SubjectHome() {
     return <SubjectNotFound />;
   }
 
-  const repeatedCount = allQuestions.filter((q) => q.repeated).length;
-  const availableExams = subject.exams.filter((exam) => !exam.deleteRights);
+  const repeatedCount = selectedQuestions.filter((q) => q.repeated).length;
   const hasAuthorizedExams = hasAuthorizedExamContent(subject);
   const currentSubjectId = subject.id;
+  const allExamSourcesSelected =
+    selectedExamYears.length ===
+    subject.exams.filter((exam) => !exam.deleteRights).length;
   const repeatedText =
     repeatedCount >= 20
       ? ` (${t.subjectHome.repeatedSuffix.replace("{count}", String(repeatedCount))})`
@@ -104,9 +116,9 @@ export default function SubjectHome() {
     ? t.subjectHome.description
     : t.subjectHome.communityDescription;
   const description = descriptionTemplate
-    .replace("{count}", String(allQuestions.length))
+    .replace("{count}", String(selectedQuestions.length))
     .replace("{repeated}", repeatedText)
-    .replace("{exams}", String(availableExams.length));
+    .replace("{exams}", String(selectedExamYears.length));
 
   function handleResetTopicProgress() {
     const clearedCount = clearTopicProgress(currentSubjectId);
@@ -115,12 +127,7 @@ export default function SubjectHome() {
       clearedCount,
     });
     if (clearedCount > 0) {
-      setProgress(
-        getTopicProgress(
-          currentSubjectId,
-          allQuestions.map((q) => ({ topic: q.topic, points: q.points })),
-        ),
-      );
+      setProgressRevision((revision) => revision + 1);
     }
     resetProgressDialogRef.current?.close();
   }
@@ -130,10 +137,18 @@ export default function SubjectHome() {
       {questionsLoaded && null}
       <SubjectHeader subject={subject} description={description} />
       <div className="mx-auto max-w-6xl px-4 pb-8">
+        <ExamSourceSelector
+          subject={subject}
+          selectedExamYears={selectedExamYears}
+          onChange={setSelectedExamYears}
+          dialogRef={examSourceDialogRef}
+        />
         <TopicsSection
           subject={subject}
-          questions={allQuestions}
+          questions={selectedQuestions}
           progress={progress}
+          allExamSourcesSelected={allExamSourcesSelected}
+          onOpenExamSources={() => examSourceDialogRef.current?.showModal()}
           onResetProgress={() => {
             track("reset_topic_progress_modal_open", {
               subjectId: currentSubjectId,
@@ -301,14 +316,21 @@ function TopicsSection({
   subject,
   questions,
   progress,
+  allExamSourcesSelected,
+  onOpenExamSources,
   onResetProgress,
 }: {
   subject: SubjectMeta;
   questions: Question[];
   progress: ReturnType<typeof getTopicProgress>;
+  allExamSourcesSelected: boolean;
+  onOpenExamSources: () => void;
   onResetProgress: () => void;
 }) {
   const t = useT();
+  const topicsWithQuestions = subject.topics.filter((topic) =>
+    questions.some((question) => question.topic === topic.key),
+  );
   const renderTopicCard = (topic: Topic) => {
     const topicQuestions = questions.filter((q) => q.topic === topic.key);
     const topicProgress = progress[topic.key];
@@ -335,23 +357,39 @@ function TopicsSection({
         <h2 className="text-fg text-lg font-semibold">
           {t.subjectHome.practiceByTopic}
         </h2>
-        <button
-          type="button"
-          data-cuelume-press="whisper"
-          onClick={onResetProgress}
-          className="text-fg-muted hover:text-incorrect-fg focus-visible:ring-accent rounded p-1 transition-colors focus-visible:ring-2 focus-visible:outline-none"
-          aria-label={t.subjectHome.resetTopicProgress}
-          title={t.subjectHome.resetTopicProgress}
-        >
-          <Restart className="size-4" weight="Filled" aria-hidden="true" />
-        </button>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            data-cuelume-press="whisper"
+            onClick={onOpenExamSources}
+            className="text-fg-muted hover:text-accent focus-visible:ring-accent rounded p-1 transition-colors focus-visible:ring-2 focus-visible:outline-none"
+            aria-label={t.subjectHome.questionSources}
+            title={t.subjectHome.questionSources}
+          >
+            <Filter
+              className="size-4"
+              weight={allExamSourcesSelected ? "Outline" : "Filled"}
+              aria-hidden="true"
+            />
+          </button>
+          <button
+            type="button"
+            data-cuelume-press="whisper"
+            onClick={onResetProgress}
+            className="text-fg-muted hover:text-incorrect-fg focus-visible:ring-accent rounded p-1 transition-colors focus-visible:ring-2 focus-visible:outline-none"
+            aria-label={t.subjectHome.resetTopicProgress}
+            title={t.subjectHome.resetTopicProgress}
+          >
+            <Restart className="size-4" weight="Filled" aria-hidden="true" />
+          </button>
+        </div>
       </div>
       {subject.megatopics ? (
         <>
           {subject.megatopics.map((megatopic) => {
-            const megatopicTopics = subject.topics.filter((topic) =>
-              megatopic.topics.includes(topic.key),
-            );
+            const megatopicTopics = subject.topics
+              .filter((topic) => megatopic.topics.includes(topic.key))
+              .filter((topic) => topicsWithQuestions.includes(topic));
             if (megatopicTopics.length === 0) return null;
             return (
               <div key={megatopic.key} className="mb-8">
@@ -366,6 +404,7 @@ function TopicsSection({
           })}
           <UngroupedTopics
             subject={subject}
+            topics={topicsWithQuestions}
             renderTopicCard={renderTopicCard}
           />
         </>
@@ -373,7 +412,7 @@ function TopicsSection({
         <div
           className={`mb-10 grid grid-cols-1 gap-4 sm:grid-cols-2 ${subject.topics.length > 4 ? "lg:grid-cols-3" : "lg:grid-cols-2"}`}
         >
-          {subject.topics.map(renderTopicCard)}
+          {topicsWithQuestions.map(renderTopicCard)}
         </div>
       )}
     </>
@@ -382,15 +421,15 @@ function TopicsSection({
 
 function UngroupedTopics({
   subject,
+  topics,
   renderTopicCard,
 }: {
   subject: SubjectMeta;
+  topics: Topic[];
   renderTopicCard: (topic: Topic) => ReactNode;
 }) {
   const groupedKeys = new Set(subject.megatopics?.flatMap((mt) => mt.topics));
-  const ungroupedTopics = subject.topics.filter(
-    (topic) => !groupedKeys.has(topic.key),
-  );
+  const ungroupedTopics = topics.filter((topic) => !groupedKeys.has(topic.key));
 
   if (ungroupedTopics.length === 0) return null;
 


### PR DESCRIPTION
## Summary
- Add per-subject exam and compilation source selection for topic practice
- Persist the selection in localStorage, defaulting to all available sources
- Filter subject counts, topic cards, progress, and direct topic practice routes
- Add a responsive modal with Reicon icons and Cuelume feedback

## Verification
- `pnpm lint`
- `pnpm build`

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds persisted per-subject source filtering across topic discovery and practice.
- Introduces a source-selection dialog backed by validated localStorage state and cross-tab synchronization.
- Filters subject totals, topic cards, progress calculations, SEO counts, and direct topic-practice questions.
- Synchronizes the practice session’s stored question index when filtering shortens the question list.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the render-time clamp prevents out-of-bounds access immediately, and the synchronization effect updates reducer state so an obsolete index cannot resurface when the list later expands.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/hooks/useExamSelection.ts | Adds validated, persisted, cross-tab-aware source selection and the shared question-filtering helper. |
| src/hooks/usePracticeSession.ts | Permanently synchronizes the reducer index after filtered question lists shrink, resolving both previously reported stale-index paths. |
| src/pages/PracticeTopic.tsx | Applies the selected sources to asynchronously loaded topic questions before creating the practice session. |
| src/pages/SubjectHome.tsx | Applies source filtering consistently to topic visibility, counts, progress, descriptions, and selector controls. |
| src/components/ExamSourceSelector.tsx | Adds the responsive dialog for selecting available exam and compilation sources. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant U as User
  participant Selector as ExamSourceSelector
  participant Selection as useExamSelection
  participant Storage as localStorage
  participant Page as SubjectHome / PracticeTopic
  participant Session as usePracticeSession
  U->>Selector: Select exam sources
  Selector->>Selection: setSelectedExamYears(years)
  Selection->>Storage: Persist selection
  Selection-->>Page: Return validated selected years
  Page->>Page: Filter questions by source
  Page->>Session: Pass filtered questions
  Session->>Session: Clamp and synchronize currentIndex
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: persist practice index clamp"](https://github.com/teenbiscuits/pasame-examenes/commit/def0d5faf279a42b4d4c8519fb1d1a82d9776504) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47261067)</sub>

**Context used:**

- Knowledge Base — [Practice Mode Flow](https://app.greptile.com/pablopl/-/custom-context/knowledge-base/teenbiscuits/pasame-examenes/-/docs/practice-flow.md)
- Knowledge Base — [Shared UI Components](https://app.greptile.com/pablopl/-/custom-context/knowledge-base/teenbiscuits/pasame-examenes/-/docs/ui-components.md)

<!-- /greptile_comment -->