### PR TITLE
Documentar convenciones de dominio y contribución

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-exam.yml
+++ b/.github/ISSUE_TEMPLATE/add-exam.yml
@@ -1,14 +1,14 @@
-name: Añadir material de práctica autorizado
-description: Solicitar añadir exámenes autorizados, pruebas, recopilatorios o ejercicios originales a una asignatura existente
-title: "[Nuevo Examen]"
+name: Añadir material de estudio
+description: Enviar archivos o enlaces para valorar añadir material a una asignatura existente
+title: "[Nuevo Material]"
 labels: ["new-exam", "enhancement"]
 body:
   - type: markdown
     attributes:
       value: |
-        ¡Gracias por ayudar a ampliar Pásame Exámenes! Usa esta plantilla para solicitar que se añadan exámenes autorizados, pruebas, recopilatorios o ejercicios originales a una asignatura que ya existe en la plataforma.
+        ¡Gracias por ayudar a ampliar Pásame Exámenes! Usa esta plantilla para enviar archivos o enlaces relacionados con una asignatura que ya existe en la plataforma.
 
-        No envíes enunciados, PDFs o materiales docentes protegidos si no tienes permiso para compartirlos.
+        Comparte únicamente material que puedas publicar legalmente. No adjuntes ni solicites enunciados, PDFs o materiales docentes protegidos sin autorización.
 
   - type: checkboxes
     id: rights-confirmation
@@ -23,58 +23,29 @@ body:
     id: subject
     attributes:
       label: Asignatura
-      description: ¿A qué asignatura pertenece este material? (ej. "eseo", "bede")
+      description: ¿A qué asignatura pertenece este material? Usa su identificador si lo conoces (ej. "eseo", "bede")
       placeholder: "ej: eseo"
     validations:
       required: true
 
-  - type: input
-    id: exam-year
+  - type: textarea
+    id: material
     attributes:
-      label: Año o identificador
-      description: El año, mes o identificador del examen/prueba/recopilatorio a añadir
-      placeholder: "ej: 2025 o 2024-06"
+      label: Material o enlaces
+      description: Adjunta los archivos aquí o pega enlaces a los materiales que quieres compartir
+      placeholder: Arrastra aquí los archivos autorizados o pega sus enlaces...
     validations:
       required: true
 
-  - type: input
-    id: total-points
+  - type: textarea
+    id: description
     attributes:
-      label: Puntuación total
-      description: Puntuación máxima del examen
-      placeholder: "ej: 60"
-
-  - type: input
-    id: pass-points
-    attributes:
-      label: Puntuación para aprobar
-      description: Puntuación mínima necesaria para aprobar
-      placeholder: "ej: 30"
-
-  - type: input
-    id: duration
-    attributes:
-      label: Duración (minutos)
-      description: Duración del examen en minutos
-      placeholder: "ej: 180"
+      label: Descripción breve (opcional)
+      description: Explica qué material estás enviando y cualquier contexto que pueda ayudar a revisarlo
+      placeholder: Es un recopilatorio de la asignatura...
 
   - type: textarea
-    id: exam-details
+    id: additional-info
     attributes:
-      label: Información extra sobre el examen (opcional)
-
-  - type: checkboxes
-    id: has-pdf
-    attributes:
-      label: ¿Tienes un PDF autorizado?
-      description: Marca esta casilla solo si dispones de un PDF que puede compartirse públicamente o con autorización.
-      options:
-        - label: Tengo un PDF autorizado o público que puede compartirse
-
-  - type: textarea
-    id: questions
-    attributes:
-      label: Preguntas y soluciones (opcional)
-      description: |
-        Si dispones de preguntas y soluciones originales o autorizadas, puedes detallarlas aquí.
-        Cuanta más información proporciones, más rápido se podrá revisar y añadir el material.
+      label: Información adicional (opcional)
+      description: Añade cualquier otro detalle relevante

--- a/.github/ISSUE_TEMPLATE/report-question.yml
+++ b/.github/ISSUE_TEMPLATE/report-question.yml
@@ -26,6 +26,15 @@ body:
     validations:
       required: true
 
+  - type: input
+    id: exam-id
+    attributes:
+      label: Examen o Recopilatorio
+      description: Identificador de la fuente en la que aparece la pregunta
+      placeholder: "ej: 2024 o recopilatorio-mayo-2026"
+    validations:
+      required: true
+
   - type: dropdown
     id: question-type
     attributes:
@@ -33,9 +42,11 @@ body:
       description: Opcionalmente, ¿de qué tipo es esta pregunta?
       options:
         - Opción múltiple (mc)
-        - Texto libre (text)
-        - Cálculo (calculation)
+        - Texto (text)
+        - Texto con varias partes (multiple-text)
         - Emparejamiento (matching)
+        - Rellenar huecos (fill)
+        - Rellenar tablas (table-fill)
     validations:
       required: false
 

--- a/.github/ISSUE_TEMPLATE/suggest-subject.yml
+++ b/.github/ISSUE_TEMPLATE/suggest-subject.yml
@@ -8,7 +8,7 @@ body:
       value: |
         ¡Gracias por sugerir una nueva asignatura para Pásame Exámenes! Cuanta más información proporciones, más fácil será añadirla.
 
-        No envíes enunciados, PDFs o materiales docentes protegidos si no tienes permiso para compartirlos.
+        Comparte únicamente material que puedas publicar legalmente. No adjuntes ni solicites enunciados, PDFs o materiales docentes protegidos sin autorización.
 
   - type: input
     id: subject-name
@@ -43,6 +43,18 @@ body:
       label: Código de la asignatura (opcional)
       description: El código oficial del plan de estudios
       placeholder: "ej: 614G01001"
+
+  - type: dropdown
+    id: professor-exams
+    attributes:
+      label: ¿El profesorado comparte sus exámenes?
+      description: Esta información ayuda a decidir si el contenido se presenta como Examen o como Recopilatorio.
+      options:
+        - Sí, el profesorado comparte sus exámenes
+        - No, el profesorado no comparte sus exámenes
+        - No lo sé
+    validations:
+      required: true
 
   - type: textarea
     id: topics

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-# Pull request
+# Resumen
 
 <!-- Resume el cambio y explica por qué hace falta. -->
 
@@ -25,6 +25,7 @@
 - [ ] `pnpm build`
 - [ ] `pnpm run doctor`
 - [ ] He probado el preview si el cambio afecta al comportamiento o al aspecto de la app.
+- [ ] He ejecutado `pnpm readme` si he añadido o modificado una asignatura, o no aplica.
 
 ## Revisión específica
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,17 @@
+## Agent skills
+
+### Issue tracker
+
+Los issues y las especificaciones viven en GitHub Issues y se gestionan con `gh`. Consulta `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Se usan las cinco etiquetas predeterminadas de triage. Consulta `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+El repositorio usa un diseño `single-context`, con `CONTEXT.md` en la raíz y ADRs en `docs/adr/`. Consulta `docs/agents/domain.md`.
+
 <!-- intent-skills:start -->
 
 # TanStack Intent - before editing files, run the matching guidance command.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,126 @@
+# Pásame Exámenes
+
+Pásame Exámenes es una plataforma de estudio para que estudiantes de la FIC preparen sus asignaturas con preguntas de exámenes y ejercicios de práctica.
+
+## Lenguaje
+
+### Personas
+
+**Estudiante**: Persona que usa Pásame Exámenes para preparar una asignatura.
+_Evitar_: Usuario, cliente
+
+### Catálogo académico
+
+**Asignatura**: Unidad académica de un grado que reúne sus temas, exámenes y preguntas. Su código oficial dentro del grado es su identidad académica; el identificador corto es una referencia de navegación.
+_Evitar_: Materia, subject
+
+**Tema**: Parte de una asignatura que agrupa preguntas sobre un área concreta del temario.
+_Evitar_: Topic, unidad
+
+**Examen**: Conjunto publicado de preguntas que se presenta como un examen de una asignatura. Puede definir una duración, un criterio de aprobado y reglas de puntuación por pregunta.
+_Evitar_: Recopilatorio, simulación
+
+**Recopilatorio**: Conjunto publicado de preguntas para practicar en una asignatura que no comparte sus exámenes oficiales, o cuyo contenido no debe presentarse como un examen de la facultad. Puede definir las mismas reglas de práctica, simulación, duración, aprobado y puntuación por pregunta que un examen.
+_Evitar_: Examen oficial, prueba oficial
+
+**Pregunta**: Unidad evaluable que pertenece a una asignatura, a un único examen o recopilatorio de origen y a un único tema, y que puede practicarse dentro de ese tema. Tiene una puntuación y puede tener una penalización propias. Dos preguntas parecidas de fuentes distintas siguen siendo preguntas diferentes.
+_Evitar_: Ítem, ejercicio, cuestión
+
+**Tipo de pregunta**: Forma en que una pregunta presenta la respuesta y determina cómo se corrige. Los tipos actuales son test, texto, texto con varias partes, emparejamiento, rellenar huecos y rellenar tablas.
+_Evitar_: Formato de pregunta
+
+**Solución modelo**: Respuesta de referencia que explica o resuelve una pregunta y permite autoevaluar las respuestas abiertas.
+_Evitar_: Respuesta correcta, solución oficial
+
+### Sesiones y resultados
+
+**Práctica**: Sesión de estudio centrada en un tema y sin límite de tiempo. Puede reunir preguntas de varias fuentes seleccionadas.
+_Evitar_: Modo práctica
+
+**Simulación de examen**: Sesión cronometrada basada en un único examen o recopilatorio publicado, que aplica sus reglas de aprobado y puntuación.
+_Evitar_: Examen, modo examen
+
+**Intento**: Resultado de enviar una práctica o una simulación de examen, incluida una simulación que termina al agotarse el tiempo. Conserva las respuestas, la puntuación y la configuración de la sesión. Una sesión abandonada antes del envío no es un intento.
+_Evitar_: Sesión, resultado
+
+La autoevaluación posterior completa el mismo intento y puede actualizar su puntuación hasta que todas las respuestas autoevaluables estén calificadas.
+
+**Aprobado**: Resultado de una simulación cuya calificación está completa y alcanza el umbral definido para el examen.
+_Evitar_: Superado, pass
+
+**Calificación pendiente**: Estado de una simulación que todavía tiene respuestas autoevaluables sin calificar ni marcar como `En blanco`.
+_Evitar_: Resultado final
+
+**Progreso**: Estado de preparación de un estudiante en un tema y dentro de las fuentes seleccionadas, calculado a partir del mejor resultado conocido para cada pregunta de las prácticas. Se agrega solo con las preguntas de las fuentes seleccionadas, y las simulaciones no cambian el progreso del tema.
+_Evitar_: Avance, porcentaje completado
+
+**Corrección automática**: Evaluación de una respuesta mediante las reglas de la pregunta, sin que el estudiante tenga que decidir si acertó.
+_Evitar_: Autocorrección
+
+**Autoevaluación**: Valoración que hace el estudiante de una respuesta abierta al compararla con la solución modelo. La valoración forma parte de la puntuación de la sesión y puede completarse indicando que la pregunta quedó `En blanco`.
+_Evitar_: Corrección automática
+
+**Puntuación parcial**: Puntos que recibe una pregunta cuando solo una parte de sus respuestas o elementos es correcta. Si otra parte es incorrecta, la penalización de la pregunta se aplica una sola vez.
+_Evitar_: Todo o nada
+
+**Puntuación acumulativa**: Modelo en el que una respuesta correcta suma sus puntos y una respuesta incorrecta o marcada `En blanco` suma cero. Es el modelo predeterminado cuando la fuente no define penalizaciones.
+_Evitar_: Puntuación negativa
+
+**Penalización por respuesta incorrecta**: Regla opcional de un examen o recopilatorio que define una resta para cada pregunta concreta. Solo se aplica una vez en simulaciones de examen cuando el estudiante marca la respuesta como incorrecta, no cuando la marca `En blanco` ni en las prácticas.
+_Evitar_: Penalización de práctica
+
+**Respuesta no introducida**: Estado en el que la aplicación no contiene texto para una respuesta. No indica si el estudiante respondió fuera de la aplicación.
+_Evitar_: En blanco, respuesta incorrecta
+
+**En blanco**: Declaración explícita del estudiante de que no respondió a una pregunta. Recibe cero puntos y no activa una penalización por respuesta incorrecta.
+_Evitar_: Campo vacío, respuesta no introducida
+
+**Puntuación total**: Resultado de sumar los puntos obtenidos y aplicar las penalizaciones de una sesión. Nunca puede ser inferior a `0.0`.
+_Evitar_: Puntuación bruta
+
+**Selección de fuentes**: Conjunto de exámenes y recopilatorios que el estudiante elige para formar su práctica por tema y delimitar el progreso que quiere consultar. Cambiarlo no modifica el catálogo ni el contenido de las fuentes.
+_Evitar_: Filtro de asignatura
+
+**Configuración de la sesión**: Datos que definen qué se estudia en un intento: el modo, el tema o examen elegido y las fuentes seleccionadas. El idioma de la interfaz no forma parte de esta configuración.
+_Evitar_: Preferencias de idioma
+
+**Megatema**: Agrupación visible de temas relacionados dentro de una asignatura. No es una unidad independiente de práctica y no cambia la pertenencia de las preguntas.
+_Evitar_: Supertema, categoría
+
+**Pregunta repetida**: Pregunta cuyo contenido sustancial aparece también en otra pregunta de un examen o recopilatorio distinto. Cada aparición conserva su propio identificador, puede marcarse como repetida y mantiene su propio dominio.
+_Evitar_: Pregunta similar, duplicado
+
+**Fuente original**: PDF, enlace u otro material del que procede un examen o recopilatorio.
+_Evitar_: Fuente de práctica
+
+**Contenido retirado**: Pregunta o examen que sigue identificado dentro de una asignatura, pero ya no está disponible para practicarlo o simularlo.
+_Evitar_: Contenido borrado, contenido eliminado
+
+**Reinicio de progreso**: Acción que elimina todos los intentos de práctica de una asignatura.
+_Evitar_: Borrar una selección
+
+### Origen del contenido
+
+**Contenido autorizado**: Preguntas o materiales de una asignatura cuya publicación cuenta con permiso para compartirlos.
+_Evitar_: Contenido oficial, contenido libre
+
+**Contenido comunitario**: Preguntas y ejercicios de una asignatura compartidos por la comunidad para practicar, sin presentar ese material como un examen oficial.
+_Evitar_: Contenido de usuario, contenido oficial
+
+Cada asignatura tiene una única política de contenido: autorizado o comunitario.
+
+### Visibilidad
+
+**Asignatura de prueba**: Asignatura que se conserva para probar contenido y comportamiento de la plataforma. Solo forma parte del catálogo durante el desarrollo interno.
+_Evitar_: Asignatura pública
+
+**Easter egg**: Funcionalidad o contenido oculto que forma parte intencionadamente de la experiencia de la web, aunque no aparezca en el catálogo público.
+_Evitar_: Asignatura de prueba, contenido retirado
+
+### Idioma
+
+**Idioma de la interfaz**: Preferencia que cambia los textos y la navegación de la plataforma. Pásame Exámenes ofrece español, galego e inglés.
+_Evitar_: Idioma de la asignatura
+
+**Idioma del contenido**: Idioma en el que está escrita una pregunta o solución. Puede ser el idioma en el que se imparte la asignatura o el idioma del material del que procede.
+_Evitar_: Traducción de la interfaz

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ Después:
 6. Guarda las imágenes de las preguntas en `assets/` y referencia sus versiones optimizadas con las utilidades existentes.
 7. Ejecuta `pnpm readme` para regenerar la tabla de asignaturas del README.
 
-Los tipos de pregunta disponibles son `mc`, `text`, `multiple-text`, `matching`, `fill` y `table-fill`. Los campos de texto admiten Markdown, fórmulas y bloques de código. Consulta [`src/data/types.ts`](./src/data/types.ts) y una asignatura existente antes de añadir una estructura nueva.
+Los tipos de pregunta disponibles son `mc`, `text`, `multiple-text`, `matching`, `fill` y `table-fill`. Los campos de texto admiten Markdown, fórmulas y bloques de código. Consulta la [guía de tipos de pregunta](./docs/content/question-types.md), [`src/data/types.ts`](./src/data/types.ts) y una asignatura existente antes de añadir una estructura nueva.
 
 La plantilla `_template` sirve como asignatura de pruebas. Solo debe aparecer en desarrollo y en previews de Vercel. No la conviertas en una asignatura pública ni la incluyas en el sitemap. `espain` es una asignatura secreta: se accede por URL directa o mediante SecretToro y no debe aparecer en la homepage ni en el sitemap.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,16 @@
 # Contribuir a Pásame Exámenes
 
-Pásame Exámenes es una plataforma de práctica para las asignaturas de la Facultade de Informática da Coruña. Se aceptan mejoras de contenido, interfaz, accesibilidad, rendimiento, SEO, documentación y herramientas del proyecto.
+Pásame Exámenes es una plataforma de estudio para que estudiantes de la FIC preparen sus asignaturas con preguntas de exámenes y ejercicios de práctica. Puedes contribuir con contenido, código, diseño, accesibilidad, rendimiento, SEO, documentación o herramientas.
 
 ## Antes de empezar
 
-Busca primero si ya existe una issue relacionada. Si no encuentras una, abre una nueva usando la plantilla que mejor encaje:
+Busca primero si ya existe una issue relacionada. Si no encuentras una, abre una nueva:
 
-- [Reportar un error en una pregunta](.github/ISSUE_TEMPLATE/report-question.yml)
-- [Añadir material de práctica autorizado](.github/ISSUE_TEMPLATE/add-exam.yml)
-- [Sugerir una asignatura](.github/ISSUE_TEMPLATE/suggest-subject.yml)
+- [Reportar un error en una pregunta](https://github.com/TeenBiscuits/Pasame-Examenes/issues/new?template=report-question.yml)
+- [Añadir material de estudio](https://github.com/TeenBiscuits/Pasame-Examenes/issues/new?template=add-exam.yml)
+- [Sugerir una asignatura](https://github.com/TeenBiscuits/Pasame-Examenes/issues/new?template=suggest-subject.yml)
 
-Para cambios grandes de arquitectura, rutas o modelo de contenido, abre una issue antes de preparar la implementación. Así podemos acordar el alcance antes de invertir tiempo en una solución que no encaje con la aplicación.
+Para cambios grandes de arquitectura, rutas o reglas del producto, abre una issue antes de implementarlos.
 
 ## Preparar el entorno
 
@@ -22,34 +22,21 @@ git switch -c mi-cambio
 pnpm dev
 ```
 
-La aplicación estará disponible en [http://localhost:3000](http://localhost:3000). El comando `pnpm dev` genera antes las estadísticas de contenido y las imágenes Open Graph necesarias para el entorno local.
+La aplicación estará disponible en [http://localhost:3000](http://localhost:3000). Consulta el [README](./README.md) si necesitas conocer la estructura del proyecto o el resto de comandos.
 
-Consulta el [README](./README.md) para conocer la arquitectura y el resto de comandos disponibles.
+Si usas un agente de programación, puedes consultar las [skills de Matt Pocock](https://www.aihero.dev/skills) para añadir flujos de trabajo guiados a tu agente.
 
-## Contenido y derechos de uso
+> [!TIP]
+> Pide a tu agente que te ponga al día con el proyecto antes de proponer cambios:
+> ```txt
+> Lee AGENTS.md, CONTEXT.md, README.md y CONTRIBUTING.md. Según la tarea, lee también docs/agents/domain.md, docs/content/question-types.md y los ADRs de docs/adr/.
+>
+> Resume en español la arquitectura, el modelo de dominio, la estructura del contenido y las convenciones que afectan a mi tarea. Indica qué archivos debería revisar y qué comprobaciones serían aplicables. No edites archivos todavía.
+> ```
 
-Solo se pueden añadir preguntas, soluciones, imágenes y documentos que cumplan una de estas condiciones:
+## Añadir una asignatura
 
-- son originales de quien contribuye;
-- tienen autorización para compartirse;
-- proceden de una fuente pública compatible con su redistribución;
-- los ha proporcionado el profesorado o la institución con permiso suficiente.
-
-No subas enunciados, PDFs, soluciones ni otros materiales protegidos si no tienes permiso para compartirlos. Si no puedes verificar los derechos de un examen, aporta ejercicios originales basados en el temario.
-
-El contenido usa CC BY-SA 4.0 por defecto. El código, la configuración y la documentación usan Apache 2.0. La asignación concreta se mantiene en [`REUSE.toml`](./REUSE.toml) y el texto de la licencia de contenido está en [`LICENSE-CONTENT.md`](./LICENSE-CONTENT.md).
-
-Si una asignatura necesita una licencia distinta, añade el texto correspondiente en `LICENSES/`, configura la anotación de la ruta en `REUSE.toml` y declara `contentLicense` en su `meta.ts`. No marques como autorizado un examen que no pueda compartirse legalmente.
-
-## Añadir o actualizar una asignatura
-
-Las asignaturas viven en `src/subjects/<subject-id>/` y normalmente contienen:
-
-- `meta.ts`, con la información de la asignatura, temas y exámenes;
-- `questions.ts`, con las preguntas;
-- `assets/`, con imágenes usadas por las preguntas.
-
-Para crear una asignatura nueva, copia la plantilla y sustituye el identificador:
+Las asignaturas viven en `src/subjects/<subject-id>/`. Para crear una:
 
 ```bash
 cp -R src/subjects/_template src/subjects/mi-asignatura
@@ -57,28 +44,59 @@ cp -R src/subjects/_template src/subjects/mi-asignatura
 
 Después:
 
-1. Actualiza `meta.ts`. El campo `id` debe coincidir con el nombre de la carpeta y `lastmod` debe usar una fecha ISO.
-2. Define los temas y los exámenes disponibles.
-3. Añade las preguntas en `questions.ts` como un array `Question[]`.
-4. Comprueba que cada pregunta tiene un `examId` que coincide con un examen de `meta.ts` y un `topic` válido.
-5. Añade solo PDFs autorizados en `public/exams/<subject-id>/` y usa `hasPdf: false` cuando un examen no tenga un PDF compartible.
-6. Guarda las imágenes de las preguntas en `assets/` y referencia sus versiones optimizadas con las utilidades existentes.
-7. Ejecuta `pnpm readme` para regenerar la tabla de asignaturas del README.
+1. Actualiza `meta.ts` con el nombre, grado, curso, código oficial, temas y fuentes de la asignatura.
+2. Indica si el profesorado comparte sus exámenes. Si los comparte, el contenido puede presentarse como `Examen`; si no, usa `Recopilatorio` para no sugerir una relación oficial con la facultad.
+3. Añade las preguntas en `questions.ts` y sus imágenes en `assets/`.
+4. Usa solo materiales que puedan publicarse legalmente.
+5. Ejecuta `pnpm readme` para regenerar la tabla de asignaturas del README.
 
-Los tipos de pregunta disponibles son `mc`, `text`, `multiple-text`, `matching`, `fill` y `table-fill`. Los campos de texto admiten Markdown, fórmulas y bloques de código. Consulta la [guía de tipos de pregunta](./docs/content/question-types.md), [`src/data/types.ts`](./src/data/types.ts) y una asignatura existente antes de añadir una estructura nueva.
+La plantilla `_template` es una asignatura de pruebas y solo debe aparecer en desarrollo y en previews de Vercel. `espain` es una asignatura secreta y no debe aparecer en la homepage ni en el sitemap.
 
-La plantilla `_template` sirve como asignatura de pruebas. Solo debe aparecer en desarrollo y en previews de Vercel. No la conviertas en una asignatura pública ni la incluyas en el sitemap. `espain` es una asignatura secreta: se accede por URL directa o mediante SecretToro y no debe aparecer en la homepage ni en el sitemap.
+> [!TIP]
+> Pide a tu agente que cree una nueva asignatura siguiendo las convenciones del repositorio:
+> ```txt
+> Quiero añadir la asignatura <nombre> con el identificador <subject-id>.
+>
+> Lee AGENTS.md, CONTEXT.md, CONTRIBUTING.md, la plantilla src/subjects/_template/ y al menos una asignatura existente parecida. Inspecciona cómo se definen meta.ts, topics, exams y questions.ts.
+>
+> Usa la información que te proporcione sobre si el profesorado comparte sus exámenes y aplica la distinción entre Examen y Recopilatorio. Si falta esa información, pregúntamela antes de elegir. Implementa la asignatura, añade los temas y fuentes que te proporcione, genera el README con pnpm readme y ejecuta las comprobaciones aplicables. Termina indicando los archivos modificados, los comandos ejecutados y cualquier dato que falte.
+> ```
+
+## Añadir contenido a una asignatura
+
+Para añadir preguntas o fuentes a una asignatura existente:
+
+1. Modifica el `meta.ts` de la asignatura si añades una fuente, un tema o una imagen de asignatura.
+2. Añade las preguntas en `questions.ts`. Cada pregunta debe tener un `examId` y un `topic` válidos.
+3. Consulta la [guía de tipos de pregunta](./docs/content/question-types.md) para elegir la estructura adecuada. Si una pregunta no encaja en ningún tipo, crea un tipo nuevo siguiendo esa guía.
+4. Guarda las imágenes de las preguntas en `assets/` y los PDFs autorizados en `public/exams/<subject-id>/`.
+5. Ejecuta `pnpm readme` si has añadido o modificado una asignatura.
+
+> [!CAUTION]
+> Comparte únicamente material que puedas publicar legalmente. No adjuntes ni solicites enunciados, PDFs o materiales docentes protegidos sin autorización.
+
+> [!TIP]
+> Pide a tu agente que añada contenido a una asignatura existente:
+> ```txt
+> Quiero añadir contenido a src/subjects/<subject-id> a partir de estos archivos o enlaces: <archivos o enlaces>.
+>
+> Lee AGENTS.md, CONTEXT.md, CONTRIBUTING.md, docs/content/question-types.md y los archivos de la asignatura. Comprueba que el material puede publicarse, usa la información disponible para identificar si corresponde a un Examen o a un Recopilatorio y pregúntame si no es suficiente. Revisa los temas y tipos de pregunta disponibles.
+>
+> Implementa el contenido respetando las estructuras existentes, añade las imágenes necesarias, actualiza los metadatos y ejecuta pnpm readme si corresponde. Ejecuta las comprobaciones aplicables y termina indicando qué material has añadido, qué comandos has ejecutado y cualquier duda que deba revisar una persona.
+> ```
 
 ## Cambios en la aplicación
 
-Ten en cuenta estas reglas al modificar la interfaz o las rutas:
-
 - Mantén los tres idiomas disponibles: español, galego e inglés.
-- Usa los componentes y utilidades existentes antes de crear una variante nueva.
-- Conserva los nombres accesibles de botones, enlaces, iconos y controles, también cuando el texto se oculte en mobile.
-- Si cambias una página pública, revisa `title`, `description`, canonical, Open Graph, datos estructurados y sitemap.
-- Si cambias el flujo de práctica o examen, prueba navegación por teclado, estados de error y tamaños de pantalla pequeños.
-- No edites a mano las filas de asignaturas generadas entre `SUBJECTS_TABLE:START` y `SUBJECTS_TABLE:END`.
+- Usa los componentes y utilidades existentes antes de crear variantes nuevas.
+- Conserva la accesibilidad de botones, enlaces, iconos y controles.
+- Si cambias una página pública, revisa sus metadatos SEO.
+- Si cambias la práctica o la simulación de examen, prueba los estados relevantes en teclado y en pantallas pequeñas.
+- No edites manualmente la tabla de asignaturas entre `SUBJECTS_TABLE:START` y `SUBJECTS_TABLE:END`.
+
+## Documentación y decisiones del proyecto
+
+`CONTEXT.md` contiene el vocabulario del dominio y los ADRs de `docs/adr/` explican decisiones importantes. Si una contribución cambia una regla del producto, actualiza la documentación correspondiente. Si el código no coincide con la documentación, adapta el código al comportamiento documentado salvo que haya cambiado la decisión del dominio.
 
 ## Comprobaciones
 
@@ -98,9 +116,7 @@ pnpm run doctor
 pnpm preview
 ```
 
-`pnpm check` y `pnpm lint` usan Biome. `pnpm run doctor` ejecuta React Doctor sin su linter integrado. Los scripts `scripts/daypo_scraper.ts` y `scripts/mistral_ocr.ts` son herramientas auxiliares para desarrolladores y no forman parte de la comprobación normal de la aplicación.
-
-Si el cambio afecta a la interfaz, prueba al menos una pantalla móvil, los tres idiomas y los temas claro y oscuro. Si afecta a contenido o prerender, comprueba también el build y las rutas públicas generadas.
+Si el cambio afecta a la interfaz, prueba al menos una pantalla móvil, los tres idiomas y los temas claro y oscuro. Si afecta al contenido o al prerenderizado, comprueba también el build y las rutas públicas generadas.
 
 ## Pull requests
 

--- a/docs/adr/0001-examenes-y-recopilatorios.md
+++ b/docs/adr/0001-examenes-y-recopilatorios.md
@@ -1,0 +1,11 @@
+# Exámenes y recopilatorios
+
+Pásame Exámenes usa el mismo modelo para los conjuntos publicados de preguntas, pero distingue su nombre visible según el origen del contenido. Usa `Examen` cuando el conjunto puede presentarse como un examen de la asignatura. Usa `Recopilatorio` cuando la asignatura no comparte sus exámenes oficiales o cuando llamar "examen" al contenido podría sugerir una relación oficial que no existe.
+
+Ambos conceptos comparten las reglas de práctica, simulación, duración, aprobado y puntuación. La diferencia de nombre conserva la precisión académica y legal sin duplicar el modelo de contenido.
+
+## Consecuencias
+
+- La interfaz y la documentación deben elegir el término según el origen y la autorización del contenido.
+- El modelo técnico puede tratar ambos conceptos como un conjunto de preguntas publicado.
+- Una asignatura de contenido comunitario no debe presentarse como si ofreciera exámenes oficiales.

--- a/docs/adr/0002-reglas-de-puntuacion.md
+++ b/docs/adr/0002-reglas-de-puntuacion.md
@@ -1,0 +1,11 @@
+---
+status: accepted
+---
+
+# Reglas de puntuación en prácticas y simulaciones
+
+La puntuación acumulativa es el comportamiento predeterminado: una respuesta correcta suma sus puntos y una respuesta incorrecta o marcada `En blanco` suma cero. Un examen o recopilatorio puede definir una penalización distinta para cada pregunta.
+
+La penalización solo se aplica en una simulación de examen, una vez por pregunta y cuando el estudiante la marca como incorrecta. No se aplica en prácticas ni cuando la pregunta se marca `En blanco`. La autoevaluación de una pregunta abierta actualiza el mismo intento. La puntuación total no puede ser inferior a `0.0`.
+
+Esta regla mantiene la práctica como una herramienta de estudio sin castigos y permite reproducir los exámenes que penalizan errores. La configuración de estas penalizaciones está pendiente del [issue #45](https://github.com/TeenBiscuits/Pasame-Examenes/issues/45).

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,39 @@
+# Documentación del dominio
+
+Indica cómo deben leer las skills de ingeniería la documentación del dominio al explorar el código.
+
+## Antes de explorar
+
+Lee uno de estos archivos:
+
+- `CONTEXT.md` en la raíz del repositorio.
+- `CONTEXT-MAP.md` en la raíz, si existe. Este archivo enlaza los `CONTEXT.md` de cada contexto.
+
+Lee también los ADRs de `docs/adr/` que afecten al área de trabajo.
+
+Si estos archivos no existen, continúa sin avisar ni proponer crearlos. La skill `domain-modeling` los crea cuando se resuelven términos o decisiones que lo requieren.
+
+## Estructura
+
+Este es un repositorio `single-context`:
+
+```text
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-decision.md
+│   └── 0002-decision.md
+└── src/
+```
+
+## Usa el vocabulario del glosario
+
+Cuando un issue, una propuesta de refactor o un test nombre un concepto del dominio, usa el término definido en `CONTEXT.md`. Si el concepto no aparece allí, comprueba si falta documentarlo antes de inventar otro nombre.
+
+## Señala conflictos con ADRs
+
+Si una propuesta contradice un ADR existente, indícalo de forma explícita en lugar de sustituirlo sin avisar.
+
+## Documentación frente a código
+
+`CONTEXT.md` y los ADRs aceptados describen el comportamiento esperado del dominio. Si el código contradice esa documentación, trata la diferencia como una carencia de la aplicación y adapta el código al modelo documentado. Solo cambia la documentación cuando cambie la decisión del dominio.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Los issues y las especificaciones de este repositorio viven en GitHub Issues. Usa `gh` para todas las operaciones.
+
+## Convenciones
+
+- Crear un issue: `gh issue create --title "..." --body "..."`. Usa un heredoc para cuerpos multilínea.
+- Leer un issue: `gh issue view <number> --comments`. Filtra los comentarios con `jq` y consulta también las etiquetas.
+- Listar issues: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'`, con los filtros `--label` y `--state` que correspondan.
+- Comentar un issue: `gh issue comment <number> --body "..."`
+- Añadir o quitar etiquetas: `gh issue edit <number> --add-label "..."` o `gh issue edit <number> --remove-label "..."`
+- Cerrar un issue: `gh issue close <number> --comment "..."`
+
+El repositorio se infiere de `git remote -v`. `gh` lo detecta al ejecutarse dentro de este clon.
+
+## Pull requests como entrada de triage
+
+**Los PRs no se usan como entrada de triage.** Cambia este valor a `yes` si el repositorio trata los PRs externos como solicitudes de funcionalidad.
+
+Cuando el valor sea `yes`, los PRs usarán las mismas etiquetas y estados que los issues, mediante los comandos equivalentes de `gh pr`:
+
+- Leer un PR: `gh pr view <number> --comments` y `gh pr diff <number>`.
+- Listar PRs externos: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments`. Conserva solo `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR` o `NONE` en `authorAssociation`.
+- Comentar, etiquetar o cerrar: `gh pr comment`, `gh pr edit --add-label` o `gh pr edit --remove-label`, y `gh pr close`.
+
+GitHub comparte la numeración entre issues y PRs. Si `#42` puede referirse a cualquiera de los dos, prueba `gh pr view 42` y después `gh issue view 42`.
+
+## Cuando una skill diga "publicar en el issue tracker"
+
+Crea un issue de GitHub.
+
+## Cuando una skill diga "obtener el ticket correspondiente"
+
+Ejecuta `gh issue view <number> --comments`.
+
+## Operaciones de wayfinder
+
+Wayfinder usa un issue principal con issues hijos.
+
+- Mapa: un issue con la etiqueta `wayfinder:map`, que contiene las secciones Notes, Decisions-so-far y Fog. Créalo con `gh issue create --label wayfinder:map`.
+- Ticket hijo: un issue vinculado al mapa como sub-issue de GitHub. Si los sub-issues no están disponibles, añade el ticket a una lista de tareas del mapa y coloca `Part of #<map>` al principio del cuerpo. Usa las etiquetas `wayfinder:<type>` con `research`, `prototype`, `grilling` o `task`. Cuando se reclame el ticket, asígnalo al desarrollador que lo está llevando.
+- Bloqueos: usa las dependencias nativas de GitHub. Añade una dependencia con `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, donde `<blocker-db-id>` es el `id` numérico del issue bloqueador. No uses el número visible ni el `node_id`. GitHub expone los bloqueos abiertos en `issue_dependencies_summary.blocked_by`. Si las dependencias no están disponibles, añade `Blocked by: #<n>, #<n>` al principio del cuerpo del ticket. Un ticket queda desbloqueado cuando todos sus bloqueos se cierran.
+- Consulta de frontera: lista los tickets hijos abiertos del mapa, elimina los que tengan bloqueos abiertos o una persona asignada, y elige el primero según el orden del mapa.
+- Reclamar: `gh issue edit <n> --add-assignee @me`. Esta debe ser la primera escritura de la sesión.
+- Resolver: `gh issue comment <n> --body "<answer>"`, después `gh issue close <n>`, y añade al mapa un enlace al contexto de la decisión.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,13 @@
+# Etiquetas de triage
+
+Las skills usan cinco roles canónicos de triage. Este archivo relaciona cada rol con la etiqueta real del issue tracker.
+
+| Rol de mattpocock/skills | Etiqueta en este repositorio | Significado |
+| --- | --- | --- |
+| `needs-triage` | `needs-triage` | El mantenedor debe evaluar el issue |
+| `needs-info` | `needs-info` | Falta información del autor |
+| `ready-for-agent` | `ready-for-agent` | El issue está definido y listo para un agente |
+| `ready-for-human` | `ready-for-human` | Requiere implementación humana |
+| `wontfix` | `wontfix` | No se va a atender |
+
+Cuando una skill mencione un rol, usa la etiqueta correspondiente de la segunda columna.

--- a/docs/content/question-types.md
+++ b/docs/content/question-types.md
@@ -1,0 +1,237 @@
+# Tipos de pregunta y conversión a TypeScript
+
+Las preguntas se escriben como objetos `Question[]` en `src/subjects/<subject-id>/questions.ts`. El enunciado y las soluciones admiten Markdown, fórmulas LaTeX, tablas y bloques de código.
+
+Cada pregunta necesita estos campos:
+
+```ts
+{
+	id: "2024_q1",
+	examId: "2024",
+	topic: "topic-1",
+	type: "mc",
+	points: 10,
+	question: "...",
+	correctAnswer: "...",
+}
+```
+
+Usa el identificador real del examen o recopilatorio en `examId` y una clave válida de `topic`. No copies al campo `question` el número de la pregunta ni su puntuación si ya están representados por `id` y `points`.
+
+## Test
+
+Usa `mc` cuando la pregunta tiene opciones cerradas y una respuesta correcta. `correctAnswer` es la letra en minúscula.
+
+Markdown de origen:
+
+```md
+2. [10 puntos] ¿Cuál es la capital de Francia? Marca la respuesta correcta.
+- [ ] Londres
+- [X] París
+- [ ] Berlín
+- [ ] Madrid
+- [ ] Roma
+```
+
+Conversión:
+
+```ts
+{
+	id: "2024_q1",
+	examId: "2024",
+	topic: "topic-1",
+	type: "mc",
+	points: 10,
+	question: "¿Cuál es la capital de Francia?",
+	options: [
+		"A. Londres",
+		"B. París",
+		"C. Berlín",
+		"D. Madrid",
+		"E. Roma",
+	],
+	correctAnswer: "b",
+}
+```
+
+Puedes añadir `explanation` para mostrar una explicación adicional después de corregir la pregunta.
+
+## Texto
+
+Usa `text` para una respuesta abierta. La solución de referencia va en `correctAnswer` y el estudiante la usa para autoevaluarse.
+
+Markdown de origen:
+
+```md
+3. [5 puntos] Explica por qué una caché mejora el rendimiento de un programa.
+
+Solución esperada: reduce el tiempo de acceso al reutilizar datos cercanos o usados recientemente.
+```
+
+Conversión:
+
+```ts
+{
+	id: "2024_q2",
+	examId: "2024",
+	topic: "arquitectura",
+	type: "text",
+	points: 5,
+	question: "Explica por qué una caché mejora el rendimiento de un programa.",
+	correctAnswer:
+		"Una caché reduce el tiempo de acceso al reutilizar datos cercanos o usados recientemente.",
+}
+```
+
+Conserva en `question` el contexto necesario, incluidos Markdown, fórmulas y código. No pongas la solución dentro del enunciado.
+
+## Emparejamiento
+
+Usa `matching` para relacionar cada elemento con una opción. Las claves de `correctAnswer` son los elementos que aparecen en la pregunta y sus valores son las letras de las opciones correctas.
+
+Markdown de origen:
+
+```md
+4. [4 puntos] Relaciona cada algoritmo con su complejidad.
+- Ordenación burbuja: A. O(n²)
+- Búsqueda binaria: B. O(log n)
+- Búsqueda lineal: C. O(n)
+```
+
+Conversión:
+
+```ts
+{
+	id: "2024_q3",
+	examId: "2024",
+	topic: "algoritmos",
+	type: "matching",
+	points: 4,
+	question: "Relaciona cada algoritmo con su complejidad.",
+	correctAnswer: {
+		"Ordenación burbuja": "A",
+		"Búsqueda binaria": "B",
+		"Búsqueda lineal": "C",
+	},
+}
+```
+
+El emparejamiento puede recibir puntuación parcial. Usa `explanation` para la explicación o una tabla de soluciones.
+
+## Rellenar huecos
+
+Usa `fill` cuando el estudiante debe escribir una o varias respuestas cortas. Cada entrada de `fillStatements` representa un campo y contiene exactamente un marcador `{{blank}}`.
+
+Markdown de origen:
+
+```md
+5. [2 puntos] Completa el cálculo.
+a) 2 + 2 = ______
+b) 3 × 4 = ______
+```
+
+Conversión:
+
+```ts
+{
+	id: "2024_q4",
+	examId: "2024",
+	topic: "aritmética",
+	type: "fill",
+	points: 2,
+	question: "Completa el cálculo.",
+	fillStatements: [
+		{ label: "a)", text: "2 + 2 = {{blank}}" },
+		{ label: "b)", text: "3 × 4 = {{blank}}" },
+	],
+	correctAnswer: ["4", "12"],
+}
+```
+
+Los valores de `correctAnswer` siguen el orden de `fillStatements`. Puedes añadir `development` para mostrar el procedimiento después de revisar la respuesta.
+
+## Rellenar tablas
+
+Usa `table-fill` cuando los huecos forman parte de una tabla. En `tableFill.rows`, escribe `{{blank}}` solo en las celdas que el estudiante debe completar.
+
+Markdown de origen:
+
+```md
+6. [2 puntos] Completa la tabla.
+
+| Expresión | Resultado |
+| --- | --- |
+| 5 + 3 | ______ |
+| 6 × 2 | ______ |
+```
+
+Conversión:
+
+```ts
+{
+	id: "2024_q5",
+	examId: "2024",
+	topic: "aritmética",
+	type: "table-fill",
+	points: 2,
+	question: "Completa la tabla.",
+	tableFill: {
+		headers: ["Expresión", "Resultado"],
+		rows: [
+			["5 + 3", "{{blank}}"],
+			["6 × 2", "{{blank}}"],
+		],
+	},
+	correctAnswer: ["8", "12"],
+}
+```
+
+Las respuestas siguen el orden de las filas y, dentro de cada fila, el orden de las celdas vacías.
+
+## Texto con varias partes
+
+Usa `multiple-text` cuando un enunciado contiene varias preguntas abiertas que deben responderse por separado. `textParts` contiene los apartados y `correctAnswer` contiene una solución modelo por apartado, en el mismo orden.
+
+Markdown de origen:
+
+```md
+7. [5 puntos] Responde las siguientes cuestiones.
+a) Define una variable.
+b) Define una constante. [3 puntos]
+```
+
+Conversión:
+
+```ts
+{
+	id: "2024_q6",
+	examId: "2024",
+	topic: "programación",
+	type: "multiple-text",
+	points: 5,
+	question: "Responde las siguientes cuestiones.",
+	textParts: [
+		{ label: "a)", text: "Define una variable." },
+		{ label: "b)", points: 3, text: "Define una constante." },
+	],
+	correctAnswer: [
+		"Una variable es un nombre asociado a un valor que puede cambiar durante la ejecución.",
+		"Una constante es un nombre asociado a un valor que no cambia durante la ejecución.",
+	],
+}
+```
+
+Los apartados sin `points` comparten a partes iguales los puntos restantes. Cada apartado se autoevalúa por separado y puede incluir `explanationImage`.
+
+## Cuando ningún tipo encaja
+
+El catálogo de tipos puede crecer. Si una pregunta no se adapta bien a un tipo existente, crea un tipo nuevo en lugar de deformar otro.
+
+1. Añade el nuevo identificador a `QuestionType` en `src/data/types.ts`.
+2. Define los campos específicos que necesite la pregunta.
+3. Añade su renderizado en `src/components/QuestionCard.tsx`.
+4. Añade su corrección y cálculo de puntuación en `src/lib/grading.ts`.
+5. Incluye un ejemplo en `src/subjects/_template/questions.ts` y actualiza esta guía.
+6. Ejecuta `pnpm check`, `pnpm typecheck` y `pnpm build`.
+
+El nuevo tipo debe representar una estructura de pregunta que no pueda expresarse con claridad usando los tipos actuales.

--- a/docs/content/question-types.md
+++ b/docs/content/question-types.md
@@ -87,15 +87,15 @@ Conserva en `question` el contexto necesario, incluidos Markdown, fórmulas y c�
 
 ## Emparejamiento
 
-Usa `matching` para relacionar cada elemento con una opción. Las claves de `correctAnswer` son los elementos que aparecen en la pregunta y sus valores son las letras de las opciones correctas.
+Usa `matching` para relacionar cada elemento con una respuesta. Las claves de `correctAnswer` son los elementos que aparecen en la pregunta y sus valores son las respuestas correctas. Para afirmaciones de verdadero o falso, usa `V` para Verdadero y `F` para Falso.
 
 Markdown de origen:
 
 ```md
-4. [4 puntos] Relaciona cada algoritmo con su complejidad.
-- Ordenación burbuja: A. O(n²)
-- Búsqueda binaria: B. O(log n)
-- Búsqueda lineal: C. O(n)
+4. [4 puntos] Marca V si la afirmación es verdadera y F si es falsa.
+- La búsqueda binaria necesita que los datos estén ordenados: V o F
+- La búsqueda lineal tiene complejidad O(log n): V o F
+- La ordenación burbuja puede tener complejidad O(n²): V o F
 ```
 
 Conversión:
@@ -107,11 +107,11 @@ Conversión:
 	topic: "algoritmos",
 	type: "matching",
 	points: 4,
-	question: "Relaciona cada algoritmo con su complejidad.",
+	question: "Marca V si la afirmación es verdadera y F si es falsa.",
 	correctAnswer: {
-		"Ordenación burbuja": "A",
-		"Búsqueda binaria": "B",
-		"Búsqueda lineal": "C",
+		"La búsqueda binaria necesita que los datos estén ordenados": "V",
+		"La búsqueda lineal tiene complejidad O(log n)": "F",
+		"La ordenación burbuja puede tener complejidad O(n²)": "V",
 	},
 }
 ```


### PR DESCRIPTION
# Pull request

Este cambio documenta el vocabulario, las decisiones de dominio y las convenciones para contribuir al proyecto. También actualiza las plantillas de issues y pull requests para recoger mejor la autorización del contenido, los tipos de pregunta y el contexto necesario para revisar contribuciones.

## Cambios

- Añadido `CONTEXT.md` con el glosario del dominio.
- Añadidos ADRs sobre exámenes, recopilatorios y reglas de puntuación.
- Añadida documentación para agentes, triage y tipos de pregunta.
- Actualizado `CONTRIBUTING.md` con las convenciones actuales para asignaturas, contenido, documentación y comprobaciones.
- Simplificadas y уточadas las plantillas de issues para material, preguntas y asignaturas.
- Actualizada la plantilla de pull request con la comprobación de `pnpm readme`.

La limitación principal es que la configuración detallada de penalizaciones continúa pendiente del issue #45.

## Issue relacionada

No aplica.

## Tipo de cambio

- [ ] Contenido o preguntas
- [ ] Interfaz o accesibilidad
- [ ] Rendimiento, SEO, Optimizaciones
- [x] Herramientas o documentación

## Comprobaciones

- [ ] `pnpm check`
- [ ] `pnpm typecheck`
- [ ] `pnpm lint`
- [ ] `pnpm build`
- [ ] `pnpm run doctor`
- [ ] He probado el preview si el cambio afecta al comportamiento o al aspecto de la app.

## Revisión específica

- [ ] He probado las rutas y los idiomas afectados.
- [ ] He revisado el comportamiento en mobile si el cambio afecta a la interfaz.
- [ ] He comprobado teclado y nombres accesibles si el cambio afecta a controles.
- [ ] He revisado title, description, Open Graph y sitemap si el cambio afecta al SEO.

## Capturas o notas para revisar

Cambio exclusivamente documental y de configuración del repositorio. Revisar especialmente la terminología de `CONTEXT.md`, los ADRs y las instrucciones de `CONTRIBUTING.md`.

## Checklist

- [x] No he incluido secretos ni archivos generados innecesarios.
- [x] He actualizado la documentación relacionada.
- [x] Esta PR está lista para revisión.



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR establishes domain vocabulary and contribution conventions while updating issue and pull-request templates.
- Adds the root domain glossary, accepted decision records, and agent guidance.
- Documents supported question structures and content-authoring workflows.
- Updates contribution forms to collect source, authorization, and subject context.
</details>


<h3>Confidence Score: 3/5</h3>

The PR does not yet appear safe to merge because the required report-source field is not prefilled and the canonical progress definition contradicts the current persisted scoring model.

Question-report links still omit a newly required identifier despite having the source ID available, and the new canonical glossary directs future work toward per-question progress semantics that the current aggregate-attempt store neither implements nor persists.

**Files Needing Attention:** .github/ISSUE_TEMPLATE/report-question.yml, src/components/QuestionCard.tsx, src/components/Disclaimer.tsx, CONTEXT.md, src/data/store.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| CONTEXT.md | Adds the canonical domain glossary, but its per-question progress definition remains inconsistent with the aggregate-attempt implementation. |
| .github/ISSUE_TEMPLATE/report-question.yml | Adds a required source identifier that remains missing from both existing prefilled report links. |
| docs/content/question-types.md | Documents supported question structures and replaces the previously ambiguous matching example with a self-contained true/false example. |
| CONTRIBUTING.md | Expands contribution, domain-documentation, content-rights, and validation guidance. |
| docs/adr/0001-examenes-y-recopilatorios.md | Records the naming distinction between exams and community compilations. |
| docs/adr/0002-reglas-de-puntuacion.md | Records intended practice and simulation scoring rules and identifies pending penalty configuration. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs(question-types): clarify true-false..."](https://github.com/teenbiscuits/pasame-examenes/commit/fc0de58293797733e2bea4250b09e2acd78abf32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57299191)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Content contribution workflows](https://app.greptile.com/pablopl/-/custom-context/knowledge-base/teenbiscuits/pasame-examenes/-/docs/content-contribution-workflows.md)
- Knowledge Base — [Session state and progress](https://app.greptile.com/pablopl/-/custom-context/knowledge-base/teenbiscuits/pasame-examenes/-/docs/session-state-and-progress.md)
- Knowledge Base — [Subject content authoring](https://app.greptile.com/pablopl/-/custom-context/knowledge-base/teenbiscuits/pasame-examenes/-/docs/subject-content-authoring.md)
</details>


<!-- /greptile_comment -->