### PR TITLE
Fix localized SEO fallback and privacy metadata

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -504,6 +504,8 @@ export const en = {
 	seo: {
 		siteName: "Pásame Exámenes",
 		locale: "en_US",
+		privacyMetaDescription:
+			"This page describes the types of data Pásame Exámenes collects and how and where that data is processed.",
 		homeTitle: "Practice FIC Exam Questions by Topic",
 		homeDescription:
 			"Practice FIC exam questions by topic or in timed sets. Check your answers, review model solutions, and prepare for exams.",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -509,6 +509,8 @@ export const es: Translations = {
 	seo: {
 		siteName: "Pásame Exámenes",
 		locale: "es_ES",
+		privacyMetaDescription:
+			"Aquí se describen los tipos de datos que Pásame Exámenes recopila y la forma y el lugar del tratamiento de dichos datos.",
 		homeTitle: "Practica preguntas de exámenes de la FIC",
 		homeDescription:
 			"Practica preguntas de exámenes de la FIC por tema o con simulacros cronometrados. Comprueba tus respuestas y consulta soluciones modelo.",

--- a/src/i18n/gl.ts
+++ b/src/i18n/gl.ts
@@ -508,6 +508,8 @@ export const gl: Translations = {
 	seo: {
 		siteName: "Pásame Exámenes",
 		locale: "gl_ES",
+		privacyMetaDescription:
+			"Aquí descríbense os tipos de datos que Pásame Exámenes recompila e a forma e o lugar do tratamento destes datos.",
 		homeTitle: "Practica preguntas de exames da FIC",
 		homeDescription:
 			"Practica preguntas de exames da FIC por tema ou con simulacións cronometradas. Comproba as túas respostas e consulta solucións modelo.",

--- a/src/pages/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy.tsx
@@ -6,7 +6,7 @@ export default function PrivacyPolicy() {
 	const t = useT();
 
 	return (
-		<article className="mx-auto w-full max-w-4xl px-4 py-10 sm:py-14">
+		<article className="mx-auto w-full max-w-prose px-4 py-10 sm:py-14">
 			<header className="border-border mb-8 space-y-3 border-b pb-6">
 				<p className="text-accent-fg text-xs font-semibold tracking-[0.18em] uppercase">
 					{t.footer.privacyLastUpdated}

--- a/src/routes/$lang.privacy.tsx
+++ b/src/routes/$lang.privacy.tsx
@@ -1,10 +1,12 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { isLang } from "../i18n/context-value";
+import { ssrDuringBuildPrerender } from "../lib/ssr";
 import PrivacyPolicy from "../pages/PrivacyPolicy";
 import { createPageHead } from "../seo/head";
 import { buildPrivacyMeta } from "../seo/meta";
 
 export const Route = createFileRoute("/$lang/privacy")({
+	ssr: ssrDuringBuildPrerender,
 	head: ({ params }) => {
 		const lang = isLang(params.lang) ? params.lang : "es";
 		return createPageHead(buildPrivacyMeta(lang), false);

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,7 +1,13 @@
 import { TanStackDevtools } from "@tanstack/react-devtools";
-import { createRootRoute, HeadContent, Scripts } from "@tanstack/react-router";
+import {
+	createRootRoute,
+	HeadContent,
+	Scripts,
+	useRouterState,
+} from "@tanstack/react-router";
 import { TanStackRouterDevtoolsPanel } from "@tanstack/react-router-devtools";
 
+import { isLang, type Lang } from "../i18n/context-value";
 import { ssrDuringBuildPrerender } from "../lib/ssr";
 import appCss from "../styles.css?url";
 
@@ -97,8 +103,13 @@ export const Route = createRootRoute({
 });
 
 function RootDocument({ children }: { children: React.ReactNode }) {
+	const pathname = useRouterState({
+		select: (state) => state.location.pathname,
+	});
+	const documentLang = getDocumentLang(pathname);
+
 	return (
-		<html lang="es" suppressHydrationWarning>
+		<html lang={documentLang} suppressHydrationWarning>
 			<head>
 				<script>{THEME_INIT_SCRIPT}</script>
 				<HeadContent />
@@ -120,4 +131,9 @@ function RootDocument({ children }: { children: React.ReactNode }) {
 			</body>
 		</html>
 	);
+}
+
+function getDocumentLang(pathname: string): Lang {
+	const [rawLang] = pathname.split("/").filter(Boolean);
+	return isLang(rawLang) ? rawLang : "es";
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,13 +1,67 @@
-import { createFileRoute, redirect } from "@tanstack/react-router";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { useEffect } from "react";
 import { detectPreferredLang } from "../i18n/detect-lang";
+import { ssrDuringBuildPrerender } from "../lib/ssr";
+import { createRedirectFallbackHead } from "../seo/head";
+import { buildHomeMeta, DEFAULT_LANG } from "../seo/meta";
 
 export const Route = createFileRoute("/")({
-	beforeLoad: () => {
-		throw redirect({
+	ssr: ssrDuringBuildPrerender,
+	head: () => createRedirectFallbackHead(buildHomeMeta(DEFAULT_LANG)),
+	component: RootFallback,
+});
+
+function RootFallback() {
+	const navigate = useNavigate();
+
+	useEffect(() => {
+		void navigate({
 			to: "/$lang",
 			params: { lang: detectPreferredLang() },
 			replace: true,
 		});
-	},
-	component: () => null,
-});
+	}, [navigate]);
+
+	return (
+		<main className="mx-auto flex min-h-dvh w-full max-w-prose flex-col justify-center gap-6 px-4 py-10">
+			<h1 className="text-fg text-3xl font-bold tracking-tight sm:text-4xl">
+				Pásame Exámenes
+			</h1>
+			<div className="text-fg-secondary space-y-2 leading-relaxed">
+				<p lang="es">
+					Si no eres redirigido automáticamente, pulsa{" "}
+					<Link
+						to="/$lang"
+						params={{ lang: "es" }}
+						className="text-accent-fg underline underline-offset-4"
+					>
+						este enlace para continuar en español
+					</Link>
+					.
+				</p>
+				<p lang="en">
+					If you are not redirected automatically, follow{" "}
+					<Link
+						to="/$lang"
+						params={{ lang: "en" }}
+						className="text-accent-fg underline underline-offset-4"
+					>
+						this link to continue in English
+					</Link>
+					.
+				</p>
+				<p lang="gl">
+					Se non es redirixido automaticamente, preme{" "}
+					<Link
+						to="/$lang"
+						params={{ lang: "gl" }}
+						className="text-accent-fg underline underline-offset-4"
+					>
+						nesta ligazón para continuar en galego
+					</Link>
+					.
+				</p>
+			</div>
+		</main>
+	);
+}

--- a/src/routes/sitemap[.]xml.ts
+++ b/src/routes/sitemap[.]xml.ts
@@ -2,7 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 
 const DEFAULT_BASE_URL = "https://pe.pablopl.dev";
 const LANGS = ["en", "es", "gl"] as const;
-const SITEMAP_GLOBAL_LASTMOD = "2026-08-16";
+const SITEMAP_GLOBAL_LASTMOD = "2026-08-23";
 
 function escapeXml(value: string): string {
 	return value

--- a/src/seo/head.ts
+++ b/src/seo/head.ts
@@ -41,6 +41,30 @@ export function createPageHead(meta: PageMetaData, indexable = true) {
 	};
 }
 
+export function createRedirectFallbackHead(meta: PageMetaData) {
+	return {
+		meta: [
+			{ title: meta.title },
+			{ name: "description", content: meta.description },
+			{ name: "robots", content: "noindex, follow" },
+			{ property: "og:title", content: meta.socialTitle },
+			{ property: "og:description", content: meta.socialDescription },
+			{ property: "og:image", content: meta.ogImage },
+			{ property: "og:image:type", content: meta.ogImageType },
+			{ property: "og:image:width", content: "1200" },
+			{ property: "og:image:height", content: "630" },
+			{ property: "og:url", content: meta.canonicalUrl },
+			{ property: "og:site_name", content: meta.siteName },
+			{ property: "og:type", content: "website" },
+			{ property: "og:locale", content: meta.locale },
+			{ name: "twitter:title", content: meta.socialTitle },
+			{ name: "twitter:description", content: meta.socialDescription },
+			{ name: "twitter:card", content: "summary_large_image" },
+			{ name: "twitter:image", content: meta.ogImage },
+		],
+	};
+}
+
 export function createNoIndexHead(
 	meta: Pick<PageMetaData, "title" | "description">,
 ) {

--- a/src/seo/meta.ts
+++ b/src/seo/meta.ts
@@ -11,7 +11,7 @@ export const LANGS = ["en", "es", "gl"] as const;
 export const DEFAULT_LANG: Lang = "es";
 export const BUNDLE_ENTRY_POINT = "/src/main.tsx";
 export const SITEMAP_LASTMOD = {
-	global: "2026-08-16",
+	global: "2026-08-23",
 	home: "2026-08-16",
 } as const;
 
@@ -229,7 +229,7 @@ export function buildHomeMeta(lang: Lang): PageMetaData {
 export function buildPrivacyMeta(lang: Lang): PageMetaData {
 	const tr = t(lang);
 	const title = appendBrand(tr.footer.privacyTitle, tr.seo.siteName);
-	const description = tr.footer.privacySummary;
+	const description = tr.seo.privacyMetaDescription;
 	const pathWithoutLang = "/privacy";
 	const canonicalUrl = fullUrl(buildCanonicalPath(lang, pathWithoutLang));
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,7 +39,9 @@ const indexableSubjectIds = readdirSync(subjectsDirectory, {
 	.map((entry) => entry.name)
 	.sort();
 const prerenderPages = [
+	{ path: "/" },
 	...LANGS.map((lang) => ({ path: `/${lang}` })),
+	...LANGS.map((lang) => ({ path: `/${lang}/privacy` })),
 	...LANGS.flatMap((lang) =>
 		indexableSubjectIds.map((subjectId) => ({
 			path: `/${lang}/${subjectId}`,


### PR DESCRIPTION
# Pull request

Mejora el fallback de la ruta raíz y los metadatos SEO localizados para evitar páginas prerenderizadas sin información adecuada y ofrecer una experiencia accesible si la redirección automática falla.

## Cambios

- Añade metadatos de privacidad específicos para español, inglés y gallego.
- Genera metadatos SEO completos y `noindex` para la ruta raíz de fallback.
- Sustituye la redirección exclusivamente del lado del router por una redirección del lado del cliente con enlaces manuales de respaldo.
- Ajusta el atributo `lang` del documento según la ruta localizada.
- Habilita el prerender de `/`, las páginas de privacidad y las rutas localizadas.
- Limita el ancho de lectura de la política de privacidad a `max-w-prose`.
- Actualiza las fechas `lastmod` del sitemap y de los metadatos globales al 23 de agosto de 2026.

## Issue relacionada

No aplica.

## Tipo de cambio

- [ ] Contenido o preguntas
- [x] Interfaz o accesibilidad
- [x] Rutas, SEO o prerender
- [ ] Rendimiento
- [ ] Herramientas o documentación

## Comprobaciones

- [x] `pnpm check`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm build`
- [ ] `pnpm run doctor`
- [x] He probado el preview si el cambio afecta al comportamiento o al aspecto de la app.

## Revisión específica

- [x] He probado las rutas y los idiomas afectados.
- [x] He revisado el comportamiento en mobile si el cambio afecta a la interfaz.
- [x] He comprobado teclado y nombres accesibles si el cambio afecta a controles.
- [x] He revisado title, description, Open Graph y sitemap si el cambio afecta al SEO.

## Capturas o notas para revisar

Revisar la ruta `/` sin JavaScript para confirmar que el fallback prerenderizado muestra los enlaces de idioma. Validar también los metadatos y el atributo `lang` en `/es`, `/en`, `/gl` y sus respectivas páginas de privacidad.

## Checklist

- [x] No he incluido secretos ni archivos generados innecesarios.
- [ ] He actualizado la documentación relacionada.
- [x] Esta PR está lista para revisión.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds localized privacy metadata and expands build-time prerendering to the root fallback and privacy pages. It also replaces the root route guard with a client redirect plus accessible language links, derives the document language from the localized pathname, and refreshes discovery metadata dates.

- Adds localized privacy descriptions and uses them for privacy-page metadata.
- Prerenders `/` and each localized privacy route.
- Gives the root fallback complete no-index social metadata and manual language navigation.
- Updates document language handling, privacy-page width, sitemap dates, and global metadata dates.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code defect identified.

The localized metadata, document-language derivation, client fallback navigation, and new prerender entries remain aligned with the repository’s existing routing and build-time SSR patterns.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/routes/index.tsx | Replaces the route-guard redirect with a prerenderable fallback page, client-side language detection, and manual localized links. |
| src/routes/__root.tsx | Derives the HTML document language from a validated leading locale segment, defaulting to Spanish. |
| src/routes/$lang.privacy.tsx | Enables build-time SSR for localized privacy pages while retaining localized no-index metadata. |
| src/seo/head.ts | Adds complete no-index Open Graph and Twitter metadata for the root fallback. |
| src/seo/meta.ts | Uses dedicated localized privacy descriptions and refreshes the global metadata date. |
| vite.config.ts | Adds the root fallback and all localized privacy pages to the explicit prerender set. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Request to root path] --> B[Prerendered fallback]
    B --> C{JavaScript available?}
    C -->|Yes| D[Detect saved or browser language]
    D --> E[Replace URL with localized home]
    C -->|No| F[Display manual language links]
    F --> E
    E --> G[Localized route and metadata]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(seo): improve localized fallback and..."](https://github.com/teenbiscuits/pasame-examenes/commit/42f7d7043bb324ddfc28e923e84c2f7d9264b1f3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56007082)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Application routing and rendering](https://app.greptile.com/pablopl/-/custom-context/knowledge-base/teenbiscuits/pasame-examenes/-/docs/application-routing-and-rendering.md)
- Knowledge Base — [Localization and language navigation](https://app.greptile.com/pablopl/-/custom-context/knowledge-base/teenbiscuits/pasame-examenes/-/docs/localization-and-language-navigation.md)
- Knowledge Base — [SEO, discovery, and analytics](https://app.greptile.com/pablopl/-/custom-context/knowledge-base/teenbiscuits/pasame-examenes/-/docs/seo-discovery-and-analytics.md)
- Knowledge Base — [Build and deployment configuration](https://app.greptile.com/pablopl/-/custom-context/knowledge-base/teenbiscuits/pasame-examenes/-/docs/build-and-deployment-configuration.md)
</details>


<!-- /greptile_comment -->