### PR TITLE
Optimiza la carga de rutas y añade benchmarks con Unlighthouse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ todos.json
 
 # Pásame Exámenes .gitignore
 .vercel
+/unlighthouse/
 temp
 reference
 src/subjects/contentStats.generated.ts

--- a/biome.json
+++ b/biome.json
@@ -21,6 +21,11 @@
 		"enabled": true,
 		"indentStyle": "tab"
 	},
+	"css": {
+		"parser": {
+			"tailwindDirectives": true
+		}
+	},
 	"assist": { "actions": { "source": { "organizeImports": "on" } } },
 	"linter": {
 		"enabled": true,

--- a/docs/performance/unlighthouse.md
+++ b/docs/performance/unlighthouse.md
@@ -1,0 +1,71 @@
+# Auditoría local de rendimiento
+
+La configuración vive en `unlighthouse.config.ts` y usa Unlighthouse `0.18.0`.
+Los informes generados se guardan en `unlighthouse/runs/`, una carpeta ignorada
+por Git. Los JSON históricos que ya existen en `unlighthouse/` también se
+mantienen solo localmente.
+
+## Medición recomendada
+
+Primero genera y sirve el build de producción:
+
+```bash
+pnpm build
+pnpm perf:preview
+```
+
+Deja ese proceso ejecutándose y, en otra terminal, lanza el conjunto rápido:
+
+```bash
+pnpm perf:baseline
+```
+
+Este conjunto mide las siete URLs representativas usadas en el baseline:
+
+- `/es`
+- `/es/bede`
+- `/es/calculo/exam/2023-01`
+- `/es/deese/practice/intro-y-objetos`
+- `/es/esei/exam/2025-07`
+- `/es/iesede`
+- `/es/privacy`
+
+Unlighthouse abre su panel local para consultar los resultados. Para generar
+un JSON expandido sin el panel, usa:
+
+```bash
+pnpm perf:baseline:json
+```
+
+La variante `:json` es la recomendada para comparar cambios: ejecuta las tres
+muestras por URL y deja el resultado en `unlighthouse/runs/ci-result.json`.
+La configuración inicializa un `localStorage` y un `sessionStorage` aislados
+para que el popup de GitHub y su contador no alteren las mediciones; los
+informes siguen siendo locales y no se suben al repositorio.
+
+## Escaneo completo
+
+Para descubrir todas las URLs mediante el sitemap y el crawler:
+
+```bash
+pnpm perf:full
+```
+
+El resultado JSON se puede generar con:
+
+```bash
+pnpm perf:full:json
+```
+
+El servidor local se inicia con `SITE_URL` para que el sitemap devuelva URLs
+locales. Si usas otro puerto o un servidor de desarrollo, define ambas
+variables al iniciar y al escanear:
+
+```bash
+SITE_URL=http://127.0.0.1:3000 pnpm dev
+UNLIGHTHOUSE_SITE=http://127.0.0.1:3000 pnpm perf:baseline
+```
+
+La configuración usa móvil, throttling, tres muestras por URL y ejecuciones
+seriales. Esto mantiene el benchmark comparable con las exportaciones
+originales y evita ráfagas innecesarias de peticiones externas.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,11 @@
     "prebuild": "pnpm run generate-build-assets",
     "build": "vite build",
     "preview": "vite preview",
+    "perf:preview": "SITE_URL=http://127.0.0.1:4173 pnpm preview --host 127.0.0.1 --port 4173",
+    "perf:baseline": "unlighthouse --urls /es,/es/bede,/es/calculo/exam/2023-01,/es/deese/practice/intro-y-objetos,/es/esei/exam/2025-07,/es/iesede,/es/privacy",
+    "perf:baseline:json": "unlighthouse-ci --urls /es,/es/bede,/es/calculo/exam/2023-01,/es/deese/practice/intro-y-objetos,/es/esei/exam/2025-07,/es/iesede,/es/privacy --reporter jsonExpanded",
+    "perf:full": "unlighthouse --disable-dynamic-sampling",
+    "perf:full:json": "unlighthouse-ci --disable-dynamic-sampling --reporter jsonExpanded",
     "pretypecheck": "pnpm run generate-content-stats",
     "typecheck": "tsc --noEmit",
     "readme": "tsx scripts/update-readme-subjects.ts",
@@ -63,6 +68,7 @@
     "@vitejs/plugin-react": "^6.1.0",
     "tsx": "^4.23.12",
     "typescript": "^6.0.3",
+    "unlighthouse": "0.18.0",
     "vite": "^8.2.2",
     "vite-imagetools": "^12.0.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ importers:
         version: 1.168.49(crossws@0.4.12(srvx@0.11.22))(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
       boneyard-js:
         specifier: ^1.9.0
-        version: 1.9.0(react@19.2.8)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+        version: 1.9.0(react@19.2.8)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))(vue@3.5.41(typescript@6.0.3))
       cuelume:
         specifier: ^0.2.2
         version: 0.2.2
@@ -46,7 +46,7 @@ importers:
         version: 0.18.4
       nitro:
         specifier: 3.0.260610-beta
-        version: 3.0.260610-beta(chokidar@5.0.0)(jiti@2.7.0)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+        version: 3.0.260610-beta(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(lru-cache@11.5.2)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -95,7 +95,7 @@ importers:
         version: 0.8.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
       '@tanstack/react-hotkeys-devtools':
         specifier: ^0.7.0
-        version: 0.7.0(@tanstack/hotkeys@0.8.0)(@types/react-dom@19.2.5(@types/react@19.2.18))(@types/react@19.2.18)(csstype@3.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(solid-js@1.9.15)
+        version: 0.7.0(@tanstack/hotkeys@0.8.0)(@types/react-dom@19.2.5(@types/react@19.2.18))(@types/react@19.2.18)(csstype@3.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(solid-js@1.9.15)(vue@3.5.41(typescript@6.0.3))
       '@tanstack/router-cli':
         specifier: ^1.167.33
         version: 1.167.33
@@ -120,6 +120,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      unlighthouse:
+        specifier: 0.18.0
+        version: 0.18.0(33e19f5c7fc2330f694693c9203e763e)
       vite:
         specifier: ^8.2.2
         version: 8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)
@@ -128,6 +131,24 @@ importers:
         version: 12.0.0(@types/node@22.20.1)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
 
 packages:
+
+  '@alloc/quick-lru@5.2.0':
+    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
+    engines: {node: '>=10'}
+
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
+  '@apm-js-collab/code-transformer-bundler-plugins@0.7.4':
+    resolution: {integrity: sha512-nAfOeZPSUAQvJa1iFT/5oCrTm5YQhMMrfCNthNnaXHZiOQhu1KGuLoIx7HtbAi3wfwaBYLaICPIeenIaEwcXIg==}
+    engines: {node: '>=18.0.0'}
+
+  '@apm-js-collab/code-transformer@0.18.1':
+    resolution: {integrity: sha512-u1Hb6bHjWtkSpiprwVP6YaHC1DTN4RAU3zYkUDUe7WMnJwdyU1pwTL9dFKiSJB9IiLue/EQovmyx6xhU7FFtAQ==}
+    hasBin: true
+
+  '@apm-js-collab/tracing-hooks@0.13.0':
+    resolution: {integrity: sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw==}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -261,8 +282,20 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@capsizecss/unpack@4.0.1':
+    resolution: {integrity: sha512-CuNiSqg7+e1cO/GjffyMOm5Tt2jUF9CWHHnvQ/UkqvtkGfHdgwEC0wpmq7fkN3gxwpRnrAN0WzO3vREKmNolMQ==}
+    engines: {node: '>=18'}
+
   '@chenglou/pretext@0.0.5':
     resolution: {integrity: sha512-A8GZN10REdFGsyuiUgLV8jjPDDFMg5GmgxGWV0I3igxBOnzj+jgz2VMmVD7g+SFyoctfeqHFxbNatKSzVRWtRg==}
+
+  '@clack/core@1.4.3':
+    resolution: {integrity: sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==}
+    engines: {node: '>= 20.12.0'}
+
+  '@clack/prompts@1.7.0':
+    resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
+    engines: {node: '>= 20.12.0'}
 
   '@emnapi/core@1.11.3':
     resolution: {integrity: sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==}
@@ -273,16 +306,34 @@ packages:
   '@emnapi/wasi-threads@1.2.3':
     resolution: {integrity: sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==}
 
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.28.2':
     resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.28.2':
     resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.28.2':
@@ -291,16 +342,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.28.2':
     resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.28.2':
     resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.28.2':
@@ -309,10 +378,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.28.2':
     resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.28.2':
@@ -321,10 +402,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.28.2':
     resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.28.2':
@@ -333,10 +426,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.28.2':
     resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.28.2':
@@ -345,10 +450,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.28.2':
     resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.28.2':
@@ -357,10 +474,22 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.28.2':
     resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.28.2':
@@ -369,16 +498,34 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.28.2':
     resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.28.2':
     resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.28.2':
@@ -387,10 +534,22 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.28.2':
     resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.28.2':
@@ -399,11 +558,23 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/openharmony-arm64@0.28.2':
     resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.28.2':
     resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
@@ -411,10 +582,22 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.28.2':
     resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
     os: [win32]
 
   '@esbuild/win32-ia32@0.28.2':
@@ -423,17 +606,64 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
   '@esbuild/win32-x64@0.28.2':
     resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
+  '@floating-ui/core@1.8.0':
+    resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
+
+  '@floating-ui/dom@1.8.0':
+    resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
+
+  '@floating-ui/utils@0.2.12':
+    resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
+
+  '@floating-ui/vue@1.1.11':
+    resolution: {integrity: sha512-HzHKCNVxnGS35r9fCHBc3+uCnjw9IWIlCPL683cGgM9Kgj2BiAl8x1mS7vtvP6F9S/e/q4O6MApwSHj8hNLGfw==}
+
   '@fontsource-variable/cascadia-code@5.3.0':
     resolution: {integrity: sha512-6I6M029Lum62MGmP0o+rXRrIBiIiptNDC4slPKLPUJiSB7NHZTLb+Ihk9G7jLvUfWziGXHJLjJPJLBzlEPjS1g==}
 
   '@fontsource-variable/onest@5.3.0':
     resolution: {integrity: sha512-K4Es0F3M+iFnVY5mfunimhPSk1Uvl3eyovQVWjtf8oS00a7WSrSg2BD5Bh/pAcAZUe4ocV4M08dg5tvCULBJ7Q==}
+
+  '@formatjs/ecma402-abstract@2.3.6':
+    resolution: {integrity: sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==}
+
+  '@formatjs/fast-memoize@2.2.7':
+    resolution: {integrity: sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==}
+
+  '@formatjs/icu-messageformat-parser@2.11.4':
+    resolution: {integrity: sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==}
+
+  '@formatjs/icu-skeleton-parser@1.8.16':
+    resolution: {integrity: sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==}
+
+  '@formatjs/intl-localematcher@0.6.2':
+    resolution: {integrity: sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==}
+
+  '@iconify/collections@1.0.728':
+    resolution: {integrity: sha512-vzRn5TOgHv5cp/gpXQ42FfywPxa2htotIypQfSVt7GXiMHeYzmawMDii2IYHFYNmpWyamuMzvMci/JlNz9epkw==}
+
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/utils@3.1.4':
+    resolution: {integrity: sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==}
+
+  '@iconify/vue@5.0.1':
+    resolution: {integrity: sha512-aumwwooJlFJ5H5qYWB6ZTAyM0C8hpfcSVLB9/a3qnH1GGvIJ+FEbpEs4s/HfErYe/M5qZeLjwmESR5fFm3lXEw==}
+    peerDependencies:
+      vue: '>=3.0.0'
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -597,6 +827,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@internationalized/date@3.12.3':
+    resolution: {integrity: sha512-fuLX+3ZKLsxI73y8b01EG/WjHb6gE6weCqlfawPO27kBWGMh9G1yH6Csv1uU7/cac9H2GHmOMt6CjmuQ1aia4Q==}
+
+  '@internationalized/number@3.6.7':
+    resolution: {integrity: sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -612,6 +848,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@lhci/utils@0.15.1':
+    resolution: {integrity: sha512-WclJnUQJeOMY271JSuaOjCv/aA0pgvuHZS29NFNdIeI14id8eiFsjith85EGKYhljgoQhJ2SiW4PsVfFiakNNw==}
 
   '@napi-rs/canvas-android-arm64@1.0.8':
     resolution: {integrity: sha512-5+nkh8i3gt6lqS/d2jTZ1xAn6tdgtB4Lf1mW6T0Qm5/rXNwBuV1sAEyLEWan5o9gJPU/GuvHR3rvSeZ+FaGrbw==}
@@ -704,6 +943,90 @@ packages:
       '@neodrag/core': 3.0.0-next.11
       solid-js: ^1.0.0
 
+  '@nodable/entities@3.0.0':
+    resolution: {integrity: sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==}
+
+  '@nuxt/devtools-kit@3.4.2':
+    resolution: {integrity: sha512-TPPbmH9xrExagYxfCe6JgtbHmgchfgDdA656Yws18rn8I/oCvB+gcw3kTWBBp2sC9ipZPXsgbsW/yZnVnGNBiA==}
+    peerDependencies:
+      vite: '>=6.0'
+
+  '@nuxt/fonts@0.14.0':
+    resolution: {integrity: sha512-4uXQl9fa5F4ibdgU8zomoOcyMdnwgdem+Pi8JEqeDYI5yPR32Kam6HnuRr47dTb97CstaepAvXPWQUUHMtjsFQ==}
+
+  '@nuxt/icon@2.5.1':
+    resolution: {integrity: sha512-zBP72Po7BS+tXzoeDRA/Y9TTY77OIcNCyzfgXsOmep7zZShTEoe4p1WZBXce/9oJDK3YXmbYC3ILQ7XvqM4/XA==}
+
+  '@nuxt/kit@4.5.2':
+    resolution: {integrity: sha512-l66LU9DcJYjmNwqwAj2I5UGRrUbnG2DOKGChnN70zIGtn0eq/z87gi/FRgha6eMb9/FmB1PFHgtx6PWVml1C2Q==}
+    engines: {node: '>=18.12.0'}
+
+  '@nuxt/schema@4.5.2':
+    resolution: {integrity: sha512-h9g1kt9O2iU9nX6HDFu9gvwtpn+8oSJX0RSTWRBnEx/Pkz+WlOHtjuS0SbkTAXw5aT1+H1GysWVwNTjJfBY/0w==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  '@nuxt/ui@4.11.0':
+    resolution: {integrity: sha512-gDs67/fWk3kipcEV4Pc5h1VnZD1glfWfINmJU7s3qpkxxRTkfkPxnUszXG664whNWcoqucS1WgZ/rNjZa3pTMw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@inertiajs/vue3': ^2.0.7 || ^3.0.0
+      '@internationalized/date': ^3.0.0
+      '@internationalized/number': ^3.0.0
+      '@nuxt/content': ^3.0.0
+      '@tiptap/core': ^3
+      '@tiptap/extension-bubble-menu': ^3
+      '@tiptap/extension-code': ^3
+      '@tiptap/extension-collaboration': ^3
+      '@tiptap/extension-drag-handle': ^3
+      '@tiptap/extension-drag-handle-vue-3': ^3
+      '@tiptap/extension-floating-menu': ^3
+      '@tiptap/extension-horizontal-rule': ^3
+      '@tiptap/extension-image': ^3
+      '@tiptap/extension-mention': ^3
+      '@tiptap/extension-node-range': ^3
+      '@tiptap/extension-placeholder': ^3
+      '@tiptap/markdown': ^3
+      '@tiptap/pm': ^3
+      '@tiptap/starter-kit': ^3
+      '@tiptap/suggestion': ^3
+      '@tiptap/vue-3': ^3
+      ai: ^6 || ^7
+      joi: ^18.0.0
+      superstruct: ^2.0.0
+      tailwindcss: ^4.0.0
+      typescript: ^5.6.3 || ^6.0.0 || ^7.0.0
+      valibot: ^1.0.0
+      vue-router: ^4.5.0 || ^5.0.0
+      yup: ^1.7.0
+      zod: ^3.24.0 || ^4.0.0
+    peerDependenciesMeta:
+      '@inertiajs/vue3':
+        optional: true
+      '@internationalized/date':
+        optional: true
+      '@internationalized/number':
+        optional: true
+      '@nuxt/content':
+        optional: true
+      ai:
+        optional: true
+      joi:
+        optional: true
+      superstruct:
+        optional: true
+      valibot:
+        optional: true
+      vue-router:
+        optional: true
+      yup:
+        optional: true
+      zod:
+        optional: true
+
+  '@nuxtjs/color-mode@4.0.1':
+    resolution: {integrity: sha512-eiA7hWXi5zNHaYKyJFCGF6i0wFZtuvR7KDXZ6jiSvwxjCpRFwphrw0MOSmNfArTSSsT1wpW+/2H92cejeVfUlg==}
+
   '@oozcitak/dom@2.0.2':
     resolution: {integrity: sha512-GjpKhkSYC3Mj4+lfwEyI1dqnsKTgwGy48ytZEhm4A/xnH/8z9M3ZVXKr/YGQi3uCLs1AEBS+x5T2JPiueEDW8w==}
     engines: {node: '>=20.0'}
@@ -719,6 +1042,48 @@ packages:
   '@oozcitak/util@10.0.0':
     resolution: {integrity: sha512-hAX0pT/73190NLqBPPWSdBVGtbY6VOhWYK3qqHqtXQ1gK7kS2yz4+ivsN07hpJ6I3aeMtKP6J6npsEKOAzuTLA==}
     engines: {node: '>=20.0'}
+
+  '@opentelemetry/api-logs@0.220.0':
+    resolution: {integrity: sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/core@2.10.0':
+    resolution: {integrity: sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/instrumentation@0.220.0':
+    resolution: {integrity: sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@2.10.0':
+    resolution: {integrity: sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.10.0':
+    resolution: {integrity: sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace@2.10.0':
+    resolution: {integrity: sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.43.0':
+    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
+    engines: {node: '>=14'}
 
   '@oxc-parser/binding-android-arm-eabi@0.120.0':
     resolution: {integrity: sha512-WU3qtINx802wOl8RxAF1v0VvmC2O4D9M8Sv486nLeQ7iPHVmncYZrtBhB4SYyX+XZxj2PNnCcN+PW21jHgiOxg==}
@@ -853,6 +1218,39 @@ packages:
   '@oxc-project/types@0.146.0':
     resolution: {integrity: sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA==}
 
+  '@parcel/watcher-wasm@2.6.0':
+    resolution: {integrity: sha512-dtjbDxKSDPQ8AmA+pS4OFaHE1FKrjtGpLGBxw85uKFkRorjNbvDM/aFPgqosu40wprbp1xw2ZSxIKqghCUHe2w==}
+    engines: {node: '>= 10.0.0'}
+    bundledDependencies:
+      - napi-wasm
+
+  '@paulirish/trace_engine@0.0.53':
+    resolution: {integrity: sha512-PUl/vlfo08Oj804VI5nDPeSk9vyslnBlVzDDwFt8SUVxY8+KdGMkra/vrXjEEHe8gb7+RqVTfOIlGw0nyrEelA==}
+
+  '@paulirish/trace_engine@0.0.65':
+    resolution: {integrity: sha512-Qsm6F5C8xf6ZzQXbQc2+wcpe6sggfs/gvc/ytqSurdvYg3kyW0ECHCqE0CWBKZpqgjVfPNX9c7SCS3r2nEIRGg==}
+
+  '@polka/url@1.0.0-next.29':
+    resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@puppeteer/browsers@2.13.2':
+    resolution: {integrity: sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@puppeteer/browsers@3.2.1':
+    resolution: {integrity: sha512-KDz+3qDRdBAlRlMjmKyj6dEs33YHTk/xRHEENSXq6TNnhgoU15ruSHtEBeVF6OZ9tBDY55Se4P0nFMNsipzU9A==}
+    engines: {node: '>=22.12.0'}
+    hasBin: true
+    peerDependencies:
+      proxy-agent: '>=8.0.1'
+      yauzl: ^2.10.0 || ^3.4.0
+    peerDependenciesMeta:
+      proxy-agent:
+        optional: true
+      yauzl:
+        optional: true
+
   '@rolldown/binding-android-arm-eabi@1.2.5':
     resolution: {integrity: sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -961,6 +1359,79 @@ packages:
       rollup:
         optional: true
 
+  '@sentry-internal/tracing@7.120.4':
+    resolution: {integrity: sha512-Fz5+4XCg3akeoFK+K7g+d7HqGMjmnLoY2eJlpONJmaeT9pXY7yfUyXKZMmMajdE2LxxKJgQ2YKvSCaGVamTjHw==}
+    engines: {node: '>=8'}
+
+  '@sentry/conventions@0.16.0':
+    resolution: {integrity: sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==}
+    engines: {node: '>=14'}
+
+  '@sentry/core@10.71.0':
+    resolution: {integrity: sha512-OIjT7rzcWJjUC6r3eBT3Td1j0afDBMkbbx9jTocSD+ZSfc25eEU7hoIPS0WvfeIOTIN3y8bfQnXavwMReaNVHQ==}
+    engines: {node: '>=18'}
+
+  '@sentry/core@7.120.4':
+    resolution: {integrity: sha512-TXu3Q5kKiq8db9OXGkWyXUbIxMMuttB5vJ031yolOl5T/B69JRyAoKuojLBjRv1XX583gS1rSSoX8YXX7ATFGA==}
+    engines: {node: '>=8'}
+
+  '@sentry/integrations@7.120.4':
+    resolution: {integrity: sha512-kkBTLk053XlhDCg7OkBQTIMF4puqFibeRO3E3YiVc4PGLnocXMaVpOSCkMqAc1k1kZ09UgGi8DxfQhnFEjUkpA==}
+    engines: {node: '>=8'}
+
+  '@sentry/node-core@10.71.0':
+    resolution: {integrity: sha512-sxd0/ZW+Uda/17H0R7lB2Othm37VYcdwKdWdyHRizg872TfCX4UwTTPaoS2tMJAUjV2tVh83ZA0fsoC2q9SpjA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/exporter-trace-otlp-http': '>=0.57.0 <1'
+      '@opentelemetry/instrumentation': '>=0.57.1 <1'
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/core':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-http':
+        optional: true
+      '@opentelemetry/instrumentation':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+
+  '@sentry/node@10.71.0':
+    resolution: {integrity: sha512-bw2M/xkMu2+ATo6QWFmtTZTYp5LV1krt9/DTtYqtt4GmhXmXgdFPXCv6783AJI3HUoEMx2BcehhNbKzGrFXo/g==}
+    engines: {node: '>=18'}
+
+  '@sentry/node@7.120.4':
+    resolution: {integrity: sha512-qq3wZAXXj2SRWhqErnGCSJKUhPSlZ+RGnCZjhfjHpP49KNpcd9YdPTIUsFMgeyjdh6Ew6aVCv23g1hTP0CHpYw==}
+    engines: {node: '>=8'}
+
+  '@sentry/opentelemetry@10.71.0':
+    resolution: {integrity: sha512-YgeL0xTObKma3MuOrt+/6M/f6mo/Z08LHh3OxPomzQpgpCgCLGyJ/739cDSSH1LRjqWdPQtoia5asl5ZRdhWmw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+
+  '@sentry/server-utils@10.71.0':
+    resolution: {integrity: sha512-zdyShKNsghzPGVWVRzc7oybYTsRZdKgdPtq+dsksImo1b6n7ILlD7eYx1Q0eAOZoWkDqDmm+Ml6MQb76IT1eTA==}
+    engines: {node: '>=18'}
+
+  '@sentry/types@7.120.4':
+    resolution: {integrity: sha512-cUq2hSSe6/qrU6oZsEP4InMI5VVdD86aypE+ENrQ6eZEVLTCYm1w6XhW1NvIu3UuWh7gZec4a9J7AFpYxki88Q==}
+    engines: {node: '>=8'}
+
+  '@sentry/utils@7.120.4':
+    resolution: {integrity: sha512-zCKpyDIWKHwtervNK2ZlaK8mMV7gVUijAgFeJStH+CU/imcdquizV3pFLlSQYRswG+Lbyd6CT/LGRh3IbtkCFw==}
+    engines: {node: '>=8'}
+
+  '@sindresorhus/is@5.6.0':
+    resolution: {integrity: sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==}
+    engines: {node: '>=14.16'}
+
   '@solid-primitives/event-listener@2.4.6':
     resolution: {integrity: sha512-5I0YJcTVYIWoMmgBSROBZGcz+ymhew/pGTg2dHW74BUjFKsV8Li4bOZYl0YAGP4mHw5o4UBd9/BEesqBci3wxw==}
     peerDependencies:
@@ -990,6 +1461,16 @@ packages:
     resolution: {integrity: sha512-ISSB5QX1qP2ynrheIpYwc4oKR5Ny4siNuUyf1qZniy+Il+p/PtDB0QK1Dnle8noiHpwRD3gpPdubOC3qI/Zamg==}
     peerDependencies:
       solid-js: ^1.6.12
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
+
+  '@szmarczak/http-timer@5.0.1':
+    resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
+    engines: {node: '>=14.16'}
 
   '@tailwindcss/node@4.3.3':
     resolution: {integrity: sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==}
@@ -1079,6 +1560,9 @@ packages:
   '@tailwindcss/oxide@4.3.3':
     resolution: {integrity: sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==}
     engines: {node: '>= 20'}
+
+  '@tailwindcss/postcss@4.3.3':
+    resolution: {integrity: sha512-JTSZZGQi1AyKirbLN3azmjVzef92tcX7h+iSqPdaeStyFpGpDlKvvpxeOE8njhbUanbRwr3z8DyzhICWnMtQeg==}
 
   '@tailwindcss/typography@0.5.20':
     resolution: {integrity: sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw==}
@@ -1355,9 +1839,249 @@ packages:
   '@tanstack/store@0.9.3':
     resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
 
+  '@tanstack/table-core@8.21.3':
+    resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
+    engines: {node: '>=12'}
+
+  '@tanstack/virtual-core@3.17.8':
+    resolution: {integrity: sha512-BfEvehNpOT75r5Ksc5xW6NZuXujTfb7nlSEyVu4XHG3gdxNg1KqXruWbDewXOUaUYIo4oRbSfkjIajz4MAT8tA==}
+
   '@tanstack/virtual-file-routes@1.162.0':
     resolution: {integrity: sha512-uhOeFyxLcU41HzvrxsGpiWdcMbScY1EDgbZ5K7DVRMYInbLYWAC0EA/kx9wXAoSM8q82bUG2hRl8+EAjE6XAbA==}
     engines: {node: '>=20.19'}
+
+  '@tanstack/vue-table@8.21.3':
+    resolution: {integrity: sha512-rusRyd77c5tDPloPskctMyPLFEQUeBzxdQ+2Eow4F7gDPlPOB1UnnhzfpdvqZ8ZyX2rRNGmqNnQWm87OI2OQPw==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      vue: '>=3.2'
+
+  '@tanstack/vue-virtual@3.13.36':
+    resolution: {integrity: sha512-gKpExv4RbB9luVG+SucTXoqPZv/gzu/Yvz6BNO+8kpNxJ2x+I/ulryzl5W9BRciahZGp5Tls3Dp5XP1ztVGbMw==}
+    peerDependencies:
+      vue: ^2.7.0 || ^3.0.0
+
+  '@tiptap/core@3.30.5':
+    resolution: {integrity: sha512-3O7N0FyKIfuLV+xrdWyDM3V5eUY/q2CgLjhhMwOAbM1Pu7VPp9VP+TpEYOdH8aRyB+h1vj5hX5A747D8ZrPfHA==}
+    peerDependencies:
+      '@tiptap/pm': 3.30.5
+
+  '@tiptap/extension-blockquote@3.30.5':
+    resolution: {integrity: sha512-8pf1ZDrl6XlVPUee/2YlWZPFSF7yqsJEX6WLW41x06MT1dapG3Qudcns0znj6kYsX8JXTJ+Mhegy4z19bvTtRg==}
+    peerDependencies:
+      '@tiptap/core': 3.30.5
+      '@tiptap/pm': 3.30.5
+
+  '@tiptap/extension-bold@3.30.5':
+    resolution: {integrity: sha512-MLZS+s/BJiJbv2C2M3G4FQGn43kPwYUUr2TiW3afSn+dRkEZlDxx5CwZYbe1PEt2+VX/SIifn945Oqr3s0axSA==}
+    peerDependencies:
+      '@tiptap/core': 3.30.5
+
+  '@tiptap/extension-bubble-menu@3.30.5':
+    resolution: {integrity: sha512-redcmBInVwmipjF/WEVcNwCUJgJygUv8leidfRb/jBSAwx7GgnQWPr2HVQDk9zeTt3ykWld2NRdrk94Crjymow==}
+    peerDependencies:
+      '@tiptap/core': 3.30.5
+      '@tiptap/pm': 3.30.5
+
+  '@tiptap/extension-bullet-list@3.30.5':
+    resolution: {integrity: sha512-66OGw4suO0Gr/4QAEiSvVi0eSvEqStvu1moHUSvUlwvEqnuB0ME2w9HuRogPElzWdrYLzbBA47mlCi9Veva0ew==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.30.5
+
+  '@tiptap/extension-code-block@3.30.5':
+    resolution: {integrity: sha512-SvkNoOio2xBy9AtSMyFKMp88MTUvyIXsGCnuz71INV2wHdH4VfRPoQLT6e077LpTCa9w6LHyTKtbZA4HYOp7wg==}
+    peerDependencies:
+      '@tiptap/core': 3.30.5
+      '@tiptap/pm': 3.30.5
+
+  '@tiptap/extension-code@3.30.5':
+    resolution: {integrity: sha512-0dCt8eBo4sMtw+LjUu+0GF0JrTlREROdWoy8TM5kFPxJ5ZU2LKDiROXDPwXStaaoFFR/aStLH9xSpdz7cHUiUA==}
+    peerDependencies:
+      '@tiptap/core': 3.30.5
+
+  '@tiptap/extension-collaboration@3.30.5':
+    resolution: {integrity: sha512-LIw2JCPhAI7mWEfaPzct2WYAmSMuv4QPRQqX6AGtg6EcqLUj2N39ds6kBg5jgC7g8vGUNs8/lj5C/9SW0YrDyw==}
+    peerDependencies:
+      '@tiptap/core': 3.30.5
+      '@tiptap/pm': 3.30.5
+      '@tiptap/y-tiptap': ^3.0.7
+      yjs: ^13
+
+  '@tiptap/extension-document@3.30.5':
+    resolution: {integrity: sha512-4mKoD3bBr5W2AQ2Y/7amOqcVw0eqJbUwRtwvxypeo5Hi0PB9O5Ev8P05c3EUTo10bllqdKYXGeCU5AcgdQsHWQ==}
+    peerDependencies:
+      '@tiptap/core': 3.30.5
+
+  '@tiptap/extension-drag-handle-vue-3@3.30.5':
+    resolution: {integrity: sha512-+cOFesVWeyHflOR85GEmHt/lijUJfrjRyqa3yl4mmtLOWfWYKYCNXd0SxIDOvQYH0xMzZ3uAPUgWyO5cZMDemg==}
+    peerDependencies:
+      '@tiptap/extension-drag-handle': 3.30.5
+      '@tiptap/pm': 3.30.5
+      '@tiptap/vue-3': 3.30.5
+      vue: ^3.0.0
+
+  '@tiptap/extension-drag-handle@3.30.5':
+    resolution: {integrity: sha512-gCqZK31AkJ5qdvYcE/5zOsThKdHGNv4bNQHq/jAVikWOjsfF/3jE2XDc7SF+CTCgXZK4ssUg2H29RIhHVzESyA==}
+    peerDependencies:
+      '@tiptap/core': 3.30.5
+      '@tiptap/extension-collaboration': 3.30.5
+      '@tiptap/extension-node-range': 3.30.5
+      '@tiptap/pm': 3.30.5
+      '@tiptap/y-tiptap': ^3.0.7
+
+  '@tiptap/extension-dropcursor@3.30.5':
+    resolution: {integrity: sha512-gJxn9PMUee8zazQBYqbOZiI7zTFXPVJ15AzTnLfUu4eDtPieMwtpgcjhCt4bZlp37drLm+Li76wWLirb7iLxsw==}
+    peerDependencies:
+      '@tiptap/extensions': 3.30.5
+
+  '@tiptap/extension-floating-menu@3.30.5':
+    resolution: {integrity: sha512-gTjGPWUpGn8IoW533TciZJZC/81LmBgU7zee+aRMRF3ix3K2z1pJjl6knDvrRQA6Kom+yWFaiueqGNXkrk38XQ==}
+    peerDependencies:
+      '@floating-ui/dom': ^1.0.0
+      '@tiptap/core': 3.30.5
+      '@tiptap/pm': 3.30.5
+
+  '@tiptap/extension-gapcursor@3.30.5':
+    resolution: {integrity: sha512-h3m2ZA1XXLAfdHwdtG0MZnf0KWbNyP8xTI3RUlTDR5apmKmYVBaeocOJwTcFFZ92gPKqxYKyhteZqYtHOCZGJA==}
+    peerDependencies:
+      '@tiptap/extensions': 3.30.5
+
+  '@tiptap/extension-hard-break@3.30.5':
+    resolution: {integrity: sha512-PcL4Z8l/DlauwZUJg0jf6SXKk6/YOXJtd8yYzqHrmCLRoY4kAa7+TxUhc/lWhuitUiOZ8+nB8V/NNM+WR6mRaw==}
+    peerDependencies:
+      '@tiptap/core': 3.30.5
+
+  '@tiptap/extension-heading@3.30.5':
+    resolution: {integrity: sha512-x7e7+p1bWXvwz6vqONPP1SVB73V0gZP7LIDL/5KMnxWLjahMTabgVPgjV30kz7GsOEgUYtEf7eCyGVGNNWL5Dg==}
+    peerDependencies:
+      '@tiptap/core': 3.30.5
+
+  '@tiptap/extension-horizontal-rule@3.30.5':
+    resolution: {integrity: sha512-s5t2xM6wPYRJl2cqYplc7Ze8m8xddk4DP2v0aLFcUuD100D1B5eJbxsiwLK6wBAzNwiuVjd486RnmUpcswaXhQ==}
+    peerDependencies:
+      '@tiptap/core': 3.30.5
+      '@tiptap/pm': 3.30.5
+
+  '@tiptap/extension-image@3.30.5':
+    resolution: {integrity: sha512-fETBsbSTaf5MLCGZaffHRRAFYUHeDIeITbnm7Q5Il+/LlX7PEiBZGKVyD/M3bIMpxhkyB0UlryIYGhC5LjN1Aw==}
+    peerDependencies:
+      '@tiptap/core': 3.30.5
+
+  '@tiptap/extension-italic@3.30.5':
+    resolution: {integrity: sha512-Fu9EuSRlHQNGES7UhY4mQod3yUKnWwxsGlPuDJURfwju/Ug04Jz8iRuERZBPcRgLNkwKDmbDsWUZF72RRIL2Uw==}
+    peerDependencies:
+      '@tiptap/core': 3.30.5
+
+  '@tiptap/extension-link@3.30.5':
+    resolution: {integrity: sha512-zsQ+q83HpCYOMTNzdjb12dggE7sZMp0aqQJhArdavSTl8hLbVY/u3qJN88t25IEwAKVK0pcTJfWWA2QFl8bjAQ==}
+    peerDependencies:
+      '@tiptap/core': 3.30.5
+      '@tiptap/pm': 3.30.5
+
+  '@tiptap/extension-list-item@3.30.5':
+    resolution: {integrity: sha512-N0fKUyQkPQBvVB48imjfIfdexU9VsAX1RydajYP2xAt+QOJ8KHVmXv1EGTp+v7pGdZMLdls1cSZ2f352vW3aWQ==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.30.5
+
+  '@tiptap/extension-list-keymap@3.30.5':
+    resolution: {integrity: sha512-3pLR2yo29uhowaGMbD8v71XpgdNmqotBg1NXlyTMVFzxELj+VjjeLLTqSguR/iWDUbHXNzIsfMEgpRnNMO//8w==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.30.5
+
+  '@tiptap/extension-list@3.30.5':
+    resolution: {integrity: sha512-CHThihH+7TA0TfwtmA+eTXP1MAsA/+p011olJHg8Rilj5xA+L+0IFkjhN16JnZkBgSA4MnfEv15UMNfRaNpuVg==}
+    peerDependencies:
+      '@tiptap/core': 3.30.5
+      '@tiptap/pm': 3.30.5
+
+  '@tiptap/extension-mention@3.30.5':
+    resolution: {integrity: sha512-UFLZbue+GanPQgdDFbLWKnzd+ivWSSsfaFQGI2jj5jS6SNaMk0yAr5djiAmZEDMVfP3HmHpDwim9ZGzShYQPiQ==}
+    peerDependencies:
+      '@tiptap/core': 3.30.5
+      '@tiptap/pm': 3.30.5
+      '@tiptap/suggestion': 3.30.5
+
+  '@tiptap/extension-node-range@3.30.5':
+    resolution: {integrity: sha512-c66LBRn6d/t2sY8WqS0nlNxPIgyrHGesnoHbR3RhkliSb7+pf3e2b5Osxxjlx3sAziKdwpwuXcmyCoR98Iv/xg==}
+    peerDependencies:
+      '@tiptap/core': 3.30.5
+      '@tiptap/pm': 3.30.5
+
+  '@tiptap/extension-ordered-list@3.30.5':
+    resolution: {integrity: sha512-bUGUnSAgjZhoUWBtr+1wRJHF3NnNvuKQr6sQ8le1tJ2yvLq448ZsSZjZGvTNeLsy3GDKBoMJ0rqLUK34+nM3hg==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.30.5
+
+  '@tiptap/extension-paragraph@3.30.5':
+    resolution: {integrity: sha512-GrNNlAImfQhYRtGE95YNAjcTclUUMPHs9JeE9vMgfcoKcOmZ6GsbWUdN0hA55xqwGaUjnroOVtf77K9z1EbkJQ==}
+    peerDependencies:
+      '@tiptap/core': 3.30.5
+
+  '@tiptap/extension-placeholder@3.30.5':
+    resolution: {integrity: sha512-WgkX4ImAAeV+Qe7ATJ+Gio2MmKWON1CKpCKPHWgCObaoMEaSmdoxXPmI9wXMuM+AJydJepp4n7U/V4TVts14rg==}
+    peerDependencies:
+      '@tiptap/extensions': 3.30.5
+
+  '@tiptap/extension-strike@3.30.5':
+    resolution: {integrity: sha512-r8IbWUm4YXNCkmc6h6dzuREQIGbO0x9z9l3GfQPUR3LxFtGssDLngE4dFXHRt/ejLWKEauy6clklf7LawtvYzw==}
+    peerDependencies:
+      '@tiptap/core': 3.30.5
+
+  '@tiptap/extension-text@3.30.5':
+    resolution: {integrity: sha512-pOgj4mIGFlw4NUdA6PCTFP/MHrYWnOYiZRYeu0I3/Yo3iN4Am/CgYBLl8PWsNh+YPO2hA2DWs7ZMke9D2j5R+g==}
+    peerDependencies:
+      '@tiptap/core': 3.30.5
+
+  '@tiptap/extension-underline@3.30.5':
+    resolution: {integrity: sha512-u12G/WW2uFRY95BzrSAU9RW002K+7lFpSCL6fb7Puh8yLhek3lddOtAx0P+NI/PyMKtcoVMtBxoi+0mwVM7NPQ==}
+    peerDependencies:
+      '@tiptap/core': 3.30.5
+
+  '@tiptap/extensions@3.30.5':
+    resolution: {integrity: sha512-5x3OiCYBvXz0G5OGM8f7ka++1dh9EXdNRZ8IcMcEd+QwW4RPwvmJ2EjheA1eRRyMlcbNU7T+4IRlBXURlTetEA==}
+    peerDependencies:
+      '@tiptap/core': 3.30.5
+      '@tiptap/pm': 3.30.5
+
+  '@tiptap/markdown@3.30.5':
+    resolution: {integrity: sha512-0yDt0AsiNHY0ZzlvELmzOmjfo55eJKV1euRYQp0aI5XPh+2YOdOm8cZqlhdHpJrN0wdrP/nVGxumsNmC/dqx4Q==}
+    peerDependencies:
+      '@tiptap/core': 3.30.5
+      '@tiptap/pm': 3.30.5
+
+  '@tiptap/pm@3.30.5':
+    resolution: {integrity: sha512-gufkLkW2tA6PZPjivYxDiGzTIIftwqhmYI6lvvKu2S4FbhcysJgMAe/GXVSywzCRVVex9SrvCe6RFYrqnwRitQ==}
+
+  '@tiptap/starter-kit@3.30.5':
+    resolution: {integrity: sha512-cmDRvukpoqjQjhE96q+l3tCLNZZcJKehxK+00Sp9F4XbKecfM2QpZ2TRHh3vi8qhCeDQNyMoCqfNaqznIjLjIQ==}
+
+  '@tiptap/suggestion@3.30.5':
+    resolution: {integrity: sha512-kXlsY2GyXlVpYKp6uSedvvfACC4Phd0I8/Gp1/7ts8fYLlkVfGco6kgqOKHxT6HcUF1pGshxkDh9lfRCakkQEA==}
+    peerDependencies:
+      '@floating-ui/dom': ^1.0.0
+      '@tiptap/core': 3.30.5
+      '@tiptap/pm': 3.30.5
+
+  '@tiptap/vue-3@3.30.5':
+    resolution: {integrity: sha512-YRHacQy09nFcokAScICxJ6pWr5daWbsLJuBiMo+DJQlr1XLi6o/zFhh3eR9+DKluL4OY3IZDYBYZfDs7YZtJNg==}
+    peerDependencies:
+      '@floating-ui/dom': ^1.0.0
+      '@tiptap/core': 3.30.5
+      '@tiptap/pm': 3.30.5
+      vue: ^3.0.0
+
+  '@tiptap/y-tiptap@3.0.9':
+    resolution: {integrity: sha512-7/El8NQ8R5V5MkdrOUdfj9IgZacpt0H071xNimX7B0AnYiWiKefQnMKd41neQYzo2MOXbWdN3iZ+7Z7BruzOSA==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
+    peerDependencies:
+      prosemirror-model: ^1.7.1
+      prosemirror-state: ^1.2.3
+      prosemirror-view: ^1.9.10
+      y-protocols: ^1.0.1
+      yjs: ^13.5.38
+
+  '@tootallnate/quickjs-emscripten@0.23.0':
+    resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -1373,6 +2097,9 @@ packages:
 
   '@types/hast@3.0.5':
     resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
+
+  '@types/http-cache-semantics@4.2.0':
+    resolution: {integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==}
 
   '@types/katex@0.16.8':
     resolution: {integrity: sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==}
@@ -1406,8 +2133,81 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
+  '@types/web-bluetooth@0.0.20':
+    resolution: {integrity: sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==}
+
+  '@types/web-bluetooth@0.0.21':
+    resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
+
+  '@types/yauzl@2.10.3':
+    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
+
   '@ungap/structured-clone@1.3.3':
     resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
+
+  '@unhead/bundler@3.4.0':
+    resolution: {integrity: sha512-RnsCYynvDiUwmZ/U7TkFwFLr6yTRXVFJlZFj3ehi+m6M4f+GWL/O+6BTQzaHdz59zg2UHHejQvwuXvcL7dj0Dw==}
+    peerDependencies:
+      '@unhead/cli': ^3.4.0
+      '@vitejs/devtools-kit': ^0.4.1
+      esbuild: '>=0.17.0'
+      lightningcss: '>=1.20.0'
+      oxc-parser: '>=0.98.0'
+      rolldown: '>=1.0.0'
+      unhead: ^3.4.0
+      vite: '>=6.4.2'
+      webpack: '>=5.0.0'
+    peerDependenciesMeta:
+      '@unhead/cli':
+        optional: true
+      '@vitejs/devtools-kit':
+        optional: true
+      esbuild:
+        optional: true
+      lightningcss:
+        optional: true
+      oxc-parser:
+        optional: true
+      rolldown:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
+
+  '@unhead/vue@3.4.0':
+    resolution: {integrity: sha512-fSnDS9d++bqR4t1z6+zFN7bQB5F0+5nwvE4yHW7BGRfEmssCP4fel0GprooUgoLkzx+FcAWMwVIakyaeErSRBA==}
+    peerDependencies:
+      vite: '>=6.4.2'
+      vue: '>=3.5.18'
+      webpack: '>=5.0.0'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+      webpack:
+        optional: true
+
+  '@unlighthouse/cli@0.18.0':
+    resolution: {integrity: sha512-rID/NqZSgxqteTYAHhiglHFSY3Y2eMXByz4EylO1NatfZ/nB47mxLGC5KWa/msDd1/5zSAqYSte6BHkxLtpE5g==}
+    engines: {node: '>=22.18.0'}
+    hasBin: true
+
+  '@unlighthouse/client@0.18.0':
+    resolution: {integrity: sha512-AYNM9i+UHHyGUNOaV5jl/0HcYvQa5ImSfajK4CceZetK1YA0I/5JZKHF/IFJRCswsQfFVG8IbrxIDp0y1BUnhg==}
+    engines: {node: '>=22.18.0'}
+
+  '@unlighthouse/core@0.18.0':
+    resolution: {integrity: sha512-YMiRXGR6BWxHCIstvqzBf04FT/42yLf9h4fRs5mvS5rAuKiSzGP8f01/0FYge5eVBFDR5WJqO4cTthbH1H0/Pg==}
+    engines: {node: '>=22.18.0'}
+    peerDependencies:
+      puppeteer: '*'
+    peerDependenciesMeta:
+      puppeteer:
+        optional: true
+
+  '@unlighthouse/server@0.18.0':
+    resolution: {integrity: sha512-XhiOmcF61pwvfa4b5UwlLp67QxUNptyVCoadNYrSgwVIVk8hw32HJqU0hQSQNXnaLZ+/Xa7KCaD4aI4SqLcYxg==}
+    engines: {node: '>=22.18.0'}
 
   '@vitejs/plugin-react@6.1.0':
     resolution: {integrity: sha512-qd2BzUBehkov86WFhg0JkEFEYyCLG9uPCe6qWTY/kRlss9OvJrOF2UbIWT7p+8IzZHkEu0DNGHc4HSv+JdDLsw==}
@@ -1425,20 +2225,169 @@ packages:
       oxc-transform-react:
         optional: true
 
+  '@vue/compiler-core@3.5.41':
+    resolution: {integrity: sha512-q0Xtv/F9w2YO/7htQhtiL+Ev2WCJbe5N2hc+XfgyKkEKqWpSxknmT8QOuGdEKNdjPq0c3F7rNpFkTo3Kfrm7pg==}
+
+  '@vue/compiler-dom@3.5.41':
+    resolution: {integrity: sha512-oKacVfNglLvGjnS6BXOlGL7EyG2h8X03pqXCjzotRZUaXGjbrTJUnVAQjrCqUnS+lyu31nwQjZY/d817GmCnfw==}
+
+  '@vue/compiler-sfc@3.5.41':
+    resolution: {integrity: sha512-XJhip7R2wy6vX3knCxdZN4KracFaZUef58s1KYewqluedHIJaPIVfXoYT7MF1F8nCvv6k8bWWxDC8opMkg1VTQ==}
+
+  '@vue/compiler-ssr@3.5.41':
+    resolution: {integrity: sha512-U3v5OejKEGqOI0Wy0+Sz7hGuIFZHA4LSXzrNM3IMIeDyJEBBfTpX26n3SDgToRpP2bLc9FfI2j/kSgcJ8Emq5A==}
+
+  '@vue/reactivity@3.5.41':
+    resolution: {integrity: sha512-rznsqKM0np0x18EjzF8x88MpEhdNsffbvFbckLL5+oUKz1BxAImEmO7J1ArRYSyo6aQaVoBDp7jEkT91OOxydA==}
+
+  '@vue/runtime-core@3.5.41':
+    resolution: {integrity: sha512-Vcry58hiAKwGen9Z1jUZE0feFsNArPCMOImYI8el48A9Idf6DuQYD0U05zZIF2Iad1hGhPSvcbBbAOhNr55fhg==}
+
+  '@vue/runtime-dom@3.5.41':
+    resolution: {integrity: sha512-3vVBahVBS9+U6cmXBLyb8nE6/yYo4J/CGI9eVFs3KiMc0YHuudwKyShTD65jtJy/L9PUUxNAFu4cj4LiJ0UFbw==}
+
+  '@vue/server-renderer@3.5.41':
+    resolution: {integrity: sha512-n6hx/pNFfbD6SuyeuMVkvqox8bwf/ET9JlA/kAz/imw8sw++wkqKe2mHX5KutjPpbKE4Z56yTHszoOjGMI9igQ==}
+
+  '@vue/shared@3.5.41':
+    resolution: {integrity: sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA==}
+
+  '@vueuse/core@10.11.1':
+    resolution: {integrity: sha512-guoy26JQktXPcz+0n3GukWIy/JDNKti9v6VEMu6kV2sYBsWuGiTU8OWdg+ADfUbHg3/3DlqySDe7JmdHrktiww==}
+
+  '@vueuse/core@14.4.0':
+    resolution: {integrity: sha512-X4WHz1HlCzCBoYXesUkifzzWBAcZgXG8Fi5iNPQg/epdzOB3gu8Fawj3hvuwYR1nGcXGnvxwYYcUC/71++svtQ==}
+    peerDependencies:
+      vue: ^3.5.0
+
+  '@vueuse/integrations@14.4.0':
+    resolution: {integrity: sha512-oJz9qTgczvA7L1nXQFRU7h8tQbOCoiceqvMMhT9XYMyOGTqLJ2rEa09PON+nD2t48sZUfeOmg4eaWJXV4sZb/w==}
+    peerDependencies:
+      async-validator: ^4
+      axios: ^1
+      change-case: ^5
+      drauu: ^0.4
+      focus-trap: ^7 || ^8
+      fuse.js: ^7
+      idb-keyval: ^6
+      jwt-decode: ^4
+      nprogress: ^0.2
+      qrcode: ^1.5
+      sortablejs: ^1
+      universal-cookie: ^7 || ^8
+      vue: ^3.5.0
+    peerDependenciesMeta:
+      async-validator:
+        optional: true
+      axios:
+        optional: true
+      change-case:
+        optional: true
+      drauu:
+        optional: true
+      focus-trap:
+        optional: true
+      fuse.js:
+        optional: true
+      idb-keyval:
+        optional: true
+      jwt-decode:
+        optional: true
+      nprogress:
+        optional: true
+      qrcode:
+        optional: true
+      sortablejs:
+        optional: true
+      universal-cookie:
+        optional: true
+
+  '@vueuse/metadata@10.11.1':
+    resolution: {integrity: sha512-IGa5FXd003Ug1qAZmyE8wF3sJ81xGLSqTqtQ6jaVfkeZ4i5kS2mwQF61yhVqojRnenVew5PldLyRgvdl4YYuSw==}
+
+  '@vueuse/metadata@14.4.0':
+    resolution: {integrity: sha512-swx/255R6JyHZFJhx845iz5CRWDZdCfvkZOpACWc5+c5WHcG24mv8gUT1WIdFQaHt6dq79rvILd9QnCWiyVm9g==}
+
+  '@vueuse/shared@10.11.1':
+    resolution: {integrity: sha512-LHpC8711VFZlDaYUXEBbFBCQ7GS3dVU9mjOhhMhXP6txTV4EhYQg/KGnQuvt/sPAtoUKq7VVUnL6mVtFoL42sA==}
+
+  '@vueuse/shared@14.4.0':
+    resolution: {integrity: sha512-JRgY90Sz8DDtPMsaDflvPMp9xYk69JZAmbuDvAquUVXKr2gEjqtzGNTTthLfckH0BzBqvnu31gb4a8TGLRe79g==}
+    peerDependencies:
+      vue: ^3.5.0
+
+  acorn@8.18.0:
+    resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
+  ansi-colors@4.1.3:
+    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
+    engines: {node: '>=6'}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
+
+  ansi-regex@6.3.0:
+    resolution: {integrity: sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==}
+    engines: {node: '>=12'}
 
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
   ansis@4.3.1:
     resolution: {integrity: sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==}
     engines: {node: '>=14'}
 
+  anymatch@3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
+
+  anynum@1.0.1:
+    resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==}
+
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
+  ast-types@0.13.4:
+    resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
+    engines: {node: '>=4'}
+
+  astring@1.9.0:
+    resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
+    hasBin: true
+
+  atomically@2.1.1:
+    resolution: {integrity: sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==}
+
+  axe-core@4.13.0:
+    resolution: {integrity: sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==}
+    engines: {node: '>=4'}
+
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
 
   babel-dead-code-elimination@1.0.12:
     resolution: {integrity: sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig==}
@@ -1446,10 +2395,51 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
+  bare-events@2.9.2:
+    resolution: {integrity: sha512-AIPKioV7/Y/8KfZ3AAhjPJxLLbY49S64Ym5DakZlUg75qQiTgUq9hEJoEwa4eUezPUlXRy/i5NpsKvo9jgKmoA==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  bare-fs@4.8.1:
+    resolution: {integrity: sha512-N1nnXdHZAOSstz0XiHikGS4HGMH4CnSwhqWdGQQMqqdvp4Jybm9sE3R1WVnpWVd4SFkc8ryPDBLViNLwiEqECg==}
+    engines: {bare: '>=1.28.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-path@3.1.1:
+    resolution: {integrity: sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==}
+
+  bare-stream@2.13.4:
+    resolution: {integrity: sha512-PcrQ8lVLbiJscNm1Kez+Yp4Gy4AHGcN1lzwjvf5NybWen7VvEgUfyfnXYJ2zNqWnzOfCb1Abq6lH8ti0syQszA==}
+    peerDependencies:
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.5.2:
+    resolution: {integrity: sha512-L13PCJzKG8RGvx8V1/DdMi12ERhC3tprr7/8a94BxpmnRsFqxh5XZNdhtMxu5HPkRshYOOWRGY8lDP7ZhpG9Cg==}
+
   baseline-browser-mapping@2.11.19:
     resolution: {integrity: sha512-Grytf1xOxOEMTGRwx6rLGKkTabd4vMg3VrKdj/7joCmV0qgh4QwMMO6xh34YEXQqirAuUdgQGa5orJQQ+69RBw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  basic-ftp@5.3.1:
+    resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
+    engines: {node: '>=10.0.0'}
 
   boneyard-js@1.9.0:
     resolution: {integrity: sha512-FlIHm7YyQ6GMBPaNY6um5ESHNyZGONoSZ0IMhayuyemBsCUhhDl4nC/gMTOi/25ojtrlnRInTWKqFKb7hGK6Cg==}
@@ -1483,6 +2473,29 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
+  c12@3.3.4:
+    resolution: {integrity: sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==}
+    peerDependencies:
+      magicast: '*'
+    peerDependenciesMeta:
+      magicast:
+        optional: true
+
+  cac@7.0.0:
+    resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
+    engines: {node: '>=20.19.0'}
+
+  cacheable-lookup@7.0.0:
+    resolution: {integrity: sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==}
+    engines: {node: '>=14.16'}
+
+  cacheable-request@10.2.14:
+    resolution: {integrity: sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==}
+    engines: {node: '>=14.16'}
+
   caniuse-lite@1.0.30001809:
     resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
 
@@ -1509,9 +2522,38 @@ packages:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
 
+  chrome-launcher@1.2.1:
+    resolution: {integrity: sha512-qmFR5PLMzHyuNJHwOloHPAHhbaNglkfeV/xDtt5b7xiFFyU1I+AZZX0PYseMuhenJSSirgxELYIbswcoc+5H4A==}
+    engines: {node: '>=12.13.0'}
+    hasBin: true
+
+  chromium-bidi@14.0.0:
+    resolution: {integrity: sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==}
+    peerDependencies:
+      devtools-protocol: '*'
+
+  chromium-bidi@17.0.2:
+    resolution: {integrity: sha512-5v9GQFhTktFvotn/OFNJBmKLKRAb6n9r0bVCwf7sHgWc3/JryK0bj1nn93L3pHFrfgcsu6Be6EWsDi+1XHTGDg==}
+    engines: {node: '>=20.19.0 <22.0.0 || >=22.12.0'}
+    peerDependencies:
+      devtools-protocol: '*'
+
+  citty@0.1.6:
+    resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
+
+  citty@0.2.2:
+    resolution: {integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==}
+
+  cjs-module-lexer@2.2.1:
+    resolution: {integrity: sha512-Ca8swihM+/4yKecYHY52kgJd300hi2lADU/a1RxNTRe+RJ9jvqQlESpbz9DnG9mowez8qwXHB8qYdIUw9e+F5Q==}
+
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
+
+  cliui@9.0.1:
+    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
+    engines: {node: '>=20'}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -1524,12 +2566,29 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  colortranslator@5.0.0:
+    resolution: {integrity: sha512-Z3UPUKasUVDFCDYAjP2fmlVRf1jFHJv1izAmPjiOa0OCIw1W7iC8PZ2GsoDa8uZv+mKyWopxxStT9q05+27h7w==}
+
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  confbox@0.2.4:
+    resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
+
+  configstore@5.0.1:
+    resolution: {integrity: sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==}
+    engines: {node: '>=8'}
+
+  configstore@7.1.0:
+    resolution: {integrity: sha512-N4oog6YJWbR9kGyXvS7jEykLDXIE2C0ILYqNBZBp9iwiJpoCBWYsuAdW6PPFn6w06jjnC+3JstVvWHO4cZqvRg==}
+    engines: {node: '>=18'}
 
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
@@ -1538,8 +2597,18 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie-es@1.2.3:
+    resolution: {integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==}
+
   cookie-es@3.1.1:
     resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  crossws@0.3.5:
+    resolution: {integrity: sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==}
 
   crossws@0.4.12:
     resolution: {integrity: sha512-aypfsr6t0uNvkqaZc6zvBfXzC6pLI0/sIulpkV6RwCVtZqG5ebBzv4weImKK0VNCj91Wl9F5j7p5WU4MNrybng==}
@@ -1548,6 +2617,20 @@ packages:
     peerDependenciesMeta:
       srvx:
         optional: true
+
+  crypto-random-string@2.0.0:
+    resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
+    engines: {node: '>=8'}
+
+  csp_evaluator@1.1.5:
+    resolution: {integrity: sha512-EL/iN9etCTzw/fBnp0/uj0f5BOOGvZut2mzsiiBZ/FdT6gFQCKRO/tmcKOxn5drWZ2Ndm/xBb1SI4zwWbGtmIw==}
+
+  csp_evaluator@1.1.8:
+    resolution: {integrity: sha512-EwOnfYuNbTytvbMKsLixTrRgnjOa0WZCxGy8A9nnSYAicrdwn+T/epU/yjgymmOxlgKnvH+8wXt+7p/8ak5Feg==}
+
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -1559,6 +2642,10 @@ packages:
 
   cuelume@0.2.2:
     resolution: {integrity: sha512-TiNzJRjhddjC4jy4M7sv63V/86VaFhdIs6iHUCrc4CKhqypaxRBv1aedCBGebrz/cO7nroPkEfqHe/P7fOE2GQ==}
+
+  data-uri-to-buffer@6.0.2:
+    resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
+    engines: {node: '>= 14'}
 
   dayjs@1.11.23:
     resolution: {integrity: sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==}
@@ -1595,12 +2682,37 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
+  defer-to-connect@2.0.1:
+    resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
+    engines: {node: '>=10'}
+
+  define-lazy-prop@2.0.0:
+    resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
+    engines: {node: '>=8'}
+
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
+  degenerator@5.0.1:
+    resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
+    engines: {node: '>= 14'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
+
+  destr@2.0.5:
+    resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -1609,9 +2721,33 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
+  devtools-protocol@0.0.1467305:
+    resolution: {integrity: sha512-LxwMLqBoPPGpMdRL4NkLFRNy3QLp6Uqa7GNp1v6JaBheop2QrB9Q7q0A/q/CYYP9sBfZdHOyszVx4gc9zyk7ow==}
+
+  devtools-protocol@0.0.1608973:
+    resolution: {integrity: sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==}
+
+  devtools-protocol@0.0.1663043:
+    resolution: {integrity: sha512-33aOY3ZnBP1dgZsshgaL+/XlsQleiFZgyUaDtdZkEa1nbZhVY1MoDeWjk+wxg25fU924l1ZJfoGNmjjeA/5s1w==}
+
+  devtools-protocol@0.0.1666840:
+    resolution: {integrity: sha512-gCcO42XCHKEs7Ag0S7aGYsnJ7hlgrO3qderYqeiY0Eqk+0GFfuvT13IA0hHreJTa2KCdDVyGMeOhdMNmrrTjVg==}
+
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
+
+  dot-prop@5.3.0:
+    resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
+    engines: {node: '>=8'}
+
+  dot-prop@9.0.0:
+    resolution: {integrity: sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==}
+    engines: {node: '>=18'}
+
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
+    engines: {node: '>=12'}
 
   driver.js@1.8.0:
     resolution: {integrity: sha512-+8/IO7h1v14IzWh2GP60N7T3PFZweXwdn5e5POuxRSBoCYUojsBxzqawPeXh3YZIibRy7EehYNEyxe7slwwtdg==}
@@ -1619,15 +2755,73 @@ packages:
   electron-to-chromium@1.5.413:
     resolution: {integrity: sha512-F1XPKvt7HVfly5WND90ec16nFsdr4g5x/cVUP3EqjeyXynupabGDqpMa84wwvuYGDnldXLBz6DLXyZXWO9TPvw==}
 
+  embla-carousel-auto-height@8.6.0:
+    resolution: {integrity: sha512-/HrJQOEM6aol/oF33gd2QlINcXy3e19fJWvHDuHWp2bpyTa+2dm9tVVJak30m2Qy6QyQ6Fc8DkImtv7pxWOJUQ==}
+    peerDependencies:
+      embla-carousel: 8.6.0
+
+  embla-carousel-auto-scroll@8.6.0:
+    resolution: {integrity: sha512-WT9fWhNXFpbQ6kP+aS07oF5IHYLZ1Dx4DkwgCY8Hv2ZyYd2KMCPfMV1q/cA3wFGuLO7GMgKiySLX90/pQkcOdQ==}
+    peerDependencies:
+      embla-carousel: 8.6.0
+
+  embla-carousel-autoplay@8.6.0:
+    resolution: {integrity: sha512-OBu5G3nwaSXkZCo1A6LTaFMZ8EpkYbwIaH+bPqdBnDGQ2fh4+NbzjXjs2SktoPNKCtflfVMc75njaDHOYXcrsA==}
+    peerDependencies:
+      embla-carousel: 8.6.0
+
+  embla-carousel-class-names@8.6.0:
+    resolution: {integrity: sha512-l1hm1+7GxQ+zwdU2sea/LhD946on7XO2qk3Xq2XWSwBaWfdgchXdK567yzLtYSHn4sWYdiX+x4nnaj+saKnJkw==}
+    peerDependencies:
+      embla-carousel: 8.6.0
+
+  embla-carousel-fade@8.6.0:
+    resolution: {integrity: sha512-qaYsx5mwCz72ZrjlsXgs1nKejSrW+UhkbOMwLgfRT7w2LtdEB03nPRI06GHuHv5ac2USvbEiX2/nAHctcDwvpg==}
+    peerDependencies:
+      embla-carousel: 8.6.0
+
+  embla-carousel-reactive-utils@8.6.0:
+    resolution: {integrity: sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==}
+    peerDependencies:
+      embla-carousel: 8.6.0
+
+  embla-carousel-vue@8.6.0:
+    resolution: {integrity: sha512-v8UO5UsyLocZnu/LbfQA7Dn2QHuZKurJY93VUmZYP//QRWoCWOsionmvLLAlibkET3pGPs7++03VhJKbWD7vhQ==}
+    peerDependencies:
+      vue: ^3.2.37
+
+  embla-carousel-wheel-gestures@8.1.0:
+    resolution: {integrity: sha512-J68jkYrxbWDmXOm2n2YHl+uMEXzkGSKjWmjaEgL9xVvPb3HqVmg6rJSKfI3sqIDVvm7mkeTy87wtG/5263XqHQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      embla-carousel: ^8.0.0 || ~8.0.0-rc03
+
+  embla-carousel@8.6.0:
+    resolution: {integrity: sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==}
+
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enhanced-resolve@5.24.5:
     resolution: {integrity: sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==}
     engines: {node: '>=10.13.0'}
 
+  enquirer@2.4.1:
+    resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
+    engines: {node: '>=8.6'}
+
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
   env-runner@0.1.16:
@@ -1648,6 +2842,17 @@ packages:
       wrangler:
         optional: true
 
+  errx@0.1.2:
+    resolution: {integrity: sha512-chfpPHmCerdo/rXr/nNvPZRkV4WwDRwzwnsJ0Uzz3tVi8Z41tDctRjduYy1138ii77AFlts1qvWtX3g/Acg91Q==}
+
+  es-module-lexer@2.3.2:
+    resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   esbuild@0.28.2:
     resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
     engines: {node: '>=18'}
@@ -1657,9 +2862,31 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
+
+  escodegen@2.1.0:
+    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
+    engines: {node: '>=6.0'}
+    hasBin: true
+
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
 
   estree-util-is-identifier-name@3.0.0:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
@@ -1667,14 +2894,58 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
+  execa@8.0.1:
+    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
+    engines: {node: '>=16.17'}
+
   exsolve@1.1.1:
     resolution: {integrity: sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
+  extract-zip@2.0.1:
+    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
+    engines: {node: '>= 10.17.0'}
+    hasBin: true
+
+  fancy-canvas@2.1.0:
+    resolution: {integrity: sha512-nifxXJ95JNLFR2NgRV4/MxVP45G9909wJTEKz5fg/TZS20JJZA6hfgRVh/bC9bwl2zBtBNcYPjiBE4njQHVBwQ==}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
+
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
+
+  fast-xml-builder@1.3.1:
+    resolution: {integrity: sha512-pIM/1n3ntFXKYrUZwW7QCK0gAW7XY+wzj1YMIV3tLDvPj/V+zTGJK5e3/4WJfwj0qWw2ElNXiTixda/R+3YSug==}
+
+  fast-xml-parser@5.11.0:
+    resolution: {integrity: sha512-9IGxMqvqLOnqP+Egi1nqDHKv5k8aZ7r9n558enxcucmyVGEBNPAU+MOg/8jPIS7rO7sSq4gFm1/nHtiaubMruw==}
+    hasBin: true
+
   fault@1.0.4:
     resolution: {integrity: sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==}
+
+  fd-slicer@1.1.0:
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1688,9 +2959,41 @@ packages:
   fetchdts@0.1.7:
     resolution: {integrity: sha512-YoZjBdafyLIop9lSxXVI33oLD5kN31q4Td+CasofLLYeLXRFeOsuOw0Uo+XNRi9PZlbfdlN2GmRtm4tCEQ9/KA==}
 
+  fontaine@0.8.0:
+    resolution: {integrity: sha512-eek1GbzOdWIj9FyQH/emqW1aEdfC3lYRCHepzwlFCm5T77fBSRSyNRKE6/antF1/B1M+SfJXVRQTY9GAr7lnDg==}
+    engines: {node: '>=18.12.0'}
+
+  fontkitten@1.0.3:
+    resolution: {integrity: sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==}
+    engines: {node: '>=20'}
+
+  fontless@0.2.1:
+    resolution: {integrity: sha512-mUWZ8w91/mw2KEcZ6gHNoNNmsAq9Wiw2IypIux5lM03nhXm+WSloXGUNuRETNTLqZexMgpt7Aj/v63qqrsWraQ==}
+    engines: {node: '>=18.12.0'}
+    peerDependencies:
+      vite: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+
+  form-data-encoder@2.1.4:
+    resolution: {integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==}
+    engines: {node: '>= 14.17'}
+
   format@0.2.2:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
     engines: {node: '>=0.4.x'}
+
+  framer-motion@13.1.1:
+    resolution: {integrity: sha512-B/xn2TPS4f61cEBLFjiYlQFnBZUW1YVj/LM+C+N4OP8Rs95VLEI2ot/RlfBg111la/EiyECFaJJi/A3FWA8MUA==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -1702,6 +3005,10 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  fuse.js@7.5.0:
+    resolution: {integrity: sha512-sQtrEfA+ez/3G0cCZecF70oqpCRttCexYUG4mUrtWL49ULUzUyxokt5kyqwtKzj1270RaKih+hcP3qLcumccow==}
+    engines: {node: '>=10'}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -1710,13 +3017,47 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
+  get-port-please@3.2.0:
+    resolution: {integrity: sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==}
+
+  get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
+
+  get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
+
+  get-stream@8.0.1:
+    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
+    engines: {node: '>=16'}
+
+  get-uri@6.0.5:
+    resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
+    engines: {node: '>= 14'}
+
+  giget@3.3.1:
+    resolution: {integrity: sha512-r+mvuDjrjMpsdw46Kmeydb8bdHm7wOKw8wNBtTndkjbPjgAp5oUJUxRE76wZFknxIPokfWvep2qSXK37aXE6zg==}
+    hasBin: true
+
   goober@2.1.19:
     resolution: {integrity: sha512-U7veizMqxyKlM58+Z5j2ngJBH/r9siDmxpvNxSw0PylF6WQvrASJEZrxh1hidRBJc2jqoBVSyOban5u8m+6Rxg==}
     peerDependencies:
       csstype: ^3.0.10
 
+  got@13.0.0:
+    resolution: {integrity: sha512-XfBk1CxOOScDcMr9O1yKkNaQyy865NbYs+F7dr4H0LZMVgCj2Le59k6PqbNHoL5ToeaEQUYh6c6yMfVcc6SJxA==}
+    engines: {node: '>=16'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  h3@1.15.11:
+    resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
 
   h3@2.0.1-rc.20:
     resolution: {integrity: sha512-28ljodXuUp0fZovdiSRq4G9OgrxCztrJe5VdYzXAB7ueRvI7pIUqLU14Xi3XqdYJ/khXjfpUOOD2EQa6CmBgsg==}
@@ -1768,6 +3109,9 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
+  hey-listen@1.0.8:
+    resolution: {integrity: sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==}
+
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
@@ -1780,15 +3124,73 @@ packages:
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
+  http-cache-semantics@4.2.0:
+    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
+  http-link-header@1.1.4:
+    resolution: {integrity: sha512-xT3GPW6/ZbGuw4UvwHqErSCEjNUlwbQJuZn9/q5U4WEKfp2kENVCAlousG1zLxHeaQ/ffOHUNpWamvkbBW0eNw==}
+    engines: {node: '>=6.0.0'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  http-shutdown@1.2.2:
+    resolution: {integrity: sha512-S9wWkJ/VSY9/k4qcjG318bqJNruzE4HySUhFYknwmu6LBP97KLLfwNf+n4V1BHurvFNkSKLFnK/RsuUnRTf9Vw==}
+    engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
+
+  http2-wrapper@2.2.1:
+    resolution: {integrity: sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==}
+    engines: {node: '>=10.19.0'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
   httpxy@0.5.5:
     resolution: {integrity: sha512-uDjmnPyp1q4Sgzf3w+J/Fc6UqcCEj0x4Wjp7OqK5dGhNeDgpyrAmnS6ey8QWrX3SWDon2DMKf9sBa5X9+CVyMA==}
+
+  human-signals@5.0.0:
+    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
+    engines: {node: '>=16.17.0'}
+
+  ignore@7.0.6:
+    resolution: {integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==}
+    engines: {node: '>= 4'}
+
+  image-ssim@0.2.0:
+    resolution: {integrity: sha512-W7+sO6/yhxy83L0G7xR8YAc5Z5QFtYEXXRV6EaE8tuYBZJnA3gVgp3q7X7muhLZVodeb9UfvjSbwt9VJwjIYAg==}
 
   imagetools-core@12.0.0:
     resolution: {integrity: sha512-9u1nEZrA6qd/dv1okXT/i1bLOnL9YAAg7k5BqnBJe5PxYYRecZ/GNyGxUXG5x6ybyvCa25zlx5XX++nSEAkjQw==}
     engines: {node: '>=22.0.0'}
 
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
+  import-in-the-middle@3.3.3:
+    resolution: {integrity: sha512-AiohS3H80sXO6owEltjGX+glb7qXaDhBoJb9XcQVH4UI207xu/bDLUcadVKp7Qe576reg9yr/PXZjV5qx8gfbA==}
+    engines: {node: '>=18'}
+
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  intl-messageformat@10.7.18:
+    resolution: {integrity: sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==}
+
+  ip-address@10.5.0:
+    resolution: {integrity: sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==}
+    engines: {node: '>= 12'}
+
+  iron-webcrypto@1.2.1:
+    resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -1799,27 +3201,81 @@ packages:
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
+  is-docker@2.2.1:
+    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
+  is-obj@2.0.0:
+    resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
+    engines: {node: '>=8'}
 
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-stream@3.0.0:
+    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  is-typedarray@1.0.0:
+    resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
+
+  is-unsafe@2.0.2:
+    resolution: {integrity: sha512-HgbIHPBH0KHHCcjLfGsCvhtPTVxjaAZlXjwdz7/GQC40SjSe4sfQsar8J5VFo8JOSbarkpV0OLG95bbaNd9aAQ==}
+
+  is-wsl@2.2.0:
+    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
+    engines: {node: '>=8'}
+
   isbot@5.2.1:
     resolution: {integrity: sha512-dJ+LpKyClQZ7NG+j3OensC/mAZkGpukE9YUrgPYvAZj2doVL0edfDgywTUh5CXa0o+nW9a1V9e5+CJTX8+SxRw==}
     engines: {node: '>=18'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isomorphic-fetch@3.0.0:
+    resolution: {integrity: sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==}
+
+  isomorphic.js@0.2.5:
+    resolution: {integrity: sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==}
 
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  jpeg-js@0.4.4:
+    resolution: {integrity: sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==}
+
+  js-library-detector@6.7.0:
+    resolution: {integrity: sha512-c80Qupofp43y4cJ7+8TTDN/AsDwLi5oOm/plBrWI+iQt485vKXCco+yVmOwEgdo9VOdsYTuV0UlTeetVPTriXA==}
+    engines: {node: '>=12'}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
+    hasBin: true
 
   js-yaml@4.3.1:
     resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
@@ -1829,6 +3285,9 @@ packages:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
     hasBin: true
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -1843,8 +3302,48 @@ packages:
     resolution: {integrity: sha512-IMPntbRLOU+eu88XDiFKqQ8Akhr9Tv7jDMXqPhjG9SI1JMA4DIgXk4x9k4skJz2NZJXBRbC+2pYBLj9olqcZow==}
     hasBin: true
 
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  klona@2.0.6:
+    resolution: {integrity: sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==}
+    engines: {node: '>= 8'}
+
+  knitwork@1.3.0:
+    resolution: {integrity: sha512-4LqMNoONzR43B1W0ek0fhXMsDNW/zxa1NdFAVMY+k28pgZLovR4G3PB5MrpTxCy1QaZCqNoiaKPr5w5qZHfSNw==}
+
   launch-editor@2.14.1:
     resolution: {integrity: sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==}
+
+  legacy-javascript@0.0.1:
+    resolution: {integrity: sha512-lPyntS4/aS7jpuvOlitZDFifBCb4W8L/3QU0PLbUTUj+zYah8rfVjYic88yG7ZKTxhS5h9iz7duT8oUXKszLhg==}
+
+  lib0@0.2.117:
+    resolution: {integrity: sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  lie@3.1.1:
+    resolution: {integrity: sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==}
+
+  lighthouse-logger@2.0.2:
+    resolution: {integrity: sha512-vWl2+u5jgOQuZR55Z1WM0XDdrJT6mzMP8zHUct7xTlWhuQs+eV0g+QL0RQdFjT54zVmbhLCP8vIVpy1wGn/gCg==}
+
+  lighthouse-stack-packs@1.12.2:
+    resolution: {integrity: sha512-Ug8feS/A+92TMTCK6yHYLwaFMuelK/hAKRMdldYkMNwv+d9PtWxjXEg6rwKtsUXTADajhdrhXyuNCJ5/sfmPFw==}
+
+  lighthouse-stack-packs@1.12.3:
+    resolution: {integrity: sha512-d8IsOpE83kbANgnM+Tp8+x6HcMpX9o2ITBiUERssgzAIFdZCQzs/f4k6D0DLQTE59enml9mbAOU52Wu35exWtg==}
+
+  lighthouse@12.6.1:
+    resolution: {integrity: sha512-85WDkjcXAVdlFem9Y6SSxqoKiz/89UsDZhLpeLJIsJ4LlHxw047XTZhlFJmjYCB7K5S1erSBAf5cYLcfyNbH3A==}
+    engines: {node: '>=18.20'}
+    hasBin: true
+
+  lighthouse@13.4.1:
+    resolution: {integrity: sha512-fDu8lt3QLK/lTqIxtp1HkzQNJ32rsFHhbadYOepcMZFLgA8oINhxutMbMv8XXnpTOvZ0TXCo4JCk1LDTWaRLnA==}
+    engines: {node: '>=22.19'}
+    hasBin: true
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -1994,20 +3493,82 @@ packages:
     resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
     engines: {node: '>= 12.0.0'}
 
+  lightweight-charts@5.2.1:
+    resolution: {integrity: sha512-IVwoK1RLFiLPubaKIjNbtjWLnpPMqiABSrTay6whmNa8L1+19292VtHJ+BWyPUuLCwF0tcQlhEWd1CLB2a1nsQ==}
+
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  linkifyjs@4.3.3:
+    resolution: {integrity: sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==}
+
+  listhen@1.10.1:
+    resolution: {integrity: sha512-6nt/86SkqUQSLW1ofz8MxC6RhRMqOl3ONISe6qqvJ3xj09aJWQx6DhgSZpugs3PX4PXdOas/WD6A9jx6J2N19A==}
+    hasBin: true
+    peerDependencies:
+      '@parcel/watcher': ^2.5.6
+    peerDependenciesMeta:
+      '@parcel/watcher':
+        optional: true
+
+  local-pkg@1.2.1:
+    resolution: {integrity: sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==}
+    engines: {node: '>=14'}
+
+  localforage@1.10.0:
+    resolution: {integrity: sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==}
+
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
+  lookup-closest-locale@6.2.0:
+    resolution: {integrity: sha512-/c2kL+Vnp1jnV6K6RpDTHK3dgg0Tu2VVp+elEiJpjfS1UyY7AjOYHohRug6wT0OpoX2qFgNORndE9RqesfVxWQ==}
+
+  lowercase-keys@3.0.0:
+    resolution: {integrity: sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   lowlight@1.20.0:
     resolution: {integrity: sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==}
 
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lru-cache@7.18.3:
+    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
+    engines: {node: '>=12'}
+
+  magic-regexp@0.10.0:
+    resolution: {integrity: sha512-Uly1Bu4lO1hwHUW0CQeSWuRtzCMNO00CmXtS8N6fyvB3B979GOEEeAkiTUDsmbYLAbvpUS/Kt5c4ibosAzVyVg==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  magic-string@1.2.3:
+    resolution: {integrity: sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==}
+
+  make-dir@3.1.0:
+    resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
+    engines: {node: '>=8'}
+
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  marked@17.0.6:
+    resolution: {integrity: sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
+  marky@1.3.0:
+    resolution: {integrity: sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==}
 
   match-sorter@8.3.0:
     resolution: {integrity: sha512-8Py1GbZi5zsclYSFcPAH4H5xfTbeD0bOREA7qP/t8bW4MbOSlPl8sbqHOedEV7O+Bxyvxm6xs/v6BXJGe+JDNA==}
@@ -2062,6 +3623,19 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
+  meriyah@6.1.4:
+    resolution: {integrity: sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==}
+    engines: {node: '>=18.0.0'}
+
+  metaviewport-parser@0.3.0:
+    resolution: {integrity: sha512-EoYJ8xfjQ6kpe9VbVHvZTZHiOl4HL1Z18CrZ+qahvLXT7ZO4YTC2JMyt5FaUp9JJp6J4Ybb/z7IsCXZt86/QkQ==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -2150,6 +3724,47 @@ packages:
   micromark@4.0.2:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
+  mimic-fn@4.0.0:
+    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
+    engines: {node: '>=12'}
+
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
+  mimic-response@4.0.0:
+    resolution: {integrity: sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
+  modern-tar@0.8.4:
+    resolution: {integrity: sha512-gN54ddmyzEg10orwZ2u4OOv+bjpMWdIl5jIkodK97bMq8QBSL5c0D7YX0lT1Ooz+99S7+PvFbnxzdjgHo1r41g==}
+    engines: {node: '>=18.0.0'}
+
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
+
+  motion-dom@13.1.1:
+    resolution: {integrity: sha512-XSf8VYWSB6G/0IY3rWVbyLcxWXtAVHkN1PQE2agTaCv3u8RGvbwu56TyyR/MNzBqqNavEBTZzErcxI1TxBrjcA==}
+
+  motion-utils@13.0.0:
+    resolution: {integrity: sha512-7DnN7TmbLcYXcG4RVadXIihWlyuM9afoUww8Y5Agg431kGKiuL2/OMyP4mJ5wLz+pvN3t5ySClLOaVXJ+wekRQ==}
+
+  motion-v@2.4.0:
+    resolution: {integrity: sha512-kRDGMAZk3nvdjEO36Wo6pezSEIStGXGhVFiwo1QkUDsUg8mB5igjYPXyece8wtu2DrHhmFfA6Y1nOz07+5QH4A==}
+    peerDependencies:
+      '@vueuse/core': '>=10.0.0'
+      vue: '>=3.0.0'
+
+  mrmime@2.0.1:
+    resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
+    engines: {node: '>=10'}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -2157,6 +3772,10 @@ packages:
     resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  netmask@2.1.1:
+    resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
+    engines: {node: '>= 0.4.0'}
 
   nf3@0.3.24:
     resolution: {integrity: sha512-HxLK4bo+5jNsEETZp4w3tJblHOA9MCBY14IN9nZJJV8JDxt9yNIYxuBuLMjTAR5GFa3HL61+8VQDUrXv3/C8fw==}
@@ -2192,12 +3811,53 @@ packages:
       zephyr-agent:
         optional: true
 
+  node-fetch-native@1.6.7:
+    resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  node-forge@1.4.0:
+    resolution: {integrity: sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==}
+    engines: {node: '>= 6.13.0'}
+
+  node-mock-http@1.0.5:
+    resolution: {integrity: sha512-KQyt/wLjG3TAc7DOUhpqWzgd4ERxR80JOlTK5VE5R1S12IaPVN5qkj4klBce9HPG1Njuup4Sb5bljaT34lIyjw==}
+
   node-releases@2.0.53:
     resolution: {integrity: sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==}
     engines: {node: '>=18'}
 
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
+  normalize-url@8.1.1:
+    resolution: {integrity: sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==}
+    engines: {node: '>=14.16'}
+
+  nostics@1.2.0:
+    resolution: {integrity: sha512-FGqEfhQjrvo1lL8KFifdTQiNwwQHJxC1jtYE1Rc54qF/jxONUNL+kC9gS1krX8Q65PgrQ5fCqH/I4NhWBvdSqg==}
+
+  npm-run-path@5.3.0:
+    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
   ocache@0.1.5:
     resolution: {integrity: sha512-kNNnkkVQup/QDvmTz8Q84wc2ntiyoVHDxa6eHWKt5qdGAmFRBIxy83rxgCYEjW0x06UJ9E3P6VgM2yY4rOBH4w==}
+
+  ofetch@1.5.1:
+    resolution: {integrity: sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==}
 
   ofetch@2.0.0-alpha.3:
     resolution: {integrity: sha512-zpYTCs2byOuft65vI3z43Dd6iSdFbOZZLb9/d21aCpx2rGastVU9dOCv0lu4ykc1Ur1anAYjDi3SUvR0vq50JA==}
@@ -2205,9 +3865,59 @@ packages:
   ohash@2.0.12:
     resolution: {integrity: sha512-65S/5gk9YSsaRjcyf7Nfa6h/d3E8/1gslpXfI4W7Dxn/oap8IKRuNT5VXkLQ1YFKIEg4apRY4Pj6aiwFzrDdmw==}
 
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  onetime@6.0.0:
+    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
+    engines: {node: '>=12'}
+
+  open@8.4.2:
+    resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
+    engines: {node: '>=12'}
+
+  orderedmap@2.1.1:
+    resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
+
   oxc-parser@0.120.0:
     resolution: {integrity: sha512-WyPWZlcIm+Fkte63FGfgFB8mAAk33aH9h5N9lphXVOHSXEBFFsmYdOBedVKly363aWABjZdaj/m9lBfEY4wt+w==}
     engines: {node: ^20.19.0 || >=22.12.0}
+
+  oxc-walker@1.1.1:
+    resolution: {integrity: sha512-Hwd7dq28zu/Er99+bpWp16CGwFrhyalJh0W3JOB7XpPvgWo3MqMi2ksWGKuzzA9zt50mJ2pIUwR5lpAdZ9ACNQ==}
+    peerDependencies:
+      '@oxc-project/types': '>=0.98.0'
+      oxc-parser: '>=0.98.0'
+      rolldown: '>=1.0.0'
+    peerDependenciesMeta:
+      '@oxc-project/types':
+        optional: true
+      oxc-parser:
+        optional: true
+      rolldown:
+        optional: true
+
+  p-cancelable@3.0.0:
+    resolution: {integrity: sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==}
+    engines: {node: '>=12.20'}
+
+  p-limit@6.2.0:
+    resolution: {integrity: sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==}
+    engines: {node: '>=18'}
+
+  pac-proxy-agent@7.2.0:
+    resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
+    engines: {node: '>= 14'}
+
+  pac-resolver@7.0.1:
+    resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
+    engines: {node: '>= 14'}
+
+  package-manager-detector@1.8.0:
+    resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
+
+  parse-cache-control@1.0.1:
+    resolution: {integrity: sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==}
 
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
@@ -2215,15 +3925,43 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
+  path-expression-matcher@1.6.2:
+    resolution: {integrity: sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==}
+    engines: {node: '>=14.0.0'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+
+  perfect-debounce@2.1.0:
+    resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
   picomatch@4.0.7:
     resolution: {integrity: sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==}
     engines: {node: '>=12'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  pkg-types@2.3.1:
+    resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
 
   playwright-core@1.62.1:
     resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
@@ -2252,8 +3990,92 @@ packages:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
 
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
+  prosemirror-changeset@2.4.2:
+    resolution: {integrity: sha512-ViYrjMSg3YFiXwIhKaluu+/mi3Yrxt6AR8ri14ulTaGcZtXO1CThl7A2gv79qx5fQnOw8woKwyBU2u+9PVCm3w==}
+
+  prosemirror-commands@1.7.2:
+    resolution: {integrity: sha512-q6Q6szxqdu9Xd6EcdKsqXghu5nQdZTpB4Q9yd04WRc7/jt763e/rT60Owh0L1GYY+T46o5rD+9lEN36dZS43tw==}
+
+  prosemirror-dropcursor@1.8.3:
+    resolution: {integrity: sha512-FoYbsJR8gK+DGlqhNoE29Loa38eIZPzQRIb1VMaDNBoo4OLP6vVof/jR8qFY/6XvUd6Dhug8MDCHl2a/h8RTfQ==}
+
+  prosemirror-gapcursor@1.4.1:
+    resolution: {integrity: sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==}
+
+  prosemirror-history@1.5.0:
+    resolution: {integrity: sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==}
+
+  prosemirror-inputrules@1.5.1:
+    resolution: {integrity: sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==}
+
+  prosemirror-keymap@1.2.3:
+    resolution: {integrity: sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==}
+
+  prosemirror-model@1.25.11:
+    resolution: {integrity: sha512-QWg9RhnpLlogAmp3p96uEFrE5txQpFynd4vhBAELkwgOCWQs/X0yCzB3/hrHqiPwf91RG5KyWq6553zs9JqIOQ==}
+
+  prosemirror-schema-list@1.5.1:
+    resolution: {integrity: sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==}
+
+  prosemirror-state@1.4.4:
+    resolution: {integrity: sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==}
+
+  prosemirror-tables@1.8.5:
+    resolution: {integrity: sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==}
+
+  prosemirror-transform@1.12.0:
+    resolution: {integrity: sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==}
+
+  prosemirror-view@1.42.3:
+    resolution: {integrity: sha512-oTN7EtH+CpwxU9NrwEYWd0UZ4JUx7l048l5A2Xppm4p/60isZYLnth9QVQmC3VRIvdrIWCxwZSd+Uz791G31/w==}
+
+  proxy-agent@6.5.0:
+    resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
+    engines: {node: '>= 14'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  puppeteer-cluster@0.25.0:
+    resolution: {integrity: sha512-WEqR6ccYoEMOqW5HAnzs8TJ40xfEaaiZ0LJG1IM8poMGdAgAQBmrZX4n+LLNvVY6G90R22rYZjuPDrw0ho5t+A==}
+    peerDependencies:
+      puppeteer: '>=24.0.0'
+
+  puppeteer-core@24.43.1:
+    resolution: {integrity: sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw==}
+    engines: {node: '>=18'}
+
+  puppeteer-core@25.9.0:
+    resolution: {integrity: sha512-U61rCwSMha62CA/Opy6tCx2Fx+ck7ouiKnbpEApzSoLYMoEu9F71nuFpHL55vmIt33/GYm6eKZVhH2ev0nAIeg==}
+    engines: {node: '>=22.12.0'}
+
+  puppeteer@25.9.0:
+    resolution: {integrity: sha512-2JqQszD2pyDTpIvBH1ZCXdrHgENVNdJIeOM6asbwHRgWknFiaLd1gNB91w/B/0hQHNpafkpxa90lPpBaJM87Hw==}
+    engines: {node: '>=22.12.0'}
+    hasBin: true
+
+  quansync@0.2.11:
+    resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
+
+  quick-lru@5.1.1:
+    resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
+    engines: {node: '>=10'}
+
+  radix3@1.1.2:
+    resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
+
+  rc9@3.0.1:
+    resolution: {integrity: sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==}
 
   react-dom@19.2.8:
     resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
@@ -2283,6 +4105,14 @@ packages:
   refractor@5.0.0:
     resolution: {integrity: sha512-QXOrHQF5jOpjjLfiNk5GFnWhRXvxjUVnlFxkeDmewR5sXkr3iM46Zo+CnRR8B+MDVqkULW4EcLVcRBNOPXHosw==}
 
+  regexp-tree@0.1.27:
+    resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
+    hasBin: true
+
+  regexparam@3.0.0:
+    resolution: {integrity: sha512-RSYAtP31mvYLkAHrOlh25pCNQ5hWnT106VukGaaFfuJrZFkGRX5GhUAdPqpSDXxOhA2c4akmRuplv1mRqnBn6Q==}
+    engines: {node: '>=8'}
+
   rehype-katex@7.0.1:
     resolution: {integrity: sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==}
 
@@ -2290,6 +4120,11 @@ packages:
     resolution: {integrity: sha512-1+6kKPSJPnNHYcA9rEbUVMpzKSXJuJPVHEkIo6l6DQnhNnEEpBXBn/XgBqEFniokMyXy+sitLv7vVpQ/xsJ26Q==}
     peerDependencies:
       react: '>=16.8.0'
+
+  reka-ui@2.10.3:
+    resolution: {integrity: sha512-nJGZbwcha8AcP2wbnjodfzsciTKBqp1mIzepC9Pi2xDI/YK3++ej3vpJOSPyxqrkq1Oorj4K+BdJkbVCV6x6ag==}
+    peerDependencies:
+      vue: '>= 3.4.0'
 
   remark-breaks@4.0.0:
     resolution: {integrity: sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==}
@@ -2316,16 +4151,47 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
+
+  resolve-alpn@1.2.1:
+    resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
+
+  responselike@3.0.0:
+    resolution: {integrity: sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==}
+    engines: {node: '>=14.16'}
+
+  robots-parser@3.0.1:
+    resolution: {integrity: sha512-s+pyvQeIKIZ0dx5iJiQk1tPLJAWln39+MI5jtM8wnyws+G5azk+dMnMX0qfbqNetKKNgcWWOdi0sfm+FbQbgdQ==}
+    engines: {node: '>=10.0.0'}
+
   rolldown@1.2.5:
     resolution: {integrity: sha512-VD2IE5PUG4Oj8zz2VGykiYd5wbnjdIiSsNQb8Qu5B+noEp+A78mu2iVvpp27g8es14Tk9rofNs5Tku9iQCS4fA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  rope-sequence@1.3.4:
+    resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
+
   rou3@0.8.1:
     resolution: {integrity: sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==}
 
+  sanitize-filename@1.6.4:
+    resolution: {integrity: sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  scule@1.3.0:
+    resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
+
+  semifies@1.0.0:
+    resolution: {integrity: sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==}
+
+  semver@5.7.2:
+    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+    hasBin: true
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -2365,15 +4231,62 @@ packages:
       '@types/node':
         optional: true
 
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
   shell-quote@1.10.0:
     resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
     engines: {node: '>= 0.4'}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  sirv@3.0.2:
+    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
+    engines: {node: '>=18'}
+
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
+  sitemapper@4.1.6:
+    resolution: {integrity: sha512-EI2dvLWzPw7+FI6LQPjdo6P4IZ4HFv0vNmssE3Hloqq/sVO9URGMPmrcP4PCNgydCBGIETAZnVmW86h8vwbHrA==}
+    engines: {node: '>= 18.0.0'}
+    hasBin: true
+
+  slugify@1.6.9:
+    resolution: {integrity: sha512-vZ7rfeehZui7wQs438JXBckYLkIIdfHOXsaVEUMyS5fHo1483l1bMdo0EDSWYclY0yZKFOipDy4KHuKs6ssvdg==}
+    engines: {node: '>=8.0.0'}
+
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  socks-proxy-agent@8.0.5:
+    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
+    engines: {node: '>= 14'}
+
+  socks@2.8.9:
+    resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
   solid-js@1.9.15:
     resolution: {integrity: sha512-EeiY2xfpZJqPLjXspVEKjAII4yv8NyG//NxZ3IpOFHdUNnnTyL0uJOeS9LWGvA7cFCz5y94cjFwYlmw5Luncsg==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
   source-map@0.7.6:
@@ -2383,14 +4296,35 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  speedline-core@1.4.3:
+    resolution: {integrity: sha512-DI7/OuAUD+GMpR6dmu8lliO2Wg5zfeh+/xsdyJZCzd8o5JgFUjCeLsBDuZjIQJdwXS3J0L/uZYrELKYqx+PXog==}
+    engines: {node: '>=8.0'}
+
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
   srvx@0.11.22:
     resolution: {integrity: sha512-LqZxxBDMKuMAZzFzJnDCkFOrs9MZQZr0LvHiO/SuSZVdQaXD7xQ5UWTUxheJrQPve1qk9MG2B/yttUvJxw8egQ==}
     engines: {node: '>=20.16.0'}
     hasBin: true
 
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
+  streamx@2.28.1:
+    resolution: {integrity: sha512-zEzXb0s5Cds7tqMH6rhZ05lcJydCWiQPEwiNngVqzsxCc962vLY4Uw+mW7od8kDH258k2Uz/JrOkdIAAhSh9VA==}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
+
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
+  string-width@8.2.2:
+    resolution: {integrity: sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==}
+    engines: {node: '>=20'}
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
@@ -2398,6 +4332,26 @@ packages:
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
+  strip-final-newline@3.0.0:
+    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
+    engines: {node: '>=12'}
+
+  strip-literal@4.0.0:
+    resolution: {integrity: sha512-PaqAvfUZKBwc/SLmNZtHmzK+v19Z4O4eS3cKPeGvbIv/U3pnyEq4Tuw3/4v/FwfM8VQaEawsyCcOQ0P+kpwWWw==}
+
+  strnum@2.4.2:
+    resolution: {integrity: sha512-rDG3Ah4TV0k1hWvLSzkZtMmLN9+eS+h3knq4MP6A42Y3Yh5qGNnOUs1jJkoSr8FG5dsL28c7KgkIBzSEykqtuw==}
+
+  stubborn-fs@2.0.0:
+    resolution: {integrity: sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==}
+
+  stubborn-utils@1.0.2:
+    resolution: {integrity: sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==}
 
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
@@ -2410,6 +4364,21 @@ packages:
     peerDependencies:
       tailwindcss: '4'
 
+  tailwind-merge@3.6.0:
+    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
+
+  tailwind-variants@3.3.1:
+    resolution: {integrity: sha512-4pAvwUtM4HKBiRZftncAbpn6V9Hhwoa5Fl7O2u5zbp7Z5Cvu+/o/6+176WY3WCEES209543quG8zFIcXCsc5Jw==}
+    engines: {node: '>=16.9.x', pnpm: '>=7.x'}
+    peerDependencies:
+      tailwind-merge: '>=3.0.0'
+      tailwindcss: '*'
+    peerDependenciesMeta:
+      tailwind-merge:
+        optional: true
+      tailwindcss:
+        optional: true
+
   tailwindcss@4.3.3:
     resolution: {integrity: sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==}
 
@@ -2417,15 +4386,70 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  tar-fs@3.1.3:
+    resolution: {integrity: sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==}
+
+  tar-stream@3.2.1:
+    resolution: {integrity: sha512-nqsEO8zLZJvrOMdEwkA0QdCLFbetHMn95Zqu4fKwX+hkaTWJPZZOrxx/PwtxoK0MMGQmBQNRW3CPs8IFYQz4cQ==}
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
+
+  third-party-web@0.26.7:
+    resolution: {integrity: sha512-buUzX4sXC4efFX6xg2bw6/eZsCUh8qQwSavC4D9HpONMFlRbcHhD8Je5qwYdCpViR6q0qla2wPP+t91a2vgolg==}
+
+  third-party-web@0.29.2:
+    resolution: {integrity: sha512-fegtha91tq2DHphyoiBXVHjVi2YG9zFaRnboT9C28tO1en9Y3wJsfspuy40F+u5wl3hHVbw7cnd1b67kEGHb8g==}
+
+  tiny-inflate@1.0.3:
+    resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
+
+  tinyclip@0.1.15:
+    resolution: {integrity: sha512-uo33abH+Ays0xYaDysoBt494Hb3hsEczMpcC0MwFl773pazORx4fmvKhclhR1wonUbB6vvpRsvVMwnhfqeMc+A==}
+    engines: {node: ^16.14.0 || >= 17.3.0}
+
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts-core@7.4.11:
+    resolution: {integrity: sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==}
+
+  tldts-icann@6.1.86:
+    resolution: {integrity: sha512-NFxmRT2lAEMcCOBgeZ0NuM0zsK/xgmNajnY6n4S1mwAKocft2s2ise1O3nQxrH3c+uY6hgHUV9GGNVp7tUE4Sg==}
+
+  tldts-icann@7.4.11:
+    resolution: {integrity: sha512-1p+NDJ7FUYCliESmsQl9EW5Um8JIyFheiy6Y6ZoHho27d+TLAGFa0gMf1VOVy02vNY1aQo6xeKiaGj45+7P+PA==}
+
+  totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
+  truncate-utf8-bytes@1.0.2:
+    resolution: {integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -2435,6 +4459,19 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
+
+  type-level-regexp@0.1.17:
+    resolution: {integrity: sha512-wTk4DH3cxwk196uGLK/E9pE45aLfeKJacKmcEgEOA/q5dnPGNxXt0cfYdFxb57L+sEpf1oJH4Dnx/pnRcku9jg==}
+
+  typed-query-selector@2.12.2:
+    resolution: {integrity: sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==}
+
+  typedarray-to-buffer@3.1.5:
+    resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -2443,14 +4480,71 @@ packages:
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
+  ultrahtml@1.7.0:
+    resolution: {integrity: sha512-2xRd0VHoAQE4M+vF/DvFFB7pUV0ZxTW1TLi7lHQWnF/Sb5TPeEUV/l+hxcNnGO00ZXGnR0voCMmYRKQf+rvJ2g==}
+
+  uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+
+  unctx@2.5.0:
+    resolution: {integrity: sha512-p+Rz9x0R7X+CYDkT+Xg8/GhpcShTlU8n+cf9OtOEf7zEQsNcCZO1dPKNRDqvUTaq+P32PMMkxWHwfrxkqfqAYg==}
+
+  unctx@3.0.1:
+    resolution: {integrity: sha512-5RAt2etv7g362RXyd33R82gm9u/kbtQlpoaOs9Bgm4E32GRMJ0xjbZyvdxUTmiuHk3V1IQb1aUNrp5IWY+JaWw==}
+    peerDependencies:
+      magic-string: '>=0.30.21'
+      oxc-parser: '>=0.140.0'
+      rolldown: ^1.1.5
+      unplugin: ^3.3.0
+    peerDependenciesMeta:
+      magic-string:
+        optional: true
+      oxc-parser:
+        optional: true
+      rolldown:
+        optional: true
+      unplugin:
+        optional: true
+
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+    engines: {node: '>=22.19.0'}
 
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
+  unhead@3.4.0:
+    resolution: {integrity: sha512-OlgpyYjY+NkFyQCaMihg2uTFbbvyr5lZr6TokS68VdFTXJ5jo4JwFtGR8PwKy/wRpjbQYgKF7ZYO+pbRgxtSmw==}
+    peerDependencies:
+      vite: '>=6.4.2'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unifont@0.7.5:
+    resolution: {integrity: sha512-ULe/Cs+ZIsq+dcFofNkhqielCrUJnb5mr+Yc4EBM2VlL+6OZR6+cjtI2mT1bJvRBrVncqHAbLURxmPLcCXzWMg==}
+
+  unimport@6.4.0:
+    resolution: {integrity: sha512-JJOOuNMFq8b4ZPBKwQUxEcba4MplskDzYI1Lvrf8rJfWphZTWvPNXWa493qsPngHUmub89w6C7j+SeLWTE/UIQ==}
+    engines: {node: '>=18.12.0'}
+    peerDependencies:
+      oxc-parser: '*'
+      rolldown: ^1.0.0
+    peerDependenciesMeta:
+      oxc-parser:
+        optional: true
+      rolldown:
+        optional: true
+
+  unique-string@2.0.0:
+    resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
+    engines: {node: '>=8'}
 
   unist-util-find-after@5.0.0:
     resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
@@ -2472,6 +4566,49 @@ packages:
 
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
+  unlighthouse@0.18.0:
+    resolution: {integrity: sha512-09+nGgKDiMXDyusDU7ccs/WwcEYBhXXm4BXF7GopLO99lC8vu5PaRY6/rLxDnmC1is71N1gpwTVPQQUTDbAfoA==}
+    engines: {node: '>=22.18.0'}
+    hasBin: true
+    peerDependencies:
+      puppeteer: '*'
+      vue: '*'
+    peerDependenciesMeta:
+      puppeteer:
+        optional: true
+      vue:
+        optional: true
+
+  unplugin-auto-import@21.1.0:
+    resolution: {integrity: sha512-EzrSqWIBulEqCuP7idADXH+tVKYrbwKlR5+r/lOWik0o+Ksny1kitmtryHGNSv7puzzORlcIwT/x2JStiszlHA==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@nuxt/kit': ^4.0.0
+      '@vueuse/core': '*'
+    peerDependenciesMeta:
+      '@nuxt/kit':
+        optional: true
+      '@vueuse/core':
+        optional: true
+
+  unplugin-utils@0.3.2:
+    resolution: {integrity: sha512-xVToRh2CTmLk2HnEG7ac4rl1MJTT3RFkpS8B++/SnB0kXvuaavD+n3m/vrzyWQOdJNSZQACnbz01pnppbwV5BA==}
+    engines: {node: '>=20.19.0'}
+
+  unplugin-vue-components@32.1.0:
+    resolution: {integrity: sha512-YiUkSxuRjab18XFOrX5VsIxXzccrfmHVGsGeJgSgklb829DQmCy9E4vvDUE4tuvZZdxyFJZX0Oc4TPnnxiiMyg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@nuxt/kit': ^3.2.2 || ^4.0.0
+      vue: ^3.0.0
+    peerDependenciesMeta:
+      '@nuxt/kit':
+        optional: true
+
+  unplugin@2.3.11:
+    resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
+    engines: {node: '>=18.12.0'}
 
   unplugin@3.3.0:
     resolution: {integrity: sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==}
@@ -2504,6 +4641,68 @@ packages:
       vite:
         optional: true
       webpack:
+        optional: true
+
+  unstorage@1.17.5:
+    resolution: {integrity: sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==}
+    peerDependencies:
+      '@azure/app-configuration': ^1.8.0
+      '@azure/cosmos': ^4.2.0
+      '@azure/data-tables': ^13.3.0
+      '@azure/identity': ^4.6.0
+      '@azure/keyvault-secrets': ^4.9.0
+      '@azure/storage-blob': ^12.26.0
+      '@capacitor/preferences': ^6 || ^7 || ^8
+      '@deno/kv': '>=0.9.0'
+      '@netlify/blobs': ^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0
+      '@planetscale/database': ^1.19.0
+      '@upstash/redis': ^1.34.3
+      '@vercel/blob': '>=0.27.1'
+      '@vercel/functions': ^2.2.12 || ^3.0.0
+      '@vercel/kv': ^1 || ^2 || ^3
+      aws4fetch: ^1.0.20
+      db0: '>=0.2.1'
+      idb-keyval: ^6.2.1
+      ioredis: ^5.4.2
+      uploadthing: ^7.4.4
+    peerDependenciesMeta:
+      '@azure/app-configuration':
+        optional: true
+      '@azure/cosmos':
+        optional: true
+      '@azure/data-tables':
+        optional: true
+      '@azure/identity':
+        optional: true
+      '@azure/keyvault-secrets':
+        optional: true
+      '@azure/storage-blob':
+        optional: true
+      '@capacitor/preferences':
+        optional: true
+      '@deno/kv':
+        optional: true
+      '@netlify/blobs':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/blob':
+        optional: true
+      '@vercel/functions':
+        optional: true
+      '@vercel/kv':
+        optional: true
+      aws4fetch:
+        optional: true
+      db0:
+        optional: true
+      idb-keyval:
+        optional: true
+      ioredis:
+        optional: true
+      uploadthing:
         optional: true
 
   unstorage@2.0.0-alpha.7:
@@ -2580,19 +4779,43 @@ packages:
       uploadthing:
         optional: true
 
+  untun@0.2.2:
+    resolution: {integrity: sha512-+NnOJcSiEtYsVgJmXUzQbJeRAFXJC4yPJYuh6kF9B0Rm6zunXcs/3GZOTllyocSbUDIxD6Bj7e/4ATw7sph1Sw==}
+    hasBin: true
+
+  untyped@2.0.0:
+    resolution: {integrity: sha512-nwNCjxJTjNuLCgFr42fEak5OcLuB3ecca+9ksPFNvtfYSLpjf+iJqSIaSnIile6ZPbKYxI5k2AfXqeopGudK/g==}
+    hasBin: true
+
   update-browserslist-db@1.3.1:
     resolution: {integrity: sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
 
+  uqr@0.1.3:
+    resolution: {integrity: sha512-0rjE8iEJe4YmT9TOhwsZtqCMRLc5DXZUI2UEYUUg63ikBkqqE5EYWaI0etFe/5KUcmcYwLih2RND1kq+hrUJXA==}
+
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  utf8-byte-length@1.0.5:
+    resolution: {integrity: sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==}
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vaul-vue@0.4.1:
+    resolution: {integrity: sha512-A6jOWOZX5yvyo1qMn7IveoWN91mJI5L3BUKsIwkg6qrTGgHs1Sb1JF/vyLJgnbN1rH4OOOxFbtqL9A46bOyGUQ==}
+    peerDependencies:
+      reka-ui: ^2.0.0
+      vue: ^3.3.0
+
+  verkit@0.3.2:
+    resolution: {integrity: sha512-zj/ob3UsvJGN0whEAKFp53REA5X66hvffVqoCtVQAakJKnKlH+/PcOfMoFwIG/o4rElqLv/ycAFlx8ZlXUorCg==}
+    engines: {node: '>=18.12.0'}
 
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
@@ -2660,15 +4883,92 @@ packages:
       vite:
         optional: true
 
+  vue-component-type-helpers@3.3.11:
+    resolution: {integrity: sha512-LwcxzeliO9fkQcpJG0PoX8X5kmAhKmH9wkpDLxNabwzkQ9Zeib2YVHwFV4pcWmMLfXVfjr/dSV+DaJ3cIPgSNA==}
+
+  vue-demi@0.14.10:
+    resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
+    engines: {node: '>=12'}
+    hasBin: true
+    peerDependencies:
+      '@vue/composition-api': ^1.0.0-rc.1
+      vue: ^3.0.0-0 || ^2.6.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
+
+  vue@3.5.41:
+    resolution: {integrity: sha512-2laE0p+aK+/AOPG/XL/WepOs/GlK755LJ1XECi9kDUrz1FKNw8rb2Xzlw9JS1rqEV55nb0ttsKxVlTCcd+R5cg==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
+
+  web-features@3.35.1:
+    resolution: {integrity: sha512-c9R1duLo60camLUu7JWP6nP/ALu1YI+bF7Pmyzo4tJM8lDzI/Uwlo++9DSfgoP3ziO/QtK+iBzaDAfp62rjBRA==}
+
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  webdriver-bidi-protocol@0.4.1:
+    resolution: {integrity: sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==}
+
+  webdriver-bidi-protocol@0.4.2:
+    resolution: {integrity: sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA==}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
+  whatwg-fetch@3.6.20:
+    resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  wheel-gestures@2.2.48:
+    resolution: {integrity: sha512-f+Gy33Oa5Z14XY9679Zze+7VFhbsQfBFXodnU2x589l4kxGM9L5Y8zETTmcMR5pWOPQyRv4Z0lNax6xCO0NSlA==}
+    engines: {node: '>=18'}
+
+  when-exit@2.1.5:
+    resolution: {integrity: sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
+
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  write-file-atomic@3.0.3:
+    resolution: {integrity: sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==}
+
+  ws@7.5.13:
+    resolution: {integrity: sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==}
+    engines: {node: '>=8.3.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   ws@8.21.3:
     resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
@@ -2682,9 +4982,27 @@ packages:
       utf-8-validate:
         optional: true
 
+  xdg-basedir@4.0.0:
+    resolution: {integrity: sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==}
+    engines: {node: '>=8'}
+
+  xdg-basedir@5.1.0:
+    resolution: {integrity: sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==}
+    engines: {node: '>=12'}
+
+  xml-naming@0.3.0:
+    resolution: {integrity: sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==}
+    engines: {node: '>=16.0.0'}
+
   xmlbuilder2@4.0.3:
     resolution: {integrity: sha512-bx8Q1STctnNaaDymWnkfQLKofs0mGNN7rLLapJlGuV3VlvegD7Ls4ggMjE3aUSWItCCzU0PEv45lI87iSigiCA==}
     engines: {node: '>=20.0'}
+
+  y-protocols@1.0.7:
+    resolution: {integrity: sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
+    peerDependencies:
+      yjs: ^13.0.0
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -2697,9 +5015,31 @@ packages:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
 
+  yargs-parser@22.0.0:
+    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
   yargs@17.7.3:
     resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
     engines: {node: '>=12'}
+
+  yargs@18.1.0:
+    resolution: {integrity: sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  yauzl@2.10.0:
+    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
+
+  yjs@13.6.32:
+    resolution: {integrity: sha512-lfiJIIC4Xayt5ItynE407ehlE03pCjeOc4hkR4yxxvvNJ4kuiN25B0g+Qp8XagYz361LLL7DCzR5bvFJ81QKtQ==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
+
+  yocto-queue@1.2.2:
+    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
+    engines: {node: '>=12.20'}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -2708,6 +5048,37 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@alloc/quick-lru@5.2.0': {}
+
+  '@antfu/install-pkg@1.1.0':
+    dependencies:
+      package-manager-detector: 1.8.0
+      tinyexec: 1.3.0
+
+  '@apm-js-collab/code-transformer-bundler-plugins@0.7.4':
+    dependencies:
+      '@apm-js-collab/code-transformer': 0.18.1
+      es-module-lexer: 2.3.2
+      magic-string: 0.30.21
+      module-details-from-path: 1.0.4
+
+  '@apm-js-collab/code-transformer@0.18.1':
+    dependencies:
+      '@types/estree': 1.0.9
+      astring: 1.9.0
+      esquery: 1.7.0
+      meriyah: 6.1.4
+      semifies: 1.0.0
+      source-map: 0.6.1
+
+  '@apm-js-collab/tracing-hooks@0.13.0':
+    dependencies:
+      '@apm-js-collab/code-transformer': 0.18.1
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -2852,8 +5223,24 @@ snapshots:
   '@biomejs/cli-win32-x64@2.5.10':
     optional: true
 
+  '@capsizecss/unpack@4.0.1':
+    dependencies:
+      fontkitten: 1.0.3
+
   '@chenglou/pretext@0.0.5':
     optional: true
+
+  '@clack/core@1.4.3':
+    dependencies:
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.7.0':
+    dependencies:
+      '@clack/core': 1.4.3
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
 
   '@emnapi/core@1.11.3':
     dependencies:
@@ -2871,87 +5258,228 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
   '@esbuild/aix-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
     optional: true
 
   '@esbuild/android-arm64@0.28.2':
     optional: true
 
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
   '@esbuild/android-arm@0.28.2':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
     optional: true
 
   '@esbuild/android-x64@0.28.2':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
   '@esbuild/darwin-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
     optional: true
 
   '@esbuild/darwin-x64@0.28.2':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-x64@0.28.2':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
   '@esbuild/linux-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
     optional: true
 
   '@esbuild/linux-arm@0.28.2':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
   '@esbuild/linux-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
     optional: true
 
   '@esbuild/linux-loong64@0.28.2':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
   '@esbuild/linux-mips64el@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
   '@esbuild/linux-ppc64@0.28.2':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
   '@esbuild/linux-riscv64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
     optional: true
 
   '@esbuild/linux-s390x@0.28.2':
     optional: true
 
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
   '@esbuild/linux-x64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/netbsd-arm64@0.28.2':
     optional: true
 
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
   '@esbuild/netbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.2':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
   '@esbuild/openbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
   '@esbuild/openharmony-arm64@0.28.2':
     optional: true
 
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
   '@esbuild/sunos-x64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
     optional: true
 
   '@esbuild/win32-arm64@0.28.2':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
   '@esbuild/win32-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@esbuild/win32-x64@0.28.2':
     optional: true
 
+  '@floating-ui/core@1.8.0':
+    dependencies:
+      '@floating-ui/utils': 0.2.12
+
+  '@floating-ui/dom@1.8.0':
+    dependencies:
+      '@floating-ui/core': 1.8.0
+      '@floating-ui/utils': 0.2.12
+
+  '@floating-ui/utils@0.2.12': {}
+
+  '@floating-ui/vue@1.1.11(vue@3.5.41(typescript@6.0.3))':
+    dependencies:
+      '@floating-ui/dom': 1.8.0
+      '@floating-ui/utils': 0.2.12
+      vue-demi: 0.14.10(vue@3.5.41(typescript@6.0.3))
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+
   '@fontsource-variable/cascadia-code@5.3.0': {}
 
   '@fontsource-variable/onest@5.3.0': {}
+
+  '@formatjs/ecma402-abstract@2.3.6':
+    dependencies:
+      '@formatjs/fast-memoize': 2.2.7
+      '@formatjs/intl-localematcher': 0.6.2
+      decimal.js: 10.6.0
+      tslib: 2.8.1
+
+  '@formatjs/fast-memoize@2.2.7':
+    dependencies:
+      tslib: 2.8.1
+
+  '@formatjs/icu-messageformat-parser@2.11.4':
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.6
+      '@formatjs/icu-skeleton-parser': 1.8.16
+      tslib: 2.8.1
+
+  '@formatjs/icu-skeleton-parser@1.8.16':
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.6
+      tslib: 2.8.1
+
+  '@formatjs/intl-localematcher@0.6.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@iconify/collections@1.0.728':
+    dependencies:
+      '@iconify/types': 2.0.0
+
+  '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@3.1.4':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/types': 2.0.0
+      import-meta-resolve: 4.2.0
+
+  '@iconify/vue@5.0.1(vue@3.5.41(typescript@6.0.3))':
+    dependencies:
+      '@iconify/types': 2.0.0
+      vue: 3.5.41(typescript@6.0.3)
 
   '@img/colour@1.1.0': {}
 
@@ -3059,6 +5587,14 @@ snapshots:
   '@img/sharp-win32-x64@0.35.3':
     optional: true
 
+  '@internationalized/date@3.12.3':
+    dependencies:
+      '@swc/helpers': 0.5.23
+
+  '@internationalized/number@3.6.7':
+    dependencies:
+      '@swc/helpers': 0.5.23
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3077,6 +5613,22 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@lhci/utils@0.15.1':
+    dependencies:
+      debug: 4.4.3
+      isomorphic-fetch: 3.0.0
+      js-yaml: 3.15.1
+      lighthouse: 12.6.1
+      tree-kill: 1.2.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - encoding
+      - react-native-b4a
+      - supports-color
+      - utf-8-validate
 
   '@napi-rs/canvas-android-arm64@1.0.8':
     optional: true
@@ -3139,6 +5691,269 @@ snapshots:
       '@neodrag/core': 3.0.0-next.11
       solid-js: 1.9.15
 
+  '@nodable/entities@3.0.0': {}
+
+  '@nuxt/devtools-kit@3.4.2(magic-string@1.2.3)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)))(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))':
+    dependencies:
+      '@nuxt/kit': 4.5.2(magic-string@1.2.3)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)))
+      execa: 8.0.1
+      vite: 8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)
+    transitivePeerDependencies:
+      - magic-string
+      - magicast
+      - oxc-parser
+      - rolldown
+      - unplugin
+
+  '@nuxt/fonts@0.14.0(db0@0.3.4)(esbuild@0.28.2)(magic-string@1.2.3)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))':
+    dependencies:
+      '@nuxt/devtools-kit': 3.4.2(magic-string@1.2.3)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)))(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+      '@nuxt/kit': 4.5.2(magic-string@1.2.3)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)))
+      consola: 3.4.2
+      defu: 6.1.7
+      fontless: 0.2.1(db0@0.3.4)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+      h3: 1.15.11
+      magic-regexp: 0.10.0
+      ofetch: 1.5.1
+      pathe: 2.0.3
+      sirv: 3.0.2
+      tinyglobby: 0.2.17
+      ufo: 1.6.4
+      unifont: 0.7.5
+      unplugin: 3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+      unstorage: 1.17.5(db0@0.3.4)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@farmfe/core'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@rspack/core'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bun-types-no-globals
+      - db0
+      - esbuild
+      - idb-keyval
+      - ioredis
+      - magic-string
+      - magicast
+      - oxc-parser
+      - rolldown
+      - rollup
+      - unloader
+      - uploadthing
+      - vite
+      - webpack
+
+  '@nuxt/icon@2.5.1(magic-string@1.2.3)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)))(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))(vue@3.5.41(typescript@6.0.3))':
+    dependencies:
+      '@iconify/collections': 1.0.728
+      '@iconify/types': 2.0.0
+      '@iconify/utils': 3.1.4
+      '@iconify/vue': 5.0.1(vue@3.5.41(typescript@6.0.3))
+      '@nuxt/devtools-kit': 3.4.2(magic-string@1.2.3)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)))(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+      '@nuxt/kit': 4.5.2(magic-string@1.2.3)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)))
+      consola: 3.4.2
+      local-pkg: 1.2.1
+      mlly: 1.8.2
+      ohash: 2.0.12
+      picomatch: 4.0.7
+      std-env: 4.2.0
+      tinyglobby: 0.2.17
+      ufo: 1.6.4
+    transitivePeerDependencies:
+      - magic-string
+      - magicast
+      - oxc-parser
+      - rolldown
+      - unplugin
+      - vite
+      - vue
+
+  '@nuxt/kit@4.5.2(magic-string@1.2.3)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)))':
+    dependencies:
+      c12: 3.3.4
+      consola: 3.4.2
+      defu: 6.1.7
+      destr: 2.0.5
+      errx: 0.1.2
+      exsolve: 1.1.1
+      ignore: 7.0.6
+      jiti: 2.7.0
+      klona: 2.0.6
+      mlly: 1.8.2
+      nostics: 1.2.0
+      ohash: 2.0.12
+      pathe: 2.0.3
+      pkg-types: 2.3.1
+      rc9: 3.0.1
+      scule: 1.3.0
+      tinyglobby: 0.2.17
+      ufo: 1.6.4
+      unctx: 3.0.1(magic-string@1.2.3)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)))
+      untyped: 2.0.0
+      verkit: 0.3.2
+    transitivePeerDependencies:
+      - magic-string
+      - magicast
+      - oxc-parser
+      - rolldown
+      - unplugin
+
+  '@nuxt/schema@4.5.2':
+    dependencies:
+      '@vue/shared': 3.5.41
+      defu: 6.1.7
+      nostics: 1.2.0
+      pathe: 2.0.3
+      pkg-types: 2.3.1
+      std-env: 4.2.0
+
+  '@nuxt/ui@4.11.0(e3c7a276a71826077077bb3a755e2430)':
+    dependencies:
+      '@floating-ui/dom': 1.8.0
+      '@iconify/vue': 5.0.1(vue@3.5.41(typescript@6.0.3))
+      '@nuxt/fonts': 0.14.0(db0@0.3.4)(esbuild@0.28.2)(magic-string@1.2.3)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+      '@nuxt/icon': 2.5.1(magic-string@1.2.3)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)))(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))(vue@3.5.41(typescript@6.0.3))
+      '@nuxt/kit': 4.5.2(magic-string@1.2.3)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)))
+      '@nuxt/schema': 4.5.2
+      '@nuxtjs/color-mode': 4.0.1(magic-string@1.2.3)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)))
+      '@standard-schema/spec': 1.1.0
+      '@tailwindcss/postcss': 4.3.3
+      '@tailwindcss/vite': 4.3.3(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+      '@tanstack/vue-table': 8.21.3(vue@3.5.41(typescript@6.0.3))
+      '@tanstack/vue-virtual': 3.13.36(vue@3.5.41(typescript@6.0.3))
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.30.5)
+      '@tiptap/extension-bubble-menu': 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)
+      '@tiptap/extension-code': 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))
+      '@tiptap/extension-collaboration': 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)(@tiptap/y-tiptap@3.0.9(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.3)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32)
+      '@tiptap/extension-drag-handle': 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/extension-collaboration@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)(@tiptap/y-tiptap@3.0.9(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.3)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32))(@tiptap/extension-node-range@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)(@tiptap/y-tiptap@3.0.9(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.3)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))
+      '@tiptap/extension-drag-handle-vue-3': 3.30.5(@tiptap/extension-drag-handle@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/extension-collaboration@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)(@tiptap/y-tiptap@3.0.9(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.3)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32))(@tiptap/extension-node-range@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)(@tiptap/y-tiptap@3.0.9(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.3)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32)))(@tiptap/pm@3.30.5)(@tiptap/vue-3@3.30.5(@floating-ui/dom@1.8.0)(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)(vue@3.5.41(typescript@6.0.3)))(vue@3.5.41(typescript@6.0.3))
+      '@tiptap/extension-floating-menu': 3.30.5(@floating-ui/dom@1.8.0)(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)
+      '@tiptap/extension-horizontal-rule': 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)
+      '@tiptap/extension-image': 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))
+      '@tiptap/extension-mention': 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)(@tiptap/suggestion@3.30.5(@floating-ui/dom@1.8.0)(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5))
+      '@tiptap/extension-node-range': 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)
+      '@tiptap/extension-placeholder': 3.30.5(@tiptap/extensions@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5))
+      '@tiptap/markdown': 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)
+      '@tiptap/pm': 3.30.5
+      '@tiptap/starter-kit': 3.30.5
+      '@tiptap/suggestion': 3.30.5(@floating-ui/dom@1.8.0)(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)
+      '@tiptap/vue-3': 3.30.5(@floating-ui/dom@1.8.0)(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)(vue@3.5.41(typescript@6.0.3))
+      '@unhead/vue': 3.4.0(@oxc-project/types@0.146.0)(esbuild@0.28.2)(lightningcss@1.33.0)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))(vue@3.5.41(typescript@6.0.3))
+      '@vueuse/core': 14.4.0(vue@3.5.41(typescript@6.0.3))
+      '@vueuse/integrations': 14.4.0(fuse.js@7.5.0)(vue@3.5.41(typescript@6.0.3))
+      '@vueuse/shared': 14.4.0(vue@3.5.41(typescript@6.0.3))
+      colortranslator: 5.0.0
+      consola: 3.4.2
+      defu: 6.1.7
+      embla-carousel-auto-height: 8.6.0(embla-carousel@8.6.0)
+      embla-carousel-auto-scroll: 8.6.0(embla-carousel@8.6.0)
+      embla-carousel-autoplay: 8.6.0(embla-carousel@8.6.0)
+      embla-carousel-class-names: 8.6.0(embla-carousel@8.6.0)
+      embla-carousel-fade: 8.6.0(embla-carousel@8.6.0)
+      embla-carousel-vue: 8.6.0(vue@3.5.41(typescript@6.0.3))
+      embla-carousel-wheel-gestures: 8.1.0(embla-carousel@8.6.0)
+      fuse.js: 7.5.0
+      hookable: 6.1.1
+      knitwork: 1.3.0
+      magic-string: 1.2.3
+      mlly: 1.8.2
+      motion-v: 2.4.0(@vueuse/core@14.4.0(vue@3.5.41(typescript@6.0.3)))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@6.0.3))
+      ohash: 2.0.12
+      pathe: 2.0.3
+      reka-ui: 2.10.3(vue@3.5.41(typescript@6.0.3))
+      scule: 1.3.0
+      tailwind-merge: 3.6.0
+      tailwind-variants: 3.3.1(tailwind-merge@3.6.0)(tailwindcss@4.3.3)
+      tailwindcss: 4.3.3
+      tinyglobby: 0.2.17
+      typescript: 6.0.3
+      ufo: 1.6.4
+      unplugin: 3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+      unplugin-auto-import: 21.1.0(@nuxt/kit@4.5.2(magic-string@1.2.3)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))))(@vueuse/core@14.4.0(vue@3.5.41(typescript@6.0.3)))(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+      unplugin-vue-components: 32.1.0(@nuxt/kit@4.5.2(magic-string@1.2.3)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))))(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))(vue@3.5.41(typescript@6.0.3))
+      vaul-vue: 0.4.1(reka-ui@2.10.3(vue@3.5.41(typescript@6.0.3)))(vue@3.5.41(typescript@6.0.3))
+      vue-component-type-helpers: 3.3.11
+    optionalDependencies:
+      '@internationalized/date': 3.12.3
+      '@internationalized/number': 3.6.7
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@farmfe/core'
+      - '@netlify/blobs'
+      - '@oxc-project/types'
+      - '@planetscale/database'
+      - '@rspack/core'
+      - '@unhead/cli'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@vitejs/devtools-kit'
+      - '@vue/composition-api'
+      - async-validator
+      - aws4fetch
+      - axios
+      - bun-types-no-globals
+      - change-case
+      - db0
+      - drauu
+      - embla-carousel
+      - esbuild
+      - focus-trap
+      - idb-keyval
+      - ioredis
+      - jwt-decode
+      - lightningcss
+      - magicast
+      - nprogress
+      - oxc-parser
+      - qrcode
+      - react
+      - react-dom
+      - rolldown
+      - rollup
+      - sortablejs
+      - universal-cookie
+      - unloader
+      - uploadthing
+      - vite
+      - vue
+      - webpack
+
+  '@nuxtjs/color-mode@4.0.1(magic-string@1.2.3)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)))':
+    dependencies:
+      '@nuxt/kit': 4.5.2(magic-string@1.2.3)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)))
+      exsolve: 1.1.1
+      pathe: 2.0.3
+      pkg-types: 2.3.1
+      semver: 7.8.5
+    transitivePeerDependencies:
+      - magic-string
+      - magicast
+      - oxc-parser
+      - rolldown
+      - unplugin
+
   '@oozcitak/dom@2.0.2':
     dependencies:
       '@oozcitak/infra': 2.0.2
@@ -3155,6 +5970,49 @@ snapshots:
       '@oozcitak/util': 10.0.0
 
   '@oozcitak/util@10.0.0': {}
+
+  '@opentelemetry/api-logs@0.220.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.220.0
+      import-in-the-middle: 3.3.3
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-trace@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/semantic-conventions@1.43.0': {}
 
   '@oxc-parser/binding-android-arm-eabi@0.120.0':
     optional: true
@@ -3225,6 +6083,45 @@ snapshots:
 
   '@oxc-project/types@0.146.0': {}
 
+  '@parcel/watcher-wasm@2.6.0':
+    dependencies:
+      is-glob: 4.0.3
+      picomatch: 4.0.7
+
+  '@paulirish/trace_engine@0.0.53':
+    dependencies:
+      legacy-javascript: 0.0.1
+      third-party-web: 0.29.2
+
+  '@paulirish/trace_engine@0.0.65':
+    dependencies:
+      legacy-javascript: 0.0.1
+      third-party-web: 0.29.2
+
+  '@polka/url@1.0.0-next.29': {}
+
+  '@puppeteer/browsers@2.13.2':
+    dependencies:
+      debug: 4.4.3
+      extract-zip: 2.0.1
+      progress: 2.0.3
+      proxy-agent: 6.5.0
+      semver: 7.8.5
+      tar-fs: 3.1.3
+      yargs: 17.7.3
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
+
+  '@puppeteer/browsers@3.2.1(yauzl@2.10.0)':
+    dependencies:
+      modern-tar: 0.8.4
+      yargs: 18.1.0
+    optionalDependencies:
+      yauzl: 2.10.0
+
   '@rolldown/binding-android-arm-eabi@1.2.5':
     optional: true
 
@@ -3278,6 +6175,92 @@ snapshots:
       estree-walker: 2.0.2
       picomatch: 4.0.7
 
+  '@sentry-internal/tracing@7.120.4':
+    dependencies:
+      '@sentry/core': 7.120.4
+      '@sentry/types': 7.120.4
+      '@sentry/utils': 7.120.4
+
+  '@sentry/conventions@0.16.0': {}
+
+  '@sentry/core@10.71.0':
+    dependencies:
+      '@sentry/conventions': 0.16.0
+
+  '@sentry/core@7.120.4':
+    dependencies:
+      '@sentry/types': 7.120.4
+      '@sentry/utils': 7.120.4
+
+  '@sentry/integrations@7.120.4':
+    dependencies:
+      '@sentry/core': 7.120.4
+      '@sentry/types': 7.120.4
+      '@sentry/utils': 7.120.4
+      localforage: 1.10.0
+
+  '@sentry/node-core@10.71.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.71.0
+      '@sentry/opentelemetry': 10.71.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
+      import-in-the-middle: 3.3.3
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@sentry/node@10.71.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.71.0
+      '@sentry/node-core': 10.71.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
+      '@sentry/opentelemetry': 10.71.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
+      '@sentry/server-utils': 10.71.0
+      import-in-the-middle: 3.3.3
+    transitivePeerDependencies:
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - supports-color
+
+  '@sentry/node@7.120.4':
+    dependencies:
+      '@sentry-internal/tracing': 7.120.4
+      '@sentry/core': 7.120.4
+      '@sentry/integrations': 7.120.4
+      '@sentry/types': 7.120.4
+      '@sentry/utils': 7.120.4
+
+  '@sentry/opentelemetry@10.71.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.71.0
+
+  '@sentry/server-utils@10.71.0':
+    dependencies:
+      '@apm-js-collab/code-transformer-bundler-plugins': 0.7.4
+      '@apm-js-collab/tracing-hooks': 0.13.0
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.71.0
+      meriyah: 6.1.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sentry/types@7.120.4': {}
+
+  '@sentry/utils@7.120.4':
+    dependencies:
+      '@sentry/types': 7.120.4
+
+  '@sindresorhus/is@5.6.0': {}
+
   '@solid-primitives/event-listener@2.4.6(solid-js@1.9.15)':
     dependencies:
       '@solid-primitives/utils': 6.4.1(solid-js@1.9.15)
@@ -3311,6 +6294,16 @@ snapshots:
   '@solid-primitives/utils@6.4.1(solid-js@1.9.15)':
     dependencies:
       solid-js: 1.9.15
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@swc/helpers@0.5.23':
+    dependencies:
+      tslib: 2.8.1
+
+  '@szmarczak/http-timer@5.0.1':
+    dependencies:
+      defer-to-connect: 2.0.1
 
   '@tailwindcss/node@4.3.3':
     dependencies:
@@ -3373,6 +6366,14 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.3
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.3
 
+  '@tailwindcss/postcss@4.3.3':
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      '@tailwindcss/node': 4.3.3
+      '@tailwindcss/oxide': 4.3.3
+      postcss: 8.5.26
+      tailwindcss: 4.3.3
+
   '@tailwindcss/typography@0.5.20(tailwindcss@4.3.3)':
     dependencies:
       postcss-selector-parser: 6.0.10
@@ -3431,11 +6432,12 @@ snapshots:
     transitivePeerDependencies:
       - csstype
 
-  '@tanstack/devtools-utils@0.4.0(@types/react@19.2.18)(react@19.2.8)(solid-js@1.9.15)':
+  '@tanstack/devtools-utils@0.4.0(@types/react@19.2.18)(react@19.2.8)(solid-js@1.9.15)(vue@3.5.41(typescript@6.0.3))':
     optionalDependencies:
       '@types/react': 19.2.18
       react: 19.2.8
       solid-js: 1.9.15
+      vue: 3.5.41(typescript@6.0.3)
 
   '@tanstack/devtools-vite@0.8.5(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))':
     dependencies:
@@ -3470,10 +6472,10 @@ snapshots:
 
   '@tanstack/history@1.162.1': {}
 
-  '@tanstack/hotkeys-devtools@0.9.0(@tanstack/hotkeys@0.8.0)(@types/react@19.2.18)(csstype@3.2.3)(react@19.2.8)':
+  '@tanstack/hotkeys-devtools@0.9.0(@tanstack/hotkeys@0.8.0)(@types/react@19.2.18)(csstype@3.2.3)(react@19.2.8)(vue@3.5.41(typescript@6.0.3))':
     dependencies:
       '@tanstack/devtools-ui': 0.5.3(csstype@3.2.3)(solid-js@1.9.15)
-      '@tanstack/devtools-utils': 0.4.0(@types/react@19.2.18)(react@19.2.8)(solid-js@1.9.15)
+      '@tanstack/devtools-utils': 0.4.0(@types/react@19.2.18)(react@19.2.8)(solid-js@1.9.15)(vue@3.5.41(typescript@6.0.3))
       '@tanstack/hotkeys': 0.8.0
       clsx: 2.1.1
       goober: 2.1.19(csstype@3.2.3)
@@ -3503,10 +6505,10 @@ snapshots:
       - solid-js
       - utf-8-validate
 
-  '@tanstack/react-hotkeys-devtools@0.7.0(@tanstack/hotkeys@0.8.0)(@types/react-dom@19.2.5(@types/react@19.2.18))(@types/react@19.2.18)(csstype@3.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(solid-js@1.9.15)':
+  '@tanstack/react-hotkeys-devtools@0.7.0(@tanstack/hotkeys@0.8.0)(@types/react-dom@19.2.5(@types/react@19.2.18))(@types/react@19.2.18)(csstype@3.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(solid-js@1.9.15)(vue@3.5.41(typescript@6.0.3))':
     dependencies:
-      '@tanstack/devtools-utils': 0.4.0(@types/react@19.2.18)(react@19.2.8)(solid-js@1.9.15)
-      '@tanstack/hotkeys-devtools': 0.9.0(@tanstack/hotkeys@0.8.0)(@types/react@19.2.18)(csstype@3.2.3)(react@19.2.8)
+      '@tanstack/devtools-utils': 0.4.0(@types/react@19.2.18)(react@19.2.8)(solid-js@1.9.15)(vue@3.5.41(typescript@6.0.3))
+      '@tanstack/hotkeys-devtools': 0.9.0(@tanstack/hotkeys@0.8.0)(@types/react@19.2.18)(csstype@3.2.3)(react@19.2.8)(vue@3.5.41(typescript@6.0.3))
       '@types/react': 19.2.18
       '@types/react-dom': 19.2.5(@types/react@19.2.18)
       react: 19.2.8
@@ -3772,7 +6774,250 @@ snapshots:
 
   '@tanstack/store@0.9.3': {}
 
+  '@tanstack/table-core@8.21.3': {}
+
+  '@tanstack/virtual-core@3.17.8': {}
+
   '@tanstack/virtual-file-routes@1.162.0': {}
+
+  '@tanstack/vue-table@8.21.3(vue@3.5.41(typescript@6.0.3))':
+    dependencies:
+      '@tanstack/table-core': 8.21.3
+      vue: 3.5.41(typescript@6.0.3)
+
+  '@tanstack/vue-virtual@3.13.36(vue@3.5.41(typescript@6.0.3))':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.8
+      vue: 3.5.41(typescript@6.0.3)
+
+  '@tiptap/core@3.30.5(@tiptap/pm@3.30.5)':
+    dependencies:
+      '@tiptap/pm': 3.30.5
+
+  '@tiptap/extension-blockquote@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)':
+    dependencies:
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.30.5)
+      '@tiptap/pm': 3.30.5
+
+  '@tiptap/extension-bold@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))':
+    dependencies:
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.30.5)
+
+  '@tiptap/extension-bubble-menu@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)':
+    dependencies:
+      '@floating-ui/dom': 1.8.0
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.30.5)
+      '@tiptap/pm': 3.30.5
+
+  '@tiptap/extension-bullet-list@3.30.5(@tiptap/extension-list@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5))':
+    dependencies:
+      '@tiptap/extension-list': 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)
+
+  '@tiptap/extension-code-block@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)':
+    dependencies:
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.30.5)
+      '@tiptap/pm': 3.30.5
+
+  '@tiptap/extension-code@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))':
+    dependencies:
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.30.5)
+
+  '@tiptap/extension-collaboration@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)(@tiptap/y-tiptap@3.0.9(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.3)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32)':
+    dependencies:
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.30.5)
+      '@tiptap/pm': 3.30.5
+      '@tiptap/y-tiptap': 3.0.9(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.3)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32)
+      yjs: 13.6.32
+
+  '@tiptap/extension-document@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))':
+    dependencies:
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.30.5)
+
+  '@tiptap/extension-drag-handle-vue-3@3.30.5(@tiptap/extension-drag-handle@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/extension-collaboration@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)(@tiptap/y-tiptap@3.0.9(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.3)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32))(@tiptap/extension-node-range@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)(@tiptap/y-tiptap@3.0.9(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.3)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32)))(@tiptap/pm@3.30.5)(@tiptap/vue-3@3.30.5(@floating-ui/dom@1.8.0)(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)(vue@3.5.41(typescript@6.0.3)))(vue@3.5.41(typescript@6.0.3))':
+    dependencies:
+      '@tiptap/extension-drag-handle': 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/extension-collaboration@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)(@tiptap/y-tiptap@3.0.9(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.3)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32))(@tiptap/extension-node-range@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)(@tiptap/y-tiptap@3.0.9(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.3)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))
+      '@tiptap/pm': 3.30.5
+      '@tiptap/vue-3': 3.30.5(@floating-ui/dom@1.8.0)(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)(vue@3.5.41(typescript@6.0.3))
+      vue: 3.5.41(typescript@6.0.3)
+
+  '@tiptap/extension-drag-handle@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/extension-collaboration@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)(@tiptap/y-tiptap@3.0.9(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.3)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32))(@tiptap/extension-node-range@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)(@tiptap/y-tiptap@3.0.9(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.3)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))':
+    dependencies:
+      '@floating-ui/dom': 1.8.0
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.30.5)
+      '@tiptap/extension-collaboration': 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)(@tiptap/y-tiptap@3.0.9(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.3)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32))(yjs@13.6.32)
+      '@tiptap/extension-node-range': 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)
+      '@tiptap/pm': 3.30.5
+      '@tiptap/y-tiptap': 3.0.9(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.3)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32)
+
+  '@tiptap/extension-dropcursor@3.30.5(@tiptap/extensions@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5))':
+    dependencies:
+      '@tiptap/extensions': 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)
+
+  '@tiptap/extension-floating-menu@3.30.5(@floating-ui/dom@1.8.0)(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)':
+    dependencies:
+      '@floating-ui/dom': 1.8.0
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.30.5)
+      '@tiptap/pm': 3.30.5
+
+  '@tiptap/extension-gapcursor@3.30.5(@tiptap/extensions@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5))':
+    dependencies:
+      '@tiptap/extensions': 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)
+
+  '@tiptap/extension-hard-break@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))':
+    dependencies:
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.30.5)
+
+  '@tiptap/extension-heading@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))':
+    dependencies:
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.30.5)
+
+  '@tiptap/extension-horizontal-rule@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)':
+    dependencies:
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.30.5)
+      '@tiptap/pm': 3.30.5
+
+  '@tiptap/extension-image@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))':
+    dependencies:
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.30.5)
+
+  '@tiptap/extension-italic@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))':
+    dependencies:
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.30.5)
+
+  '@tiptap/extension-link@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)':
+    dependencies:
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.30.5)
+      '@tiptap/pm': 3.30.5
+      linkifyjs: 4.3.3
+
+  '@tiptap/extension-list-item@3.30.5(@tiptap/extension-list@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5))':
+    dependencies:
+      '@tiptap/extension-list': 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)
+
+  '@tiptap/extension-list-keymap@3.30.5(@tiptap/extension-list@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5))':
+    dependencies:
+      '@tiptap/extension-list': 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)
+
+  '@tiptap/extension-list@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)':
+    dependencies:
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.30.5)
+      '@tiptap/pm': 3.30.5
+
+  '@tiptap/extension-mention@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)(@tiptap/suggestion@3.30.5(@floating-ui/dom@1.8.0)(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5))':
+    dependencies:
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.30.5)
+      '@tiptap/pm': 3.30.5
+      '@tiptap/suggestion': 3.30.5(@floating-ui/dom@1.8.0)(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)
+
+  '@tiptap/extension-node-range@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)':
+    dependencies:
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.30.5)
+      '@tiptap/pm': 3.30.5
+
+  '@tiptap/extension-ordered-list@3.30.5(@tiptap/extension-list@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5))':
+    dependencies:
+      '@tiptap/extension-list': 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)
+
+  '@tiptap/extension-paragraph@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))':
+    dependencies:
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.30.5)
+
+  '@tiptap/extension-placeholder@3.30.5(@tiptap/extensions@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5))':
+    dependencies:
+      '@tiptap/extensions': 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)
+
+  '@tiptap/extension-strike@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))':
+    dependencies:
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.30.5)
+
+  '@tiptap/extension-text@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))':
+    dependencies:
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.30.5)
+
+  '@tiptap/extension-underline@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))':
+    dependencies:
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.30.5)
+
+  '@tiptap/extensions@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)':
+    dependencies:
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.30.5)
+      '@tiptap/pm': 3.30.5
+
+  '@tiptap/markdown@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)':
+    dependencies:
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.30.5)
+      '@tiptap/pm': 3.30.5
+      marked: 17.0.6
+
+  '@tiptap/pm@3.30.5':
+    dependencies:
+      prosemirror-changeset: 2.4.2
+      prosemirror-commands: 1.7.2
+      prosemirror-dropcursor: 1.8.3
+      prosemirror-gapcursor: 1.4.1
+      prosemirror-history: 1.5.0
+      prosemirror-inputrules: 1.5.1
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.11
+      prosemirror-schema-list: 1.5.1
+      prosemirror-state: 1.4.4
+      prosemirror-tables: 1.8.5
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.42.3
+
+  '@tiptap/starter-kit@3.30.5':
+    dependencies:
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.30.5)
+      '@tiptap/extension-blockquote': 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)
+      '@tiptap/extension-bold': 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))
+      '@tiptap/extension-bullet-list': 3.30.5(@tiptap/extension-list@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5))
+      '@tiptap/extension-code': 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))
+      '@tiptap/extension-code-block': 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)
+      '@tiptap/extension-document': 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))
+      '@tiptap/extension-dropcursor': 3.30.5(@tiptap/extensions@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5))
+      '@tiptap/extension-gapcursor': 3.30.5(@tiptap/extensions@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5))
+      '@tiptap/extension-hard-break': 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))
+      '@tiptap/extension-heading': 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))
+      '@tiptap/extension-horizontal-rule': 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)
+      '@tiptap/extension-italic': 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))
+      '@tiptap/extension-link': 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)
+      '@tiptap/extension-list': 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)
+      '@tiptap/extension-list-item': 3.30.5(@tiptap/extension-list@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5))
+      '@tiptap/extension-list-keymap': 3.30.5(@tiptap/extension-list@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5))
+      '@tiptap/extension-ordered-list': 3.30.5(@tiptap/extension-list@3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5))
+      '@tiptap/extension-paragraph': 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))
+      '@tiptap/extension-strike': 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))
+      '@tiptap/extension-text': 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))
+      '@tiptap/extension-underline': 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))
+      '@tiptap/extensions': 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)
+      '@tiptap/pm': 3.30.5
+
+  '@tiptap/suggestion@3.30.5(@floating-ui/dom@1.8.0)(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)':
+    dependencies:
+      '@floating-ui/dom': 1.8.0
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.30.5)
+      '@tiptap/pm': 3.30.5
+
+  '@tiptap/vue-3@3.30.5(@floating-ui/dom@1.8.0)(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)(vue@3.5.41(typescript@6.0.3))':
+    dependencies:
+      '@floating-ui/dom': 1.8.0
+      '@tiptap/core': 3.30.5(@tiptap/pm@3.30.5)
+      '@tiptap/pm': 3.30.5
+      vue: 3.5.41(typescript@6.0.3)
+    optionalDependencies:
+      '@tiptap/extension-bubble-menu': 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)
+      '@tiptap/extension-floating-menu': 3.30.5(@floating-ui/dom@1.8.0)(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)
+
+  '@tiptap/y-tiptap@3.0.9(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.3)(y-protocols@1.0.7(yjs@13.6.32))(yjs@13.6.32)':
+    dependencies:
+      lib0: 0.2.117
+      prosemirror-model: 1.25.11
+      prosemirror-state: 1.4.4
+      prosemirror-view: 1.42.3
+      y-protocols: 1.0.7(yjs@13.6.32)
+      yjs: 13.6.32
+
+  '@tootallnate/quickjs-emscripten@0.23.0': {}
 
   '@tybys/wasm-util@0.10.3':
     dependencies:
@@ -3792,6 +7037,8 @@ snapshots:
   '@types/hast@3.0.5':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/http-cache-semantics@4.2.0': {}
 
   '@types/katex@0.16.8': {}
 
@@ -3823,22 +7070,617 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
+  '@types/web-bluetooth@0.0.20': {}
+
+  '@types/web-bluetooth@0.0.21': {}
+
+  '@types/yauzl@2.10.3':
+    dependencies:
+      '@types/node': 22.20.1
+    optional: true
+
   '@ungap/structured-clone@1.3.3': {}
+
+  '@unhead/bundler@3.4.0(@oxc-project/types@0.146.0)(esbuild@0.28.2)(lightningcss@1.33.0)(rolldown@1.2.5)(unhead@3.4.0(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)))(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))':
+    dependencies:
+      magic-string: 1.2.3
+      oxc-walker: 1.1.1(@oxc-project/types@0.146.0)(rolldown@1.2.5)
+      unhead: 3.4.0(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+      unplugin: 3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+    optionalDependencies:
+      esbuild: 0.28.2
+      lightningcss: 1.33.0
+      rolldown: 1.2.5
+      vite: 8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@oxc-project/types'
+      - '@rspack/core'
+      - bun-types-no-globals
+      - rollup
+      - unloader
+
+  '@unhead/vue@3.4.0(@oxc-project/types@0.146.0)(esbuild@0.28.2)(lightningcss@1.33.0)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))(vue@3.5.41(typescript@6.0.3))':
+    dependencies:
+      '@unhead/bundler': 3.4.0(@oxc-project/types@0.146.0)(esbuild@0.28.2)(lightningcss@1.33.0)(rolldown@1.2.5)(unhead@3.4.0(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)))(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+      hookable: 6.1.1
+      unhead: 3.4.0(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+      unplugin: 3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+      vue: 3.5.41(typescript@6.0.3)
+    optionalDependencies:
+      vite: 8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@oxc-project/types'
+      - '@rspack/core'
+      - '@unhead/cli'
+      - '@vitejs/devtools-kit'
+      - bun-types-no-globals
+      - esbuild
+      - lightningcss
+      - oxc-parser
+      - rolldown
+      - rollup
+      - unloader
+
+  '@unlighthouse/cli@0.18.0(4304ff7df3b01adfd53a0c4cd139f424)':
+    dependencies:
+      '@lhci/utils': 0.15.1
+      '@unlighthouse/client': 0.18.0(ce335527f92a80ce512b53adb18789f9)
+      '@unlighthouse/core': 0.18.0(434fe901b7dc0e50f21c041ba2487a0c)
+      '@unlighthouse/server': 0.18.0(4304ff7df3b01adfd53a0c4cd139f424)
+      cac: 7.0.0
+      consola: 3.4.2
+      defu: 6.1.7
+      lodash-es: 4.18.1
+      pathe: 2.0.3
+      std-env: 4.2.0
+      tinyexec: 1.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@farmfe/core'
+      - '@inertiajs/vue3'
+      - '@internationalized/date'
+      - '@internationalized/number'
+      - '@netlify/blobs'
+      - '@nuxt/content'
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - '@oxc-project/types'
+      - '@parcel/watcher'
+      - '@planetscale/database'
+      - '@rspack/core'
+      - '@tiptap/core'
+      - '@tiptap/extension-bubble-menu'
+      - '@tiptap/extension-code'
+      - '@tiptap/extension-collaboration'
+      - '@tiptap/extension-drag-handle'
+      - '@tiptap/extension-drag-handle-vue-3'
+      - '@tiptap/extension-floating-menu'
+      - '@tiptap/extension-horizontal-rule'
+      - '@tiptap/extension-image'
+      - '@tiptap/extension-mention'
+      - '@tiptap/extension-node-range'
+      - '@tiptap/extension-placeholder'
+      - '@tiptap/markdown'
+      - '@tiptap/pm'
+      - '@tiptap/starter-kit'
+      - '@tiptap/suggestion'
+      - '@tiptap/vue-3'
+      - '@unhead/cli'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@vitejs/devtools-kit'
+      - '@vue/composition-api'
+      - ai
+      - async-validator
+      - aws4fetch
+      - axios
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - bun-types-no-globals
+      - change-case
+      - db0
+      - drauu
+      - embla-carousel
+      - encoding
+      - esbuild
+      - focus-trap
+      - idb-keyval
+      - ioredis
+      - joi
+      - jwt-decode
+      - lightningcss
+      - magicast
+      - nprogress
+      - oxc-parser
+      - proxy-agent
+      - puppeteer
+      - qrcode
+      - react
+      - react-dom
+      - react-native-b4a
+      - rolldown
+      - rollup
+      - sortablejs
+      - srvx
+      - superstruct
+      - supports-color
+      - tailwindcss
+      - typescript
+      - universal-cookie
+      - unloader
+      - uploadthing
+      - utf-8-validate
+      - valibot
+      - vite
+      - vue-router
+      - webpack
+      - yauzl
+      - yup
+      - zod
+
+  '@unlighthouse/client@0.18.0(ce335527f92a80ce512b53adb18789f9)':
+    dependencies:
+      '@nuxt/ui': 4.11.0(e3c7a276a71826077077bb3a755e2430)
+      '@tailwindcss/vite': 4.3.3(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+      defu: 6.1.7
+      fuse.js: 7.5.0
+      lightweight-charts: 5.2.1
+      lodash-es: 4.18.1
+      ofetch: 1.5.1
+      ufo: 1.6.4
+      vue: 3.5.41(typescript@6.0.3)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@farmfe/core'
+      - '@inertiajs/vue3'
+      - '@internationalized/date'
+      - '@internationalized/number'
+      - '@netlify/blobs'
+      - '@nuxt/content'
+      - '@oxc-project/types'
+      - '@planetscale/database'
+      - '@rspack/core'
+      - '@tiptap/core'
+      - '@tiptap/extension-bubble-menu'
+      - '@tiptap/extension-code'
+      - '@tiptap/extension-collaboration'
+      - '@tiptap/extension-drag-handle'
+      - '@tiptap/extension-drag-handle-vue-3'
+      - '@tiptap/extension-floating-menu'
+      - '@tiptap/extension-horizontal-rule'
+      - '@tiptap/extension-image'
+      - '@tiptap/extension-mention'
+      - '@tiptap/extension-node-range'
+      - '@tiptap/extension-placeholder'
+      - '@tiptap/markdown'
+      - '@tiptap/pm'
+      - '@tiptap/starter-kit'
+      - '@tiptap/suggestion'
+      - '@tiptap/vue-3'
+      - '@unhead/cli'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@vitejs/devtools-kit'
+      - '@vue/composition-api'
+      - ai
+      - async-validator
+      - aws4fetch
+      - axios
+      - bun-types-no-globals
+      - change-case
+      - db0
+      - drauu
+      - embla-carousel
+      - esbuild
+      - focus-trap
+      - idb-keyval
+      - ioredis
+      - joi
+      - jwt-decode
+      - lightningcss
+      - magicast
+      - nprogress
+      - oxc-parser
+      - qrcode
+      - react
+      - react-dom
+      - rolldown
+      - rollup
+      - sortablejs
+      - superstruct
+      - tailwindcss
+      - typescript
+      - universal-cookie
+      - unloader
+      - uploadthing
+      - valibot
+      - vite
+      - vue-router
+      - webpack
+      - yup
+      - zod
+
+  '@unlighthouse/core@0.18.0(434fe901b7dc0e50f21c041ba2487a0c)':
+    dependencies:
+      '@clack/prompts': 1.7.0
+      '@puppeteer/browsers': 3.2.1(yauzl@2.10.0)
+      '@unlighthouse/client': 0.18.0(ce335527f92a80ce512b53adb18789f9)
+      c12: 3.3.4
+      chrome-launcher: 1.2.1
+      consola: 3.4.2
+      defu: 6.1.7
+      h3: 1.15.11
+      hookable: 6.1.1
+      launch-editor: 2.14.1
+      lighthouse: 13.4.1(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(yauzl@2.10.0)
+      lodash-es: 4.18.1
+      ofetch: 1.5.1
+      pathe: 2.0.3
+      puppeteer-cluster: 0.25.0(puppeteer@25.9.0(yauzl@2.10.0))
+      puppeteer-core: 25.9.0(yauzl@2.10.0)
+      radix3: 1.1.2
+      regexparam: 3.0.0
+      sanitize-filename: 1.6.4
+      sitemapper: 4.1.6
+      slugify: 1.6.9
+      tinyexec: 1.3.0
+      ufo: 1.6.4
+      ultrahtml: 1.7.0
+      unctx: 2.5.0
+      ws: 8.21.3
+    optionalDependencies:
+      puppeteer: 25.9.0(yauzl@2.10.0)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@farmfe/core'
+      - '@inertiajs/vue3'
+      - '@internationalized/date'
+      - '@internationalized/number'
+      - '@netlify/blobs'
+      - '@nuxt/content'
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - '@oxc-project/types'
+      - '@planetscale/database'
+      - '@rspack/core'
+      - '@tiptap/core'
+      - '@tiptap/extension-bubble-menu'
+      - '@tiptap/extension-code'
+      - '@tiptap/extension-collaboration'
+      - '@tiptap/extension-drag-handle'
+      - '@tiptap/extension-drag-handle-vue-3'
+      - '@tiptap/extension-floating-menu'
+      - '@tiptap/extension-horizontal-rule'
+      - '@tiptap/extension-image'
+      - '@tiptap/extension-mention'
+      - '@tiptap/extension-node-range'
+      - '@tiptap/extension-placeholder'
+      - '@tiptap/markdown'
+      - '@tiptap/pm'
+      - '@tiptap/starter-kit'
+      - '@tiptap/suggestion'
+      - '@tiptap/vue-3'
+      - '@unhead/cli'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@vitejs/devtools-kit'
+      - '@vue/composition-api'
+      - ai
+      - async-validator
+      - aws4fetch
+      - axios
+      - bufferutil
+      - bun-types-no-globals
+      - change-case
+      - db0
+      - drauu
+      - embla-carousel
+      - esbuild
+      - focus-trap
+      - idb-keyval
+      - ioredis
+      - joi
+      - jwt-decode
+      - lightningcss
+      - magicast
+      - nprogress
+      - oxc-parser
+      - proxy-agent
+      - qrcode
+      - react
+      - react-dom
+      - rolldown
+      - rollup
+      - sortablejs
+      - superstruct
+      - supports-color
+      - tailwindcss
+      - typescript
+      - universal-cookie
+      - unloader
+      - uploadthing
+      - utf-8-validate
+      - valibot
+      - vite
+      - vue-router
+      - webpack
+      - yauzl
+      - yup
+      - zod
+
+  '@unlighthouse/server@0.18.0(4304ff7df3b01adfd53a0c4cd139f424)':
+    dependencies:
+      '@unlighthouse/core': 0.18.0(434fe901b7dc0e50f21c041ba2487a0c)
+      h3: 1.15.11
+      listhen: 1.10.1(srvx@0.11.22)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@farmfe/core'
+      - '@inertiajs/vue3'
+      - '@internationalized/date'
+      - '@internationalized/number'
+      - '@netlify/blobs'
+      - '@nuxt/content'
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - '@oxc-project/types'
+      - '@parcel/watcher'
+      - '@planetscale/database'
+      - '@rspack/core'
+      - '@tiptap/core'
+      - '@tiptap/extension-bubble-menu'
+      - '@tiptap/extension-code'
+      - '@tiptap/extension-collaboration'
+      - '@tiptap/extension-drag-handle'
+      - '@tiptap/extension-drag-handle-vue-3'
+      - '@tiptap/extension-floating-menu'
+      - '@tiptap/extension-horizontal-rule'
+      - '@tiptap/extension-image'
+      - '@tiptap/extension-mention'
+      - '@tiptap/extension-node-range'
+      - '@tiptap/extension-placeholder'
+      - '@tiptap/markdown'
+      - '@tiptap/pm'
+      - '@tiptap/starter-kit'
+      - '@tiptap/suggestion'
+      - '@tiptap/vue-3'
+      - '@unhead/cli'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@vitejs/devtools-kit'
+      - '@vue/composition-api'
+      - ai
+      - async-validator
+      - aws4fetch
+      - axios
+      - bufferutil
+      - bun-types-no-globals
+      - change-case
+      - db0
+      - drauu
+      - embla-carousel
+      - esbuild
+      - focus-trap
+      - idb-keyval
+      - ioredis
+      - joi
+      - jwt-decode
+      - lightningcss
+      - magicast
+      - nprogress
+      - oxc-parser
+      - proxy-agent
+      - puppeteer
+      - qrcode
+      - react
+      - react-dom
+      - rolldown
+      - rollup
+      - sortablejs
+      - srvx
+      - superstruct
+      - supports-color
+      - tailwindcss
+      - typescript
+      - universal-cookie
+      - unloader
+      - uploadthing
+      - utf-8-validate
+      - valibot
+      - vite
+      - vue-router
+      - webpack
+      - yauzl
+      - yup
+      - zod
 
   '@vitejs/plugin-react@6.1.0(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)
 
+  '@vue/compiler-core@3.5.41':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@vue/shared': 3.5.41
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
+  '@vue/compiler-dom@3.5.41':
+    dependencies:
+      '@vue/compiler-core': 3.5.41
+      '@vue/shared': 3.5.41
+
+  '@vue/compiler-sfc@3.5.41':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@vue/compiler-core': 3.5.41
+      '@vue/compiler-dom': 3.5.41
+      '@vue/compiler-ssr': 3.5.41
+      '@vue/shared': 3.5.41
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.26
+      source-map-js: 1.2.1
+
+  '@vue/compiler-ssr@3.5.41':
+    dependencies:
+      '@vue/compiler-dom': 3.5.41
+      '@vue/shared': 3.5.41
+
+  '@vue/reactivity@3.5.41':
+    dependencies:
+      '@vue/shared': 3.5.41
+
+  '@vue/runtime-core@3.5.41':
+    dependencies:
+      '@vue/reactivity': 3.5.41
+      '@vue/shared': 3.5.41
+
+  '@vue/runtime-dom@3.5.41':
+    dependencies:
+      '@vue/reactivity': 3.5.41
+      '@vue/runtime-core': 3.5.41
+      '@vue/shared': 3.5.41
+      csstype: 3.2.3
+
+  '@vue/server-renderer@3.5.41':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.41
+      '@vue/runtime-dom': 3.5.41
+      '@vue/shared': 3.5.41
+
+  '@vue/shared@3.5.41': {}
+
+  '@vueuse/core@10.11.1(vue@3.5.41(typescript@6.0.3))':
+    dependencies:
+      '@types/web-bluetooth': 0.0.20
+      '@vueuse/metadata': 10.11.1
+      '@vueuse/shared': 10.11.1(vue@3.5.41(typescript@6.0.3))
+      vue-demi: 0.14.10(vue@3.5.41(typescript@6.0.3))
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+
+  '@vueuse/core@14.4.0(vue@3.5.41(typescript@6.0.3))':
+    dependencies:
+      '@types/web-bluetooth': 0.0.21
+      '@vueuse/metadata': 14.4.0
+      '@vueuse/shared': 14.4.0(vue@3.5.41(typescript@6.0.3))
+      vue: 3.5.41(typescript@6.0.3)
+
+  '@vueuse/integrations@14.4.0(fuse.js@7.5.0)(vue@3.5.41(typescript@6.0.3))':
+    dependencies:
+      '@vueuse/core': 14.4.0(vue@3.5.41(typescript@6.0.3))
+      '@vueuse/shared': 14.4.0(vue@3.5.41(typescript@6.0.3))
+      vue: 3.5.41(typescript@6.0.3)
+    optionalDependencies:
+      fuse.js: 7.5.0
+
+  '@vueuse/metadata@10.11.1': {}
+
+  '@vueuse/metadata@14.4.0': {}
+
+  '@vueuse/shared@10.11.1(vue@3.5.41(typescript@6.0.3))':
+    dependencies:
+      vue-demi: 0.14.10(vue@3.5.41(typescript@6.0.3))
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+
+  '@vueuse/shared@14.4.0(vue@3.5.41(typescript@6.0.3))':
+    dependencies:
+      vue: 3.5.41(typescript@6.0.3)
+
+  acorn@8.18.0: {}
+
+  agent-base@7.1.4: {}
+
+  ansi-colors@4.1.3: {}
+
   ansi-regex@5.0.1: {}
+
+  ansi-regex@6.3.0: {}
 
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@6.2.3: {}
+
   ansis@4.3.1: {}
 
+  anymatch@3.1.3:
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.2
+
+  anynum@1.0.1: {}
+
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
   argparse@2.0.1: {}
+
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
+  ast-types@0.13.4:
+    dependencies:
+      tslib: 2.8.1
+
+  astring@1.9.0: {}
+
+  atomically@2.1.1:
+    dependencies:
+      stubborn-fs: 2.0.0
+      when-exit: 2.1.5
+
+  axe-core@4.13.0: {}
+
+  b4a@1.8.1: {}
 
   babel-dead-code-elimination@1.0.12:
     dependencies:
@@ -3851,15 +7693,47 @@ snapshots:
 
   bail@2.0.2: {}
 
+  bare-events@2.9.2: {}
+
+  bare-fs@4.8.1:
+    dependencies:
+      bare-events: 2.9.2
+      bare-path: 3.1.1
+      bare-stream: 2.13.4(bare-events@2.9.2)
+      bare-url: 2.5.2
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  bare-path@3.1.1: {}
+
+  bare-stream@2.13.4(bare-events@2.9.2):
+    dependencies:
+      b4a: 1.8.1
+      streamx: 2.28.1
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.9.2
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  bare-url@2.5.2:
+    dependencies:
+      bare-path: 3.1.1
+
   baseline-browser-mapping@2.11.19: {}
 
-  boneyard-js@1.9.0(react@19.2.8)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)):
+  basic-ftp@5.3.1: {}
+
+  boneyard-js@1.9.0(react@19.2.8)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))(vue@3.5.41(typescript@6.0.3)):
     dependencies:
       playwright: 1.62.1
     optionalDependencies:
       '@chenglou/pretext': 0.0.5
       react: 19.2.8
       vite: 8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)
+      vue: 3.5.41(typescript@6.0.3)
 
   browserslist@4.28.8:
     dependencies:
@@ -3868,6 +7742,37 @@ snapshots:
       electron-to-chromium: 1.5.413
       node-releases: 2.0.53
       update-browserslist-db: 1.3.1(browserslist@4.28.8)
+
+  buffer-crc32@0.2.13: {}
+
+  c12@3.3.4:
+    dependencies:
+      chokidar: 5.0.0
+      confbox: 0.2.4
+      defu: 6.1.7
+      dotenv: 17.4.2
+      exsolve: 1.1.1
+      giget: 3.3.1
+      jiti: 2.7.0
+      ohash: 2.0.12
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      pkg-types: 2.3.1
+      rc9: 3.0.1
+
+  cac@7.0.0: {}
+
+  cacheable-lookup@7.0.0: {}
+
+  cacheable-request@10.2.14:
+    dependencies:
+      '@types/http-cache-semantics': 4.2.0
+      get-stream: 6.0.1
+      http-cache-semantics: 4.2.0
+      keyv: 4.5.4
+      mimic-response: 4.0.0
+      normalize-url: 8.1.1
+      responselike: 3.0.0
 
   caniuse-lite@1.0.30001809: {}
 
@@ -3887,11 +7792,46 @@ snapshots:
     dependencies:
       readdirp: 5.1.1
 
+  chrome-launcher@1.2.1:
+    dependencies:
+      '@types/node': 22.20.1
+      escape-string-regexp: 4.0.0
+      is-wsl: 2.2.0
+      lighthouse-logger: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  chromium-bidi@14.0.0(devtools-protocol@0.0.1608973):
+    dependencies:
+      devtools-protocol: 0.0.1608973
+      mitt: 3.0.1
+      zod: 3.25.76
+
+  chromium-bidi@17.0.2(devtools-protocol@0.0.1666840):
+    dependencies:
+      devtools-protocol: 0.0.1666840
+      mitt: 3.0.1
+      zod: 3.25.76
+
+  citty@0.1.6:
+    dependencies:
+      consola: 3.4.2
+
+  citty@0.2.2: {}
+
+  cjs-module-lexer@2.2.1: {}
+
   cliui@8.0.1:
     dependencies:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+
+  cliui@9.0.1:
+    dependencies:
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
 
   clsx@2.1.1: {}
 
@@ -3901,25 +7841,72 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  colortranslator@5.0.0: {}
+
   comma-separated-tokens@2.0.3: {}
 
   commander@8.3.0: {}
+
+  confbox@0.1.8: {}
+
+  confbox@0.2.4: {}
+
+  configstore@5.0.1:
+    dependencies:
+      dot-prop: 5.3.0
+      graceful-fs: 4.2.11
+      make-dir: 3.1.0
+      unique-string: 2.0.0
+      write-file-atomic: 3.0.3
+      xdg-basedir: 4.0.0
+
+  configstore@7.1.0:
+    dependencies:
+      atomically: 2.1.1
+      dot-prop: 9.0.0
+      graceful-fs: 4.2.11
+      xdg-basedir: 5.1.0
 
   consola@3.4.2: {}
 
   convert-source-map@2.0.0: {}
 
+  cookie-es@1.2.3: {}
+
   cookie-es@3.1.1: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  crossws@0.3.5:
+    dependencies:
+      uncrypto: 0.1.3
 
   crossws@0.4.12(srvx@0.11.22):
     optionalDependencies:
       srvx: 0.11.22
+
+  crypto-random-string@2.0.0: {}
+
+  csp_evaluator@1.1.5: {}
+
+  csp_evaluator@1.1.8: {}
+
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
 
   cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
 
   cuelume@0.2.2: {}
+
+  data-uri-to-buffer@6.0.2: {}
 
   dayjs@1.11.23: {}
 
@@ -3929,11 +7916,31 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decimal.js@10.6.0: {}
+
   decode-named-character-reference@1.3.0:
     dependencies:
       character-entities: 2.0.2
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
+  defer-to-connect@2.0.1: {}
+
+  define-lazy-prop@2.0.0: {}
+
+  defu@6.1.7: {}
+
+  degenerator@5.0.1:
+    dependencies:
+      ast-types: 0.13.4
+      escodegen: 2.1.0
+      esprima: 4.0.1
+
   dequal@2.0.3: {}
+
+  destr@2.0.5: {}
 
   detect-libc@2.1.2: {}
 
@@ -3941,20 +7948,88 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  devtools-protocol@0.0.1467305: {}
+
+  devtools-protocol@0.0.1608973: {}
+
+  devtools-protocol@0.0.1663043: {}
+
+  devtools-protocol@0.0.1666840: {}
+
   diff@8.0.4: {}
+
+  dot-prop@5.3.0:
+    dependencies:
+      is-obj: 2.0.0
+
+  dot-prop@9.0.0:
+    dependencies:
+      type-fest: 4.41.0
+
+  dotenv@17.4.2: {}
 
   driver.js@1.8.0: {}
 
   electron-to-chromium@1.5.413: {}
 
+  embla-carousel-auto-height@8.6.0(embla-carousel@8.6.0):
+    dependencies:
+      embla-carousel: 8.6.0
+
+  embla-carousel-auto-scroll@8.6.0(embla-carousel@8.6.0):
+    dependencies:
+      embla-carousel: 8.6.0
+
+  embla-carousel-autoplay@8.6.0(embla-carousel@8.6.0):
+    dependencies:
+      embla-carousel: 8.6.0
+
+  embla-carousel-class-names@8.6.0(embla-carousel@8.6.0):
+    dependencies:
+      embla-carousel: 8.6.0
+
+  embla-carousel-fade@8.6.0(embla-carousel@8.6.0):
+    dependencies:
+      embla-carousel: 8.6.0
+
+  embla-carousel-reactive-utils@8.6.0(embla-carousel@8.6.0):
+    dependencies:
+      embla-carousel: 8.6.0
+
+  embla-carousel-vue@8.6.0(vue@3.5.41(typescript@6.0.3)):
+    dependencies:
+      embla-carousel: 8.6.0
+      embla-carousel-reactive-utils: 8.6.0(embla-carousel@8.6.0)
+      vue: 3.5.41(typescript@6.0.3)
+
+  embla-carousel-wheel-gestures@8.1.0(embla-carousel@8.6.0):
+    dependencies:
+      embla-carousel: 8.6.0
+      wheel-gestures: 2.2.48
+
+  embla-carousel@8.6.0: {}
+
+  emoji-regex@10.6.0: {}
+
   emoji-regex@8.0.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   enhanced-resolve@5.24.5:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
 
+  enquirer@2.4.1:
+    dependencies:
+      ansi-colors: 4.1.3
+      strip-ansi: 6.0.1
+
   entities@6.0.1: {}
+
+  entities@7.0.1: {}
 
   env-runner@0.1.16:
     dependencies:
@@ -3962,6 +8037,39 @@ snapshots:
       exsolve: 1.1.1
       httpxy: 0.5.5
       srvx: 0.11.22
+
+  errx@0.1.2: {}
+
+  es-module-lexer@2.3.2: {}
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
 
   esbuild@0.28.2:
     optionalDependencies:
@@ -3994,19 +8102,103 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-string-regexp@4.0.0: {}
+
   escape-string-regexp@5.0.0: {}
+
+  escodegen@2.1.0:
+    dependencies:
+      esprima: 4.0.1
+      estraverse: 5.3.0
+      esutils: 2.0.3
+    optionalDependencies:
+      source-map: 0.6.1
+
+  esprima@4.0.1: {}
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
 
   estree-util-is-identifier-name@3.0.0: {}
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  esutils@2.0.3: {}
+
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.9.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+
+  execa@8.0.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 8.0.1
+      human-signals: 5.0.0
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.3.0
+      onetime: 6.0.0
+      signal-exit: 4.1.0
+      strip-final-newline: 3.0.0
+
   exsolve@1.1.1: {}
 
   extend@3.0.2: {}
 
+  extract-zip@2.0.1:
+    dependencies:
+      debug: 4.4.3
+      get-stream: 5.2.0
+      yauzl: 2.10.0
+    optionalDependencies:
+      '@types/yauzl': 2.10.3
+    transitivePeerDependencies:
+      - supports-color
+
+  fancy-canvas@2.1.0: {}
+
+  fast-fifo@1.3.2: {}
+
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
+
+  fast-xml-builder@1.3.1:
+    dependencies:
+      path-expression-matcher: 1.6.2
+      xml-naming: 0.3.0
+
+  fast-xml-parser@5.11.0:
+    dependencies:
+      '@nodable/entities': 3.0.0
+      fast-xml-builder: 1.3.1
+      is-unsafe: 2.0.2
+      path-expression-matcher: 1.6.2
+      strnum: 2.4.2
+      xml-naming: 0.3.0
+
   fault@1.0.4:
     dependencies:
       format: 0.2.2
+
+  fd-slicer@1.1.0:
+    dependencies:
+      pend: 1.2.0
 
   fdir@6.5.0(picomatch@4.0.7):
     optionalDependencies:
@@ -4014,7 +8206,70 @@ snapshots:
 
   fetchdts@0.1.7: {}
 
+  fontaine@0.8.0:
+    dependencies:
+      '@capsizecss/unpack': 4.0.1
+      css-tree: 3.2.1
+      magic-regexp: 0.10.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      ufo: 1.6.4
+      unplugin: 2.3.11
+
+  fontkitten@1.0.3:
+    dependencies:
+      tiny-inflate: 1.0.3
+
+  fontless@0.2.1(db0@0.3.4)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)):
+    dependencies:
+      consola: 3.4.2
+      css-tree: 3.2.1
+      defu: 6.1.7
+      esbuild: 0.27.7
+      fontaine: 0.8.0
+      jiti: 2.7.0
+      lightningcss: 1.33.0
+      magic-string: 0.30.21
+      ohash: 2.0.12
+      pathe: 2.0.3
+      ufo: 1.6.4
+      unifont: 0.7.5
+      unstorage: 1.17.5(db0@0.3.4)
+    optionalDependencies:
+      vite: 8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - db0
+      - idb-keyval
+      - ioredis
+      - uploadthing
+
+  form-data-encoder@2.1.4: {}
+
   format@0.2.2: {}
+
+  framer-motion@13.1.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      motion-dom: 13.1.1
+      motion-utils: 13.0.0
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
   fsevents@2.3.2:
     optional: true
@@ -4022,15 +8277,65 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  fuse.js@7.5.0: {}
+
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
+
+  get-east-asian-width@1.6.0: {}
+
+  get-port-please@3.2.0: {}
+
+  get-stream@5.2.0:
+    dependencies:
+      pump: 3.0.4
+
+  get-stream@6.0.1: {}
+
+  get-stream@8.0.1: {}
+
+  get-uri@6.0.5:
+    dependencies:
+      basic-ftp: 5.3.1
+      data-uri-to-buffer: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  giget@3.3.1: {}
 
   goober@2.1.19(csstype@3.2.3):
     dependencies:
       csstype: 3.2.3
 
+  got@13.0.0:
+    dependencies:
+      '@sindresorhus/is': 5.6.0
+      '@szmarczak/http-timer': 5.0.1
+      cacheable-lookup: 7.0.0
+      cacheable-request: 10.2.14
+      decompress-response: 6.0.0
+      form-data-encoder: 2.1.4
+      get-stream: 6.0.1
+      http2-wrapper: 2.2.1
+      lowercase-keys: 3.0.0
+      p-cancelable: 3.0.0
+      responselike: 3.0.0
+
   graceful-fs@4.2.11: {}
+
+  h3@1.15.11:
+    dependencies:
+      cookie-es: 1.2.3
+      crossws: 0.3.5
+      defu: 6.1.7
+      destr: 2.0.5
+      iron-webcrypto: 1.2.1
+      node-mock-http: 1.0.5
+      radix3: 1.1.2
+      ufo: 1.6.4
+      uncrypto: 0.1.3
 
   h3@2.0.1-rc.20(crossws@0.4.12(srvx@0.11.22)):
     dependencies:
@@ -4126,6 +8431,8 @@ snapshots:
       property-information: 7.2.0
       space-separated-tokens: 2.0.2
 
+  hey-listen@1.0.8: {}
+
   highlight.js@10.7.3: {}
 
   highlightjs-vue@1.0.0: {}
@@ -4134,11 +8441,65 @@ snapshots:
 
   html-url-attributes@3.0.1: {}
 
+  http-cache-semantics@4.2.0: {}
+
+  http-link-header@1.1.4: {}
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  http-shutdown@1.2.2: {}
+
+  http2-wrapper@2.2.1:
+    dependencies:
+      quick-lru: 5.1.1
+      resolve-alpn: 1.2.1
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   httpxy@0.5.5: {}
+
+  human-signals@5.0.0: {}
+
+  ignore@7.0.6: {}
+
+  image-ssim@0.2.0: {}
 
   imagetools-core@12.0.0: {}
 
+  immediate@3.0.6: {}
+
+  import-in-the-middle@3.3.3:
+    dependencies:
+      cjs-module-lexer: 2.2.1
+      es-module-lexer: 2.3.2
+      module-details-from-path: 1.0.4
+
+  import-meta-resolve@4.2.0: {}
+
+  imurmurhash@0.1.4: {}
+
   inline-style-parser@0.2.7: {}
+
+  intl-messageformat@10.7.18:
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.6
+      '@formatjs/fast-memoize': 2.2.7
+      '@formatjs/icu-messageformat-parser': 2.11.4
+      tslib: 2.8.1
+
+  ip-address@10.5.0: {}
+
+  iron-webcrypto@1.2.1: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -4149,23 +8510,67 @@ snapshots:
 
   is-decimal@2.0.1: {}
 
+  is-docker@2.2.1: {}
+
+  is-extglob@2.1.1: {}
+
   is-fullwidth-code-point@3.0.0: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
 
   is-hexadecimal@2.0.1: {}
 
+  is-obj@2.0.0: {}
+
   is-plain-obj@4.1.0: {}
+
+  is-stream@3.0.0: {}
+
+  is-typedarray@1.0.0: {}
+
+  is-unsafe@2.0.2: {}
+
+  is-wsl@2.2.0:
+    dependencies:
+      is-docker: 2.2.1
 
   isbot@5.2.1: {}
 
+  isexe@2.0.0: {}
+
+  isomorphic-fetch@3.0.0:
+    dependencies:
+      node-fetch: 2.7.0
+      whatwg-fetch: 3.6.20
+    transitivePeerDependencies:
+      - encoding
+
+  isomorphic.js@0.2.5: {}
+
   jiti@2.7.0: {}
 
+  jpeg-js@0.4.4: {}
+
+  js-library-detector@6.7.0: {}
+
+  js-tokens@10.0.0: {}
+
   js-tokens@4.0.0: {}
+
+  js-yaml@3.15.1:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
 
   js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
   jsesc@3.1.0: {}
+
+  json-buffer@3.0.1: {}
 
   json5@2.2.3: {}
 
@@ -4177,10 +8582,114 @@ snapshots:
     dependencies:
       commander: 8.3.0
 
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  klona@2.0.6: {}
+
+  knitwork@1.3.0: {}
+
   launch-editor@2.14.1:
     dependencies:
       picocolors: 1.1.1
       shell-quote: 1.10.0
+
+  legacy-javascript@0.0.1: {}
+
+  lib0@0.2.117:
+    dependencies:
+      isomorphic.js: 0.2.5
+
+  lie@3.1.1:
+    dependencies:
+      immediate: 3.0.6
+
+  lighthouse-logger@2.0.2:
+    dependencies:
+      debug: 4.4.3
+      marky: 1.3.0
+    transitivePeerDependencies:
+      - supports-color
+
+  lighthouse-stack-packs@1.12.2: {}
+
+  lighthouse-stack-packs@1.12.3: {}
+
+  lighthouse@12.6.1:
+    dependencies:
+      '@paulirish/trace_engine': 0.0.53
+      '@sentry/node': 7.120.4
+      axe-core: 4.13.0
+      chrome-launcher: 1.2.1
+      configstore: 5.0.1
+      csp_evaluator: 1.1.5
+      devtools-protocol: 0.0.1467305
+      enquirer: 2.4.1
+      http-link-header: 1.1.4
+      intl-messageformat: 10.7.18
+      jpeg-js: 0.4.4
+      js-library-detector: 6.7.0
+      lighthouse-logger: 2.0.2
+      lighthouse-stack-packs: 1.12.2
+      lodash-es: 4.18.1
+      lookup-closest-locale: 6.2.0
+      metaviewport-parser: 0.3.0
+      open: 8.4.2
+      parse-cache-control: 1.0.1
+      puppeteer-core: 24.43.1
+      robots-parser: 3.0.1
+      semver: 5.7.2
+      speedline-core: 1.4.3
+      third-party-web: 0.26.7
+      tldts-icann: 6.1.86
+      ws: 7.5.13
+      yargs: 17.7.3
+      yargs-parser: 21.1.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - react-native-b4a
+      - supports-color
+      - utf-8-validate
+
+  lighthouse@13.4.1(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(yauzl@2.10.0):
+    dependencies:
+      '@paulirish/trace_engine': 0.0.65
+      '@sentry/node': 10.71.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))
+      axe-core: 4.13.0
+      chrome-launcher: 1.2.1
+      configstore: 7.1.0
+      csp_evaluator: 1.1.8
+      devtools-protocol: 0.0.1663043
+      enquirer: 2.4.1
+      http-link-header: 1.1.4
+      intl-messageformat: 10.7.18
+      jpeg-js: 0.4.4
+      js-library-detector: 6.7.0
+      lighthouse-logger: 2.0.2
+      lighthouse-stack-packs: 1.12.3
+      lodash-es: 4.18.1
+      lookup-closest-locale: 6.2.0
+      open: 8.4.2
+      puppeteer-core: 25.9.0(yauzl@2.10.0)
+      robots-parser: 3.0.1
+      speedline-core: 1.4.3
+      third-party-web: 0.29.2
+      tldts-icann: 7.4.11
+      web-features: 3.35.1
+      ws: 7.5.13
+      yargs: 17.7.3
+      yargs-parser: 21.1.1
+    transitivePeerDependencies:
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - bufferutil
+      - proxy-agent
+      - supports-color
+      - utf-8-validate
+      - yauzl
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -4280,22 +8789,93 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.33.0
       lightningcss-win32-x64-msvc: 1.33.0
 
+  lightweight-charts@5.2.1:
+    dependencies:
+      fancy-canvas: 2.1.0
+
+  lilconfig@3.1.3: {}
+
+  linkifyjs@4.3.3: {}
+
+  listhen@1.10.1(srvx@0.11.22):
+    dependencies:
+      '@parcel/watcher-wasm': 2.6.0
+      citty: 0.2.2
+      consola: 3.4.2
+      crossws: 0.4.12(srvx@0.11.22)
+      defu: 6.1.7
+      get-port-please: 3.2.0
+      h3: 1.15.11
+      http-shutdown: 1.2.2
+      jiti: 2.7.0
+      node-forge: 1.4.0
+      pathe: 2.0.3
+      std-env: 4.2.0
+      tinyclip: 0.1.15
+      ufo: 1.6.4
+      untun: 0.2.2
+      uqr: 0.1.3
+    transitivePeerDependencies:
+      - srvx
+
+  local-pkg@1.2.1:
+    dependencies:
+      mlly: 1.8.2
+      pkg-types: 2.3.1
+      quansync: 0.2.11
+
+  localforage@1.10.0:
+    dependencies:
+      lie: 3.1.1
+
+  lodash-es@4.18.1: {}
+
   longest-streak@3.1.0: {}
+
+  lookup-closest-locale@6.2.0: {}
+
+  lowercase-keys@3.0.0: {}
 
   lowlight@1.20.0:
     dependencies:
       fault: 1.0.4
       highlight.js: 10.7.3
 
+  lru-cache@11.5.2: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lru-cache@7.18.3: {}
+
+  magic-regexp@0.10.0:
+    dependencies:
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      regexp-tree: 0.1.27
+      type-level-regexp: 0.1.17
+      ufo: 1.6.4
+      unplugin: 2.3.11
 
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  magic-string@1.2.3:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  make-dir@3.1.0:
+    dependencies:
+      semver: 6.3.1
+
   markdown-table@3.0.4: {}
+
+  marked@17.0.6: {}
+
+  marky@1.3.0: {}
 
   match-sorter@8.3.0:
     dependencies:
@@ -4471,6 +9051,14 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  mdn-data@2.27.1: {}
+
+  merge-stream@2.0.0: {}
+
+  meriyah@6.1.4: {}
+
+  metaviewport-parser@0.3.0: {}
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -4673,13 +9261,54 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mimic-fn@4.0.0: {}
+
+  mimic-response@3.1.0: {}
+
+  mimic-response@4.0.0: {}
+
+  mitt@3.0.1: {}
+
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.18.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
+
+  modern-tar@0.8.4: {}
+
+  module-details-from-path@1.0.4: {}
+
+  motion-dom@13.1.1:
+    dependencies:
+      motion-utils: 13.0.0
+
+  motion-utils@13.0.0: {}
+
+  motion-v@2.4.0(@vueuse/core@14.4.0(vue@3.5.41(typescript@6.0.3)))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@6.0.3)):
+    dependencies:
+      '@vueuse/core': 14.4.0(vue@3.5.41(typescript@6.0.3))
+      framer-motion: 13.1.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      hey-listen: 1.0.8
+      motion-dom: 13.1.1
+      motion-utils: 13.0.0
+      vue: 3.5.41(typescript@6.0.3)
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  mrmime@2.0.1: {}
+
   ms@2.1.3: {}
 
   nanoid@3.3.18: {}
 
+  netmask@2.1.1: {}
+
   nf3@0.3.24: {}
 
-  nitro@3.0.260610-beta(chokidar@5.0.0)(jiti@2.7.0)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)):
+  nitro@3.0.260610-beta(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(lru-cache@11.5.2)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.12(srvx@0.11.22)
@@ -4694,8 +9323,10 @@ snapshots:
       rolldown: 1.2.5
       srvx: 0.11.22
       unenv: 2.0.0-rc.24
-      unstorage: 2.0.0-alpha.7(chokidar@5.0.0)(db0@0.3.4)(ofetch@2.0.0-alpha.3)
+      unstorage: 2.0.0-alpha.7(chokidar@5.0.0)(db0@0.3.4)(lru-cache@11.5.2)(ofetch@2.0.0-alpha.3)
     optionalDependencies:
+      dotenv: 17.4.2
+      giget: 3.3.1
       jiti: 2.7.0
       vite: 8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)
     transitivePeerDependencies:
@@ -4730,15 +9361,59 @@ snapshots:
       - uploadthing
       - wrangler
 
+  node-fetch-native@1.6.7: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  node-forge@1.4.0: {}
+
+  node-mock-http@1.0.5: {}
+
   node-releases@2.0.53: {}
+
+  normalize-path@3.0.0: {}
+
+  normalize-url@8.1.1: {}
+
+  nostics@1.2.0: {}
+
+  npm-run-path@5.3.0:
+    dependencies:
+      path-key: 4.0.0
+
+  obug@2.1.4: {}
 
   ocache@0.1.5:
     dependencies:
       ohash: 2.0.12
 
+  ofetch@1.5.1:
+    dependencies:
+      destr: 2.0.5
+      node-fetch-native: 1.6.7
+      ufo: 1.6.4
+
   ofetch@2.0.0-alpha.3: {}
 
   ohash@2.0.12: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  onetime@6.0.0:
+    dependencies:
+      mimic-fn: 4.0.0
+
+  open@8.4.2:
+    dependencies:
+      define-lazy-prop: 2.0.0
+      is-docker: 2.2.1
+      is-wsl: 2.2.0
+
+  orderedmap@2.1.1: {}
 
   oxc-parser@0.120.0(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3):
     dependencies:
@@ -4768,6 +9443,39 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
+  oxc-walker@1.1.1(@oxc-project/types@0.146.0)(rolldown@1.2.5):
+    optionalDependencies:
+      '@oxc-project/types': 0.146.0
+      rolldown: 1.2.5
+
+  p-cancelable@3.0.0: {}
+
+  p-limit@6.2.0:
+    dependencies:
+      yocto-queue: 1.2.2
+
+  pac-proxy-agent@7.2.0:
+    dependencies:
+      '@tootallnate/quickjs-emscripten': 0.23.0
+      agent-base: 7.1.4
+      debug: 4.4.3
+      get-uri: 6.0.5
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      pac-resolver: 7.0.1
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  pac-resolver@7.0.1:
+    dependencies:
+      degenerator: 5.0.1
+      netmask: 2.1.1
+
+  package-manager-detector@1.8.0: {}
+
+  parse-cache-control@1.0.1: {}
+
   parse-entities@4.0.2:
     dependencies:
       '@types/unist': 2.0.11
@@ -4782,11 +9490,35 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  path-expression-matcher@1.6.2: {}
+
+  path-key@3.1.1: {}
+
+  path-key@4.0.0: {}
+
   pathe@2.0.3: {}
+
+  pend@1.2.0: {}
+
+  perfect-debounce@2.1.0: {}
 
   picocolors@1.1.1: {}
 
+  picomatch@2.3.2: {}
+
   picomatch@4.0.7: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
+
+  pkg-types@2.3.1:
+    dependencies:
+      confbox: 0.2.4
+      exsolve: 1.1.1
+      pathe: 2.0.3
 
   playwright-core@1.62.1: {}
 
@@ -4811,7 +9543,166 @@ snapshots:
 
   prismjs@1.30.0: {}
 
+  progress@2.0.3: {}
+
   property-information@7.2.0: {}
+
+  prosemirror-changeset@2.4.2:
+    dependencies:
+      prosemirror-transform: 1.12.0
+
+  prosemirror-commands@1.7.2:
+    dependencies:
+      prosemirror-model: 1.25.11
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
+  prosemirror-dropcursor@1.8.3:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.42.3
+
+  prosemirror-gapcursor@1.4.1:
+    dependencies:
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.11
+      prosemirror-state: 1.4.4
+      prosemirror-view: 1.42.3
+
+  prosemirror-history@1.5.0:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.42.3
+      rope-sequence: 1.3.4
+
+  prosemirror-inputrules@1.5.1:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
+  prosemirror-keymap@1.2.3:
+    dependencies:
+      prosemirror-state: 1.4.4
+      w3c-keyname: 2.2.8
+
+  prosemirror-model@1.25.11:
+    dependencies:
+      orderedmap: 2.1.1
+
+  prosemirror-schema-list@1.5.1:
+    dependencies:
+      prosemirror-model: 1.25.11
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
+  prosemirror-state@1.4.4:
+    dependencies:
+      prosemirror-model: 1.25.11
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.42.3
+
+  prosemirror-tables@1.8.5:
+    dependencies:
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.11
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.42.3
+
+  prosemirror-transform@1.12.0:
+    dependencies:
+      prosemirror-model: 1.25.11
+
+  prosemirror-view@1.42.3:
+    dependencies:
+      prosemirror-model: 1.25.11
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
+  proxy-agent@6.5.0:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      lru-cache: 7.18.3
+      pac-proxy-agent: 7.2.0
+      proxy-from-env: 1.1.0
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  proxy-from-env@1.1.0: {}
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
+  puppeteer-cluster@0.25.0(puppeteer@25.9.0(yauzl@2.10.0)):
+    dependencies:
+      debug: 4.4.3
+      puppeteer: 25.9.0(yauzl@2.10.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  puppeteer-core@24.43.1:
+    dependencies:
+      '@puppeteer/browsers': 2.13.2
+      chromium-bidi: 14.0.0(devtools-protocol@0.0.1608973)
+      debug: 4.4.3
+      devtools-protocol: 0.0.1608973
+      typed-query-selector: 2.12.2
+      webdriver-bidi-protocol: 0.4.1
+      ws: 8.21.3
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - react-native-b4a
+      - supports-color
+      - utf-8-validate
+
+  puppeteer-core@25.9.0(yauzl@2.10.0):
+    dependencies:
+      '@puppeteer/browsers': 3.2.1(yauzl@2.10.0)
+      chromium-bidi: 17.0.2(devtools-protocol@0.0.1666840)
+      devtools-protocol: 0.0.1666840
+      typed-query-selector: 2.12.2
+      webdriver-bidi-protocol: 0.4.2
+      ws: 8.21.3
+    transitivePeerDependencies:
+      - bufferutil
+      - proxy-agent
+      - utf-8-validate
+      - yauzl
+
+  puppeteer@25.9.0(yauzl@2.10.0):
+    dependencies:
+      '@puppeteer/browsers': 3.2.1(yauzl@2.10.0)
+      chromium-bidi: 17.0.2(devtools-protocol@0.0.1666840)
+      devtools-protocol: 0.0.1666840
+      lilconfig: 3.1.3
+      puppeteer-core: 25.9.0(yauzl@2.10.0)
+      typed-query-selector: 2.12.2
+    transitivePeerDependencies:
+      - bufferutil
+      - proxy-agent
+      - utf-8-validate
+      - yauzl
+
+  quansync@0.2.11: {}
+
+  quick-lru@5.1.1: {}
+
+  radix3@1.1.2: {}
+
+  rc9@3.0.1:
+    dependencies:
+      defu: 6.1.7
+      destr: 2.0.5
 
   react-dom@19.2.8(react@19.2.8):
     dependencies:
@@ -4857,6 +9748,10 @@ snapshots:
       hastscript: 9.0.1
       parse-entities: 4.0.2
 
+  regexp-tree@0.1.27: {}
+
+  regexparam@3.0.0: {}
+
   rehype-katex@7.0.1:
     dependencies:
       '@types/hast': 3.0.5
@@ -4870,6 +9765,22 @@ snapshots:
   reicon-react@1.2.0(react@19.2.8):
     dependencies:
       react: 19.2.8
+
+  reka-ui@2.10.3(vue@3.5.41(typescript@6.0.3)):
+    dependencies:
+      '@floating-ui/dom': 1.8.0
+      '@floating-ui/vue': 1.1.11(vue@3.5.41(typescript@6.0.3))
+      '@internationalized/date': 3.12.3
+      '@internationalized/number': 3.6.7
+      '@tanstack/vue-virtual': 3.13.36(vue@3.5.41(typescript@6.0.3))
+      '@vueuse/core': 14.4.0(vue@3.5.41(typescript@6.0.3))
+      '@vueuse/shared': 14.4.0(vue@3.5.41(typescript@6.0.3))
+      aria-hidden: 1.2.6
+      defu: 6.1.7
+      ohash: 2.0.12
+      vue: 3.5.41(typescript@6.0.3)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
 
   remark-breaks@4.0.0:
     dependencies:
@@ -4924,6 +9835,21 @@ snapshots:
 
   require-directory@2.1.1: {}
 
+  require-in-the-middle@8.0.1:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
+
+  resolve-alpn@1.2.1: {}
+
+  responselike@3.0.0:
+    dependencies:
+      lowercase-keys: 3.0.0
+
+  robots-parser@3.0.1: {}
+
   rolldown@1.2.5:
     dependencies:
       '@oxc-project/types': 0.146.0
@@ -4945,9 +9871,21 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.2.5
       '@rolldown/binding-win32-x64-msvc': 1.2.5
 
+  rope-sequence@1.3.4: {}
+
   rou3@0.8.1: {}
 
+  sanitize-filename@1.6.4:
+    dependencies:
+      truncate-utf8-bytes: 1.0.2
+
   scheduler@0.27.0: {}
+
+  scule@1.3.0: {}
+
+  semifies@1.0.0: {}
+
+  semver@5.7.2: {}
 
   semver@6.3.1: {}
 
@@ -4998,7 +9936,48 @@ snapshots:
       '@img/sharp-win32-x64': 0.35.3
       '@types/node': 22.20.1
 
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
   shell-quote@1.10.0: {}
+
+  signal-exit@3.0.7: {}
+
+  signal-exit@4.1.0: {}
+
+  sirv@3.0.2:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
+
+  sisteransi@1.0.5: {}
+
+  sitemapper@4.1.6:
+    dependencies:
+      fast-xml-parser: 5.11.0
+      got: 13.0.0
+      p-limit: 6.2.0
+
+  slugify@1.6.9: {}
+
+  smart-buffer@4.2.0: {}
+
+  socks-proxy-agent@8.0.5:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      socks: 2.8.9
+    transitivePeerDependencies:
+      - supports-color
+
+  socks@2.8.9:
+    dependencies:
+      ip-address: 10.5.0
+      smart-buffer: 4.2.0
 
   solid-js@1.9.15:
     dependencies:
@@ -5008,17 +9987,49 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  source-map@0.6.1: {}
+
   source-map@0.7.6: {}
 
   space-separated-tokens@2.0.2: {}
 
+  speedline-core@1.4.3:
+    dependencies:
+      '@types/node': 22.20.1
+      image-ssim: 0.2.0
+      jpeg-js: 0.4.4
+
+  sprintf-js@1.0.3: {}
+
   srvx@0.11.22: {}
+
+  std-env@4.2.0: {}
+
+  streamx@2.28.1:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
 
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
+
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
+  string-width@8.2.2:
+    dependencies:
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
 
   stringify-entities@4.0.4:
     dependencies:
@@ -5028,6 +10039,26 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.3.0
+
+  strip-final-newline@3.0.0: {}
+
+  strip-literal@4.0.0:
+    dependencies:
+      js-tokens: 10.0.0
+
+  strnum@2.4.2:
+    dependencies:
+      anynum: 1.0.1
+
+  stubborn-fs@2.0.0:
+    dependencies:
+      stubborn-utils: 1.0.2
+
+  stubborn-utils@1.0.2: {}
 
   style-to-js@1.1.21:
     dependencies:
@@ -5041,21 +10072,95 @@ snapshots:
     dependencies:
       tailwindcss: 4.3.3
 
+  tailwind-merge@3.6.0: {}
+
+  tailwind-variants@3.3.1(tailwind-merge@3.6.0)(tailwindcss@4.3.3):
+    optionalDependencies:
+      tailwind-merge: 3.6.0
+      tailwindcss: 4.3.3
+
   tailwindcss@4.3.3: {}
 
   tapable@2.3.3: {}
+
+  tar-fs@3.1.3:
+    dependencies:
+      pump: 3.0.4
+      tar-stream: 3.2.1
+    optionalDependencies:
+      bare-fs: 4.8.1
+      bare-path: 3.1.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  tar-stream@3.2.1:
+    dependencies:
+      b4a: 1.8.1
+      bare-fs: 4.8.1
+      fast-fifo: 1.3.2
+      streamx: 2.28.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.28.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.1
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  third-party-web@0.26.7: {}
+
+  third-party-web@0.29.2: {}
+
+  tiny-inflate@1.0.3: {}
+
+  tinyclip@0.1.15: {}
+
+  tinyexec@1.3.0: {}
 
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.7)
       picomatch: 4.0.7
 
+  tldts-core@6.1.86: {}
+
+  tldts-core@7.4.11: {}
+
+  tldts-icann@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
+  tldts-icann@7.4.11:
+    dependencies:
+      tldts-core: 7.4.11
+
+  totalist@3.0.1: {}
+
+  tr46@0.0.3: {}
+
+  tree-kill@1.2.2: {}
+
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
 
-  tslib@2.8.1:
-    optional: true
+  truncate-utf8-bytes@1.0.2:
+    dependencies:
+      utf8-byte-length: 1.0.5
+
+  tslib@2.8.1: {}
 
   tsx@4.23.12:
     dependencies:
@@ -5063,15 +10168,60 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  type-fest@4.41.0: {}
+
+  type-level-regexp@0.1.17: {}
+
+  typed-query-selector@2.12.2: {}
+
+  typedarray-to-buffer@3.1.5:
+    dependencies:
+      is-typedarray: 1.0.0
+
   typescript@6.0.3: {}
 
   ufo@1.6.4: {}
 
+  ultrahtml@1.7.0: {}
+
+  uncrypto@0.1.3: {}
+
+  unctx@2.5.0:
+    dependencies:
+      acorn: 8.18.0
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+      unplugin: 2.3.11
+
+  unctx@3.0.1(magic-string@1.2.3)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))):
+    optionalDependencies:
+      magic-string: 1.2.3
+      rolldown: 1.2.5
+      unplugin: 3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+
   undici-types@6.21.0: {}
+
+  undici@8.10.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:
       pathe: 2.0.3
+
+  unhead@3.4.0(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)):
+    dependencies:
+      hookable: 6.1.1
+      unplugin: 3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+    optionalDependencies:
+      vite: 8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - bun-types-no-globals
+      - esbuild
+      - rolldown
+      - rollup
+      - unloader
+      - webpack
 
   unified@11.0.5:
     dependencies:
@@ -5082,6 +10232,44 @@ snapshots:
       is-plain-obj: 4.1.0
       trough: 2.2.0
       vfile: 6.0.3
+
+  unifont@0.7.5:
+    dependencies:
+      css-tree: 3.2.1
+      ohash: 2.0.12
+      undici: 8.10.0
+
+  unimport@6.4.0(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)):
+    dependencies:
+      acorn: 8.18.0
+      escape-string-regexp: 5.0.0
+      estree-walker: 3.0.3
+      local-pkg: 1.2.1
+      magic-string: 1.2.3
+      mlly: 1.8.2
+      pathe: 2.0.3
+      picomatch: 4.0.7
+      pkg-types: 2.3.1
+      scule: 1.3.0
+      strip-literal: 4.0.0
+      tinyglobby: 0.2.17
+      unplugin: 3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+      unplugin-utils: 0.3.2
+    optionalDependencies:
+      rolldown: 1.2.5
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - bun-types-no-globals
+      - esbuild
+      - rollup
+      - unloader
+      - vite
+      - webpack
+
+  unique-string@2.0.0:
+    dependencies:
+      crypto-random-string: 2.0.0
 
   unist-util-find-after@5.0.0:
     dependencies:
@@ -5116,6 +10304,167 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
+  unlighthouse@0.18.0(33e19f5c7fc2330f694693c9203e763e):
+    dependencies:
+      '@unlighthouse/cli': 0.18.0(4304ff7df3b01adfd53a0c4cd139f424)
+      '@unlighthouse/client': 0.18.0(ce335527f92a80ce512b53adb18789f9)
+      '@unlighthouse/core': 0.18.0(434fe901b7dc0e50f21c041ba2487a0c)
+    optionalDependencies:
+      puppeteer: 25.9.0(yauzl@2.10.0)
+      vue: 3.5.41(typescript@6.0.3)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@farmfe/core'
+      - '@inertiajs/vue3'
+      - '@internationalized/date'
+      - '@internationalized/number'
+      - '@netlify/blobs'
+      - '@nuxt/content'
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - '@oxc-project/types'
+      - '@parcel/watcher'
+      - '@planetscale/database'
+      - '@rspack/core'
+      - '@tiptap/core'
+      - '@tiptap/extension-bubble-menu'
+      - '@tiptap/extension-code'
+      - '@tiptap/extension-collaboration'
+      - '@tiptap/extension-drag-handle'
+      - '@tiptap/extension-drag-handle-vue-3'
+      - '@tiptap/extension-floating-menu'
+      - '@tiptap/extension-horizontal-rule'
+      - '@tiptap/extension-image'
+      - '@tiptap/extension-mention'
+      - '@tiptap/extension-node-range'
+      - '@tiptap/extension-placeholder'
+      - '@tiptap/markdown'
+      - '@tiptap/pm'
+      - '@tiptap/starter-kit'
+      - '@tiptap/suggestion'
+      - '@tiptap/vue-3'
+      - '@unhead/cli'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@vitejs/devtools-kit'
+      - '@vue/composition-api'
+      - ai
+      - async-validator
+      - aws4fetch
+      - axios
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - bun-types-no-globals
+      - change-case
+      - db0
+      - drauu
+      - embla-carousel
+      - encoding
+      - esbuild
+      - focus-trap
+      - idb-keyval
+      - ioredis
+      - joi
+      - jwt-decode
+      - lightningcss
+      - magicast
+      - nprogress
+      - oxc-parser
+      - proxy-agent
+      - qrcode
+      - react
+      - react-dom
+      - react-native-b4a
+      - rolldown
+      - rollup
+      - sortablejs
+      - srvx
+      - superstruct
+      - supports-color
+      - tailwindcss
+      - typescript
+      - universal-cookie
+      - unloader
+      - uploadthing
+      - utf-8-validate
+      - valibot
+      - vite
+      - vue-router
+      - webpack
+      - yauzl
+      - yup
+      - zod
+
+  unplugin-auto-import@21.1.0(@nuxt/kit@4.5.2(magic-string@1.2.3)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))))(@vueuse/core@14.4.0(vue@3.5.41(typescript@6.0.3)))(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)):
+    dependencies:
+      local-pkg: 1.2.1
+      magic-string: 1.2.3
+      picomatch: 4.0.7
+      unimport: 6.4.0(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+      unplugin: 3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+      unplugin-utils: 0.3.2
+    optionalDependencies:
+      '@nuxt/kit': 4.5.2(magic-string@1.2.3)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)))
+      '@vueuse/core': 14.4.0(vue@3.5.41(typescript@6.0.3))
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - bun-types-no-globals
+      - esbuild
+      - oxc-parser
+      - rolldown
+      - rollup
+      - unloader
+      - vite
+      - webpack
+
+  unplugin-utils@0.3.2:
+    dependencies:
+      pathe: 2.0.3
+      picomatch: 4.0.7
+
+  unplugin-vue-components@32.1.0(@nuxt/kit@4.5.2(magic-string@1.2.3)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))))(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))(vue@3.5.41(typescript@6.0.3)):
+    dependencies:
+      chokidar: 5.0.0
+      local-pkg: 1.2.1
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      obug: 2.1.4
+      picomatch: 4.0.7
+      tinyglobby: 0.2.17
+      unplugin: 3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+      unplugin-utils: 0.3.2
+      vue: 3.5.41(typescript@6.0.3)
+    optionalDependencies:
+      '@nuxt/kit': 4.5.2(magic-string@1.2.3)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)))
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - bun-types-no-globals
+      - esbuild
+      - rolldown
+      - rollup
+      - unloader
+      - vite
+      - webpack
+
+  unplugin@2.3.11:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      acorn: 8.18.0
+      picomatch: 4.0.7
+      webpack-virtual-modules: 0.6.2
+
   unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)):
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -5126,11 +10475,35 @@ snapshots:
       rolldown: 1.2.5
       vite: 8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)
 
-  unstorage@2.0.0-alpha.7(chokidar@5.0.0)(db0@0.3.4)(ofetch@2.0.0-alpha.3):
+  unstorage@1.17.5(db0@0.3.4):
+    dependencies:
+      anymatch: 3.1.3
+      chokidar: 5.0.0
+      destr: 2.0.5
+      h3: 1.15.11
+      lru-cache: 11.5.2
+      node-fetch-native: 1.6.7
+      ofetch: 1.5.1
+      ufo: 1.6.4
+    optionalDependencies:
+      db0: 0.3.4
+
+  unstorage@2.0.0-alpha.7(chokidar@5.0.0)(db0@0.3.4)(lru-cache@11.5.2)(ofetch@2.0.0-alpha.3):
     optionalDependencies:
       chokidar: 5.0.0
       db0: 0.3.4
+      lru-cache: 11.5.2
       ofetch: 2.0.0-alpha.3
+
+  untun@0.2.2: {}
+
+  untyped@2.0.0:
+    dependencies:
+      citty: 0.1.6
+      defu: 6.1.7
+      jiti: 2.7.0
+      knitwork: 1.3.0
+      scule: 1.3.0
 
   update-browserslist-db@1.3.1(browserslist@4.28.8):
     dependencies:
@@ -5138,11 +10511,25 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
+  uqr@0.1.3: {}
+
   use-sync-external-store@1.6.0(react@19.2.8):
     dependencies:
       react: 19.2.8
 
+  utf8-byte-length@1.0.5: {}
+
   util-deprecate@1.0.2: {}
+
+  vaul-vue@0.4.1(reka-ui@2.10.3(vue@3.5.41(typescript@6.0.3)))(vue@3.5.41(typescript@6.0.3)):
+    dependencies:
+      '@vueuse/core': 10.11.1(vue@3.5.41(typescript@6.0.3))
+      reka-ui: 2.10.3(vue@3.5.41(typescript@6.0.3))
+      vue: 3.5.41(typescript@6.0.3)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+
+  verkit@0.3.2: {}
 
   vfile-location@5.0.3:
     dependencies:
@@ -5187,9 +10574,50 @@ snapshots:
     optionalDependencies:
       vite: 8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)
 
+  vue-component-type-helpers@3.3.11: {}
+
+  vue-demi@0.14.10(vue@3.5.41(typescript@6.0.3)):
+    dependencies:
+      vue: 3.5.41(typescript@6.0.3)
+
+  vue@3.5.41(typescript@6.0.3):
+    dependencies:
+      '@vue/compiler-dom': 3.5.41
+      '@vue/compiler-sfc': 3.5.41
+      '@vue/runtime-dom': 3.5.41
+      '@vue/server-renderer': 3.5.41
+      '@vue/shared': 3.5.41
+    optionalDependencies:
+      typescript: 6.0.3
+
+  w3c-keyname@2.2.8: {}
+
+  web-features@3.35.1: {}
+
   web-namespaces@2.0.1: {}
 
+  webdriver-bidi-protocol@0.4.1: {}
+
+  webdriver-bidi-protocol@0.4.2: {}
+
+  webidl-conversions@3.0.1: {}
+
   webpack-virtual-modules@0.6.2: {}
+
+  whatwg-fetch@3.6.20: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
+  wheel-gestures@2.2.48: {}
+
+  when-exit@2.1.5: {}
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
 
   wrap-ansi@7.0.0:
     dependencies:
@@ -5197,7 +10625,30 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
+  wrappy@1.0.2: {}
+
+  write-file-atomic@3.0.3:
+    dependencies:
+      imurmurhash: 0.1.4
+      is-typedarray: 1.0.0
+      signal-exit: 3.0.7
+      typedarray-to-buffer: 3.1.5
+
+  ws@7.5.13: {}
+
   ws@8.21.3: {}
+
+  xdg-basedir@4.0.0: {}
+
+  xdg-basedir@5.1.0: {}
+
+  xml-naming@0.3.0: {}
 
   xmlbuilder2@4.0.3:
     dependencies:
@@ -5206,11 +10657,18 @@ snapshots:
       '@oozcitak/util': 10.0.0
       js-yaml: 4.3.1
 
+  y-protocols@1.0.7(yjs@13.6.32):
+    dependencies:
+      lib0: 0.2.117
+      yjs: 13.6.32
+
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
 
   yargs-parser@21.1.1: {}
+
+  yargs-parser@22.0.0: {}
 
   yargs@17.7.3:
     dependencies:
@@ -5221,6 +10679,28 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yargs@18.1.0:
+    dependencies:
+      cliui: 9.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      string-width: 8.2.2
+      y18n: 5.0.8
+      yargs-parser: 22.0.0
+
+  yauzl@2.10.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      fd-slicer: 1.1.0
+
+  yjs@13.6.32:
+    dependencies:
+      lib0: 0.2.117
+
+  yocto-queue@1.2.2: {}
+
+  zod@3.25.76: {}
 
   zod@4.4.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,6 @@
 allowBuilds:
   esbuild: true
   lightningcss: true
-  puppeteer: set this to true or false
-  vue-demi: set this to true or false
+  puppeteer: true
+  vue-demi: true
 minimumReleaseAge: 1440

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,6 @@
 allowBuilds:
   esbuild: true
   lightningcss: true
+  puppeteer: set this to true or false
+  vue-demi: set this to true or false
 minimumReleaseAge: 1440

--- a/src/components/KeyboardShortcutsSection.tsx
+++ b/src/components/KeyboardShortcutsSection.tsx
@@ -1,453 +1,453 @@
 import {
-  formatForDisplay,
-  useHeldKeys,
-  useHotkeyRecorder,
-  useHotkeySequenceRecorder,
+	formatForDisplay,
+	useHeldKeys,
+	useHotkeyRecorder,
+	useHotkeySequenceRecorder,
 } from "@tanstack/react-hotkeys";
 import { useRef, useState } from "react";
 import { Keyboard, Restart, TriangleWarning } from "reicon-react";
 import { useT } from "../i18n/hooks";
 import {
-  COMMAND_MODULES,
-  COMMANDS,
-  type CommandAssignment,
-  type CommandId,
-  DEFAULT_COMMAND_ASSIGNMENTS,
+	COMMAND_MODULES,
+	COMMANDS,
+	type CommandAssignment,
+	type CommandId,
+	DEFAULT_COMMAND_ASSIGNMENTS,
 } from "../lib/commands";
 import { useKeyboardCommands } from "../lib/keyboard-commands";
 import { track } from "../lib/umami";
 
 function getAssignmentKeys(assignment: CommandAssignment): readonly string[] {
-  return assignment.type === "hotkeys"
-    ? assignment.hotkeys
-    : assignment.sequence;
+	return assignment.type === "hotkeys"
+		? assignment.hotkeys
+		: assignment.sequence;
 }
 
 function getKeyedValues(values: readonly string[]) {
-  const occurrences = new Map<string, number>();
+	const occurrences = new Map<string, number>();
 
-  return values.map((value) => {
-    const occurrence = occurrences.get(value) ?? 0;
-    occurrences.set(value, occurrence + 1);
-    return { id: `${value}-${occurrence}`, value };
-  });
+	return values.map((value) => {
+		const occurrence = occurrences.get(value) ?? 0;
+		occurrences.set(value, occurrence + 1);
+		return { id: `${value}-${occurrence}`, value };
+	});
 }
 
 function HotkeyKeycaps({ hotkey }: { hotkey: string }) {
-  const displayKeys = getKeyedValues(
-    formatForDisplay(hotkey).split(/\s+/).filter(Boolean),
-  );
+	const displayKeys = getKeyedValues(
+		formatForDisplay(hotkey).split(/\s+/).filter(Boolean),
+	);
 
-  return (
-    <span className="inline-flex items-center gap-1">
-      {displayKeys.map(({ id, value: key }, displayKeyIndex) => (
-        <span key={id} className="inline-flex items-center gap-1">
-          <kbd className="border-border bg-code text-fg-secondary inline-flex min-h-8 items-center rounded-md border px-2 font-mono text-s leading-none font-medium shadow-[0_1px_0_var(--color-border)]">
-            {key}
-          </kbd>
-          {displayKeyIndex < displayKeys.length - 1 && (
-            <span className="text-fg-muted text-[0.65rem]" aria-hidden="true">
-              +
-            </span>
-          )}
-        </span>
-      ))}
-    </span>
-  );
+	return (
+		<span className="inline-flex items-center gap-1">
+			{displayKeys.map(({ id, value: key }, displayKeyIndex) => (
+				<span key={id} className="inline-flex items-center gap-1">
+					<kbd className="border-border bg-code text-fg-secondary inline-flex min-h-8 items-center rounded-md border px-2 font-mono text-s leading-none font-medium shadow-[0_1px_0_var(--color-border)]">
+						{key}
+					</kbd>
+					{displayKeyIndex < displayKeys.length - 1 && (
+						<span className="text-fg-muted text-[0.65rem]" aria-hidden="true">
+							+
+						</span>
+					)}
+				</span>
+			))}
+		</span>
+	);
 }
 
 function AssignmentKeycaps({ assignment }: { assignment: CommandAssignment }) {
-  const keys = getAssignmentKeys(assignment);
-  const separator = assignment.type === "hotkeys" ? "/" : "·";
+	const keys = getAssignmentKeys(assignment);
+	const separator = assignment.type === "hotkeys" ? "/" : "·";
 
-  return (
-    <span className="flex min-w-0 flex-wrap items-center justify-end gap-1.5">
-      {getKeyedValues(keys).map(({ id, value: hotkey }, index) => (
-        <span key={id} className="inline-flex items-center gap-1.5">
-          {index > 0 && (
-            <span className="text-fg-muted text-[0.65rem]" aria-hidden="true">
-              {separator}
-            </span>
-          )}
-          <HotkeyKeycaps hotkey={hotkey} />
-        </span>
-      ))}
-    </span>
-  );
+	return (
+		<span className="flex min-w-0 flex-wrap items-center justify-end gap-1.5">
+			{getKeyedValues(keys).map(({ id, value: hotkey }, index) => (
+				<span key={id} className="inline-flex items-center gap-1.5">
+					{index > 0 && (
+						<span className="text-fg-muted text-[0.65rem]" aria-hidden="true">
+							{separator}
+						</span>
+					)}
+					<HotkeyKeycaps hotkey={hotkey} />
+				</span>
+			))}
+		</span>
+	);
 }
 
 function isSameAssignment(
-  left: CommandAssignment,
-  right: CommandAssignment,
+	left: CommandAssignment,
+	right: CommandAssignment,
 ): boolean {
-  if (left.type !== right.type) return false;
-  const leftKeys = left.type === "hotkeys" ? left.hotkeys : left.sequence;
-  const rightKeys = right.type === "hotkeys" ? right.hotkeys : right.sequence;
-  return (
-    leftKeys.length === rightKeys.length &&
-    leftKeys.every((key, index) => key === rightKeys[index])
-  );
+	if (left.type !== right.type) return false;
+	const leftKeys = left.type === "hotkeys" ? left.hotkeys : left.sequence;
+	const rightKeys = right.type === "hotkeys" ? right.hotkeys : right.sequence;
+	return (
+		leftKeys.length === rightKeys.length &&
+		leftKeys.every((key, index) => key === rightKeys[index])
+	);
 }
 
 function HeldKeysIndicator() {
-  const t = useT();
-  const heldKeys = useHeldKeys();
+	const t = useT();
+	const heldKeys = useHeldKeys();
 
-  if (heldKeys.length === 0) return null;
+	if (heldKeys.length === 0) return null;
 
-  return (
-    <div
-      className="border-border bg-code/50 text-fg-secondary flex items-center gap-2 rounded-lg border px-3 py-2 text-xs"
-      aria-live="polite"
-    >
-      <span className="font-semibold">{t.settings.heldKeys}</span>
-      <span className="flex min-w-0 flex-wrap gap-1">
-        {heldKeys.map((key) => (
-          <kbd
-            key={key}
-            className="bg-surface text-fg rounded border border-current/15 px-1.5 py-0.5 font-mono text-[0.7rem]"
-          >
-            {formatForDisplay(key)}
-          </kbd>
-        ))}
-      </span>
-    </div>
-  );
+	return (
+		<div
+			className="border-border bg-code/50 text-fg-secondary flex items-center gap-2 rounded-lg border px-3 py-2 text-xs"
+			aria-live="polite"
+		>
+			<span className="font-semibold">{t.settings.heldKeys}</span>
+			<span className="flex min-w-0 flex-wrap gap-1">
+				{heldKeys.map((key) => (
+					<kbd
+						key={key}
+						className="bg-surface text-fg rounded border border-current/15 px-1.5 py-0.5 font-mono text-[0.7rem]"
+					>
+						{formatForDisplay(key)}
+					</kbd>
+				))}
+			</span>
+		</div>
+	);
 }
 
 function ShortcutBinding({
-  assignment,
-  hasConflict,
-  isRecording,
-  recordedSteps,
-  onStart,
-  onCommit,
-  onCancel,
+	assignment,
+	hasConflict,
+	isRecording,
+	recordedSteps,
+	onStart,
+	onCommit,
+	onCancel,
 }: {
-  assignment: CommandAssignment;
-  hasConflict: boolean;
-  isRecording: boolean;
-  recordedSteps: readonly string[];
-  onStart: () => void;
-  onCommit: () => void;
-  onCancel: () => void;
+	assignment: CommandAssignment;
+	hasConflict: boolean;
+	isRecording: boolean;
+	recordedSteps: readonly string[];
+	onStart: () => void;
+	onCommit: () => void;
+	onCancel: () => void;
 }) {
-  const t = useT();
-  const assignmentKeys = getAssignmentKeys(assignment);
-  const isSequence = assignment.type === "sequence";
-  const isUnassigned = !isRecording && assignmentKeys.length === 0;
+	const t = useT();
+	const assignmentKeys = getAssignmentKeys(assignment);
+	const isSequence = assignment.type === "sequence";
+	const isUnassigned = !isRecording && assignmentKeys.length === 0;
 
-  return (
-    <div className="flex shrink-0 items-stretch gap-2">
-      <button
-        type="button"
-        onClick={onStart}
-        className={`border-border bg-surface text-fg hover:border-accent hover:text-accent-fg focus-visible:ring-accent group-hover/shortcut-card:border-accent flex min-h-10 min-w-0 items-center justify-end gap-3 border border-dashed px-2 py-1.5 text-left transition-[background-color,border-color,color,scale] duration-150 focus-visible:ring-2 focus-visible:outline-none active:scale-[0.98] ${hasConflict ? "rounded-se-lg rounded-ee-none" : "rounded-e-lg"} ${isRecording ? "border-accent bg-accent-light text-accent-fg" : ""}`}
-        aria-label={
-          isRecording ? t.settings.recording : t.settings.editShortcut
-        }
-      >
-        {isRecording ? (
-          recordedSteps.length > 0 ? (
-            <span className="flex min-w-0 flex-wrap items-center justify-end gap-1.5">
-              {getKeyedValues(recordedSteps).map(
-                ({ id, value: hotkey }, index) => (
-                  <span key={id} className="inline-flex items-center gap-1.5">
-                    {index > 0 && (
-                      <span
-                        className="text-fg-muted text-[0.65rem]"
-                        aria-hidden="true"
-                      >
-                        ·
-                      </span>
-                    )}
-                    <HotkeyKeycaps hotkey={hotkey} />
-                  </span>
-                ),
-              )}
-            </span>
-          ) : (
-            <span className="text-fg-muted text-xs font-medium">
-              {t.settings.pressKeys}
-            </span>
-          )
-        ) : isUnassigned ? (
-          <span className="text-fg-muted text-xs font-medium">
-            {t.settings.shortcutUnassigned}
-          </span>
-        ) : (
-          <AssignmentKeycaps assignment={assignment} />
-        )}
-      </button>
-      {isRecording && isSequence && (
-        <div className="flex items-center gap-1.5">
-          <button
-            type="button"
-            onClick={onCommit}
-            disabled={recordedSteps.length === 0}
-            className="bg-accent text-on-accent hover:bg-accent-hover focus-visible:ring-accent min-h-10 rounded-lg px-3 text-xs font-semibold transition-[background-color,scale] duration-150 focus-visible:ring-2 focus-visible:outline-none active:scale-[0.96] disabled:cursor-not-allowed disabled:opacity-40"
-          >
-            {t.settings.saveShortcut}
-          </button>
-          <button
-            type="button"
-            onClick={onCancel}
-            className="border-border text-fg-secondary hover:bg-surface focus-visible:ring-accent min-h-10 rounded-lg border px-3 text-xs transition-colors focus-visible:ring-2 focus-visible:outline-none"
-          >
-            {t.settings.cancelShortcut}
-          </button>
-        </div>
-      )}
-    </div>
-  );
+	return (
+		<div className="flex shrink-0 items-stretch gap-2">
+			<button
+				type="button"
+				onClick={onStart}
+				className={`border-border bg-surface text-fg hover:border-accent hover:text-accent-fg focus-visible:ring-accent group-hover/shortcut-card:border-accent flex min-h-10 min-w-0 items-center justify-end gap-3 border border-dashed px-2 py-1.5 text-left transition-[background-color,border-color,color,scale] duration-150 focus-visible:ring-2 focus-visible:outline-none active:scale-[0.98] ${hasConflict ? "rounded-se-lg rounded-ee-none" : "rounded-e-lg"} ${isRecording ? "border-accent bg-accent-light text-accent-fg" : ""}`}
+				aria-label={
+					isRecording ? t.settings.recording : t.settings.editShortcut
+				}
+			>
+				{isRecording ? (
+					recordedSteps.length > 0 ? (
+						<span className="flex min-w-0 flex-wrap items-center justify-end gap-1.5">
+							{getKeyedValues(recordedSteps).map(
+								({ id, value: hotkey }, index) => (
+									<span key={id} className="inline-flex items-center gap-1.5">
+										{index > 0 && (
+											<span
+												className="text-fg-muted text-[0.65rem]"
+												aria-hidden="true"
+											>
+												·
+											</span>
+										)}
+										<HotkeyKeycaps hotkey={hotkey} />
+									</span>
+								),
+							)}
+						</span>
+					) : (
+						<span className="text-fg-muted text-xs font-medium">
+							{t.settings.pressKeys}
+						</span>
+					)
+				) : isUnassigned ? (
+					<span className="text-fg-muted text-xs font-medium">
+						{t.settings.shortcutUnassigned}
+					</span>
+				) : (
+					<AssignmentKeycaps assignment={assignment} />
+				)}
+			</button>
+			{isRecording && isSequence && (
+				<div className="flex items-center gap-1.5">
+					<button
+						type="button"
+						onClick={onCommit}
+						disabled={recordedSteps.length === 0}
+						className="bg-accent text-on-accent hover:bg-accent-hover focus-visible:ring-accent min-h-10 rounded-lg px-3 text-xs font-semibold transition-[background-color,scale] duration-150 focus-visible:ring-2 focus-visible:outline-none active:scale-[0.96] disabled:cursor-not-allowed disabled:opacity-40"
+					>
+						{t.settings.saveShortcut}
+					</button>
+					<button
+						type="button"
+						onClick={onCancel}
+						className="border-border text-fg-secondary hover:bg-surface focus-visible:ring-accent min-h-10 rounded-lg border px-3 text-xs transition-colors focus-visible:ring-2 focus-visible:outline-none"
+					>
+						{t.settings.cancelShortcut}
+					</button>
+				</div>
+			)}
+		</div>
+	);
 }
 
 export default function KeyboardShortcutsSection() {
-  const t = useT();
-  const {
-    assignments,
-    conflicts,
-    resetAllAssignments,
-    resetAssignment,
-    setAssignment,
-  } = useKeyboardCommands();
-  const [editingCommandId, setEditingCommandId] = useState<CommandId | null>(
-    null,
-  );
-  const [recordingKind, setRecordingKind] = useState<
-    "hotkeys" | "sequence" | null
-  >(null);
-  const editingCommandRef = useRef<CommandId | null>(null);
+	const t = useT();
+	const {
+		assignments,
+		conflicts,
+		resetAllAssignments,
+		resetAssignment,
+		setAssignment,
+	} = useKeyboardCommands();
+	const [editingCommandId, setEditingCommandId] = useState<CommandId | null>(
+		null,
+	);
+	const [recordingKind, setRecordingKind] = useState<
+		"hotkeys" | "sequence" | null
+	>(null);
+	const editingCommandRef = useRef<CommandId | null>(null);
 
-  function finishRecording() {
-    editingCommandRef.current = null;
-    setEditingCommandId(null);
-    setRecordingKind(null);
-  }
+	function finishRecording() {
+		editingCommandRef.current = null;
+		setEditingCommandId(null);
+		setRecordingKind(null);
+	}
 
-  const hotkeyRecorder = useHotkeyRecorder({
-    onRecord: (hotkey) => {
-      const commandId = editingCommandRef.current;
-      if (!commandId) return;
-      setAssignment(commandId, {
-        type: "hotkeys",
-        hotkeys: hotkey ? [hotkey] : [],
-      });
-      track("keyboard_shortcut_change", {
-        commandId,
-        bindingType: "hotkey",
-      });
-      finishRecording();
-    },
-    onClear: () => {
-      const commandId = editingCommandRef.current;
-      if (!commandId) return;
-      setAssignment(commandId, { type: "hotkeys", hotkeys: [] });
-      track("keyboard_shortcut_change", {
-        commandId,
-        bindingType: "hotkey-cleared",
-      });
-      finishRecording();
-    },
-    onCancel: finishRecording,
-  });
+	const hotkeyRecorder = useHotkeyRecorder({
+		onRecord: (hotkey) => {
+			const commandId = editingCommandRef.current;
+			if (!commandId) return;
+			setAssignment(commandId, {
+				type: "hotkeys",
+				hotkeys: hotkey ? [hotkey] : [],
+			});
+			track("keyboard_shortcut_change", {
+				commandId,
+				bindingType: "hotkey",
+			});
+			finishRecording();
+		},
+		onClear: () => {
+			const commandId = editingCommandRef.current;
+			if (!commandId) return;
+			setAssignment(commandId, { type: "hotkeys", hotkeys: [] });
+			track("keyboard_shortcut_change", {
+				commandId,
+				bindingType: "hotkey-cleared",
+			});
+			finishRecording();
+		},
+		onCancel: finishRecording,
+	});
 
-  const sequenceRecorder = useHotkeySequenceRecorder({
-    onRecord: (sequence) => {
-      const commandId = editingCommandRef.current;
-      if (!commandId) return;
-      setAssignment(commandId, { type: "sequence", sequence });
-      track("keyboard_shortcut_change", {
-        commandId,
-        bindingType: "sequence",
-      });
-      finishRecording();
-    },
-    onClear: () => {
-      const commandId = editingCommandRef.current;
-      if (!commandId) return;
-      setAssignment(commandId, { type: "sequence", sequence: [] });
-      track("keyboard_shortcut_change", {
-        commandId,
-        bindingType: "sequence-cleared",
-      });
-      finishRecording();
-    },
-    onCancel: finishRecording,
-  });
+	const sequenceRecorder = useHotkeySequenceRecorder({
+		onRecord: (sequence) => {
+			const commandId = editingCommandRef.current;
+			if (!commandId) return;
+			setAssignment(commandId, { type: "sequence", sequence });
+			track("keyboard_shortcut_change", {
+				commandId,
+				bindingType: "sequence",
+			});
+			finishRecording();
+		},
+		onClear: () => {
+			const commandId = editingCommandRef.current;
+			if (!commandId) return;
+			setAssignment(commandId, { type: "sequence", sequence: [] });
+			track("keyboard_shortcut_change", {
+				commandId,
+				bindingType: "sequence-cleared",
+			});
+			finishRecording();
+		},
+		onCancel: finishRecording,
+	});
 
-  function startRecording(commandId: CommandId) {
-    const command = COMMANDS.find((item) => item.id === commandId);
-    if (!command) return;
+	function startRecording(commandId: CommandId) {
+		const command = COMMANDS.find((item) => item.id === commandId);
+		if (!command) return;
 
-    hotkeyRecorder.stopRecording();
-    sequenceRecorder.stopRecording();
-    editingCommandRef.current = commandId;
-    setEditingCommandId(commandId);
-    setRecordingKind(command.kind);
-    if (command.kind === "sequence") sequenceRecorder.startRecording();
-    else hotkeyRecorder.startRecording();
-  }
+		hotkeyRecorder.stopRecording();
+		sequenceRecorder.stopRecording();
+		editingCommandRef.current = commandId;
+		setEditingCommandId(commandId);
+		setRecordingKind(command.kind);
+		if (command.kind === "sequence") sequenceRecorder.startRecording();
+		else hotkeyRecorder.startRecording();
+	}
 
-  function cancelRecording() {
-    hotkeyRecorder.stopRecording();
-    sequenceRecorder.stopRecording();
-    finishRecording();
-  }
+	function cancelRecording() {
+		hotkeyRecorder.stopRecording();
+		sequenceRecorder.stopRecording();
+		finishRecording();
+	}
 
-  function resetOne(commandId: CommandId) {
-    if (editingCommandRef.current === commandId) cancelRecording();
-    resetAssignment(commandId);
-  }
+	function resetOne(commandId: CommandId) {
+		if (editingCommandRef.current === commandId) cancelRecording();
+		resetAssignment(commandId);
+	}
 
-  function resetAll() {
-    cancelRecording();
-    resetAllAssignments();
-  }
+	function resetAll() {
+		cancelRecording();
+		resetAllAssignments();
+	}
 
-  const commandsById = new Map(
-    COMMANDS.map((command) => [command.id, command]),
-  );
-  const commandsForModules = (
-    modules: ReadonlyArray<(typeof COMMAND_MODULES)[number]>,
-  ) =>
-    modules.flatMap((module) =>
-      module.commands.flatMap((commandId) => {
-        const command = commandsById.get(commandId);
-        return command ? [command] : [];
-      }),
-    );
-  const groupedCommands = [
-    {
-      id: "global",
-      label: t.settings.shortcutScopes.global,
-      commands: commandsForModules(
-        COMMAND_MODULES.filter((module) => module.scope === "global"),
-      ),
-    },
-    {
-      id: "practice-exam",
-      label: t.settings.shortcutScopes.practiceExam,
-      commands: commandsForModules(
-        COMMAND_MODULES.filter((module) => module.scope !== "global"),
-      ),
-    },
-  ];
+	const commandsById = new Map(
+		COMMANDS.map((command) => [command.id, command]),
+	);
+	const commandsForModules = (
+		modules: ReadonlyArray<(typeof COMMAND_MODULES)[number]>,
+	) =>
+		modules.flatMap((module) =>
+			module.commands.flatMap((commandId) => {
+				const command = commandsById.get(commandId);
+				return command ? [command] : [];
+			}),
+		);
+	const groupedCommands = [
+		{
+			id: "global",
+			label: t.settings.shortcutScopes.global,
+			commands: commandsForModules(
+				COMMAND_MODULES.filter((module) => module.scope === "global"),
+			),
+		},
+		{
+			id: "practice-exam",
+			label: t.settings.shortcutScopes.practiceExam,
+			commands: commandsForModules(
+				COMMAND_MODULES.filter((module) => module.scope !== "global"),
+			),
+		},
+	];
 
-  return (
-    <section className="space-y-5" aria-labelledby="settings-shortcuts-title">
-      <div className="flex items-start justify-between gap-4">
-        <div className="min-w-0">
-          <h2
-            id="settings-shortcuts-title"
-            className="text-fg inline-flex items-center gap-2 text-sm font-semibold"
-          >
-            <Keyboard size={18} aria-hidden="true" />
-            {t.settings.keyboardShortcuts}
-          </h2>
-          <p className="text-fg-muted mt-1 text-xs leading-relaxed">
-            {t.settings.keyboardShortcutsDescription}
-          </p>
-        </div>
-        <button
-          type="button"
-          onClick={resetAll}
-          className="text-accent-fg hover:text-accent-hover focus-visible:ring-accent inline-flex shrink-0 items-center gap-1 rounded-md px-1.5 py-1 text-xs font-semibold transition-colors focus-visible:ring-2 focus-visible:outline-none"
-        >
-          <Restart size={14} aria-hidden="true" />
-          {t.settings.resetShortcuts}
-        </button>
-      </div>
+	return (
+		<section className="space-y-5" aria-labelledby="settings-shortcuts-title">
+			<div className="flex items-start justify-between gap-4">
+				<div className="min-w-0">
+					<h2
+						id="settings-shortcuts-title"
+						className="text-fg inline-flex items-center gap-2 text-sm font-semibold"
+					>
+						<Keyboard size={18} aria-hidden="true" />
+						{t.settings.keyboardShortcuts}
+					</h2>
+					<p className="text-fg-muted mt-1 text-xs leading-relaxed">
+						{t.settings.keyboardShortcutsDescription}
+					</p>
+				</div>
+				<button
+					type="button"
+					onClick={resetAll}
+					className="text-accent-fg hover:text-accent-hover focus-visible:ring-accent inline-flex shrink-0 items-center gap-1 rounded-md px-1.5 py-1 text-xs font-semibold transition-colors focus-visible:ring-2 focus-visible:outline-none"
+				>
+					<Restart size={14} aria-hidden="true" />
+					{t.settings.resetShortcuts}
+				</button>
+			</div>
 
-      <div className="space-y-5">
-        {groupedCommands.map(({ id, label, commands }) => (
-          <div key={id} className="space-y-2.5">
-            <h3 className="text-fg-muted text-[0.68rem] font-bold tracking-[0.12em] uppercase">
-              {label}
-            </h3>
-            <div className="space-y-2">
-              {commands.map((command) => {
-                const assignment = assignments[command.id];
-                const commandConflicts = conflicts.get(command.id);
-                const isRecording =
-                  editingCommandId === command.id &&
-                  recordingKind === command.kind;
-                const isDefault = isSameAssignment(
-                  assignment,
-                  DEFAULT_COMMAND_ASSIGNMENTS[command.id],
-                );
+			<div className="space-y-5">
+				{groupedCommands.map(({ id, label, commands }) => (
+					<div key={id} className="space-y-2.5">
+						<h3 className="text-fg-muted text-[0.68rem] font-bold tracking-[0.12em] uppercase">
+							{label}
+						</h3>
+						<div className="space-y-2">
+							{commands.map((command) => {
+								const assignment = assignments[command.id];
+								const commandConflicts = conflicts.get(command.id);
+								const isRecording =
+									editingCommandId === command.id &&
+									recordingKind === command.kind;
+								const isDefault = isSameAssignment(
+									assignment,
+									DEFAULT_COMMAND_ASSIGNMENTS[command.id],
+								);
 
-                return (
-                  <div
-                    key={command.id}
-                    className="flex min-w-0 items-start gap-2"
-                  >
-                    <div className="min-w-0 flex-1">
-                      <div className="group/shortcut-card flex min-w-0 items-stretch">
-                        <button
-                          type="button"
-                          onClick={() => startRecording(command.id)}
-                          className={`border-e-0 min-w-0 flex-1 cursor-pointer border p-3 text-left transition-[border-color,background-color,scale] hover:border-accent focus-visible:ring-accent focus-visible:z-10 focus-visible:ring-2 focus-visible:outline-none active:scale-[0.98] ${commandConflicts ? "rounded-ss-lg rounded-es-none border-danger-border bg-danger-bg/40" : "rounded-s-lg border-border bg-surface"}`}
-                        >
-                          <div className="min-w-0">
-                            <p className="text-fg text-sm font-medium">
-                              {t.settings.shortcutCommands[command.id]}
-                            </p>
-                            <p className="text-fg-muted mt-0.5 text-[0.68rem]">
-                              {command.kind === "sequence"
-                                ? t.settings.sequenceHint
-                                : t.settings.shortcutHint}
-                            </p>
-                          </div>
-                        </button>
-                        <ShortcutBinding
-                          assignment={assignment}
-                          hasConflict={Boolean(commandConflicts)}
-                          isRecording={isRecording}
-                          recordedSteps={
-                            command.kind === "sequence"
-                              ? sequenceRecorder.steps
-                              : []
-                          }
-                          onStart={() => startRecording(command.id)}
-                          onCommit={() => sequenceRecorder.commitRecording()}
-                          onCancel={cancelRecording}
-                        />
-                      </div>
-                      {commandConflicts && (
-                        <p className="text-danger-fg flex items-start gap-1.5 rounded-b-lg border border-t-0 border-danger-border bg-danger-bg/40 px-3 py-2 text-xs">
-                          <TriangleWarning
-                            size={14}
-                            aria-hidden="true"
-                            className="mt-0.5 shrink-0"
-                          />
-                          <span>
-                            {t.settings.shortcutConflict}
-                            {t.settings.shortcutConflictDescription}
-                          </span>
-                        </p>
-                      )}
-                    </div>
-                    {!isDefault && !isRecording && (
-                      <button
-                        type="button"
-                        onClick={() => resetOne(command.id)}
-                        className="text-fg-muted hover:text-accent-fg focus-visible:ring-accent mt-2 inline-flex size-9 shrink-0 items-center justify-center rounded-lg transition-colors focus-visible:ring-2 focus-visible:outline-none"
-                        aria-label={t.settings.resetShortcut}
-                        title={t.settings.resetShortcut}
-                      >
-                        <Restart size={15} aria-hidden="true" />
-                      </button>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-        ))}
-      </div>
+								return (
+									<div
+										key={command.id}
+										className="flex min-w-0 items-start gap-2"
+									>
+										<div className="min-w-0 flex-1">
+											<div className="group/shortcut-card flex min-w-0 items-stretch">
+												<button
+													type="button"
+													onClick={() => startRecording(command.id)}
+													className={`border-e-0 min-w-0 flex-1 cursor-pointer border p-3 text-left transition-[border-color,background-color,scale] hover:border-accent focus-visible:ring-accent focus-visible:z-10 focus-visible:ring-2 focus-visible:outline-none active:scale-[0.98] ${commandConflicts ? "rounded-ss-lg rounded-es-none border-danger-border bg-danger-bg/40" : "rounded-s-lg border-border bg-surface"}`}
+												>
+													<div className="min-w-0">
+														<p className="text-fg text-sm font-medium">
+															{t.settings.shortcutCommands[command.id]}
+														</p>
+														<p className="text-fg-muted mt-0.5 text-[0.68rem]">
+															{command.kind === "sequence"
+																? t.settings.sequenceHint
+																: t.settings.shortcutHint}
+														</p>
+													</div>
+												</button>
+												<ShortcutBinding
+													assignment={assignment}
+													hasConflict={Boolean(commandConflicts)}
+													isRecording={isRecording}
+													recordedSteps={
+														command.kind === "sequence"
+															? sequenceRecorder.steps
+															: []
+													}
+													onStart={() => startRecording(command.id)}
+													onCommit={() => sequenceRecorder.commitRecording()}
+													onCancel={cancelRecording}
+												/>
+											</div>
+											{commandConflicts && (
+												<p className="text-danger-fg flex items-start gap-1.5 rounded-b-lg border border-t-0 border-danger-border bg-danger-bg/40 px-3 py-2 text-xs">
+													<TriangleWarning
+														size={14}
+														aria-hidden="true"
+														className="mt-0.5 shrink-0"
+													/>
+													<span>
+														{t.settings.shortcutConflict}
+														{t.settings.shortcutConflictDescription}
+													</span>
+												</p>
+											)}
+										</div>
+										{!isDefault && !isRecording && (
+											<button
+												type="button"
+												onClick={() => resetOne(command.id)}
+												className="text-fg-muted hover:text-accent-fg focus-visible:ring-accent mt-2 inline-flex size-9 shrink-0 items-center justify-center rounded-lg transition-colors focus-visible:ring-2 focus-visible:outline-none"
+												aria-label={t.settings.resetShortcut}
+												title={t.settings.resetShortcut}
+											>
+												<Restart size={15} aria-hidden="true" />
+											</button>
+										)}
+									</div>
+								);
+							})}
+						</div>
+					</div>
+				))}
+			</div>
 
-      <HeldKeysIndicator />
-    </section>
-  );
+			<HeldKeysIndicator />
+		</section>
+	);
 }

--- a/src/components/KeyboardShortcutsSection.tsx
+++ b/src/components/KeyboardShortcutsSection.tsx
@@ -1,453 +1,453 @@
 import {
-	formatForDisplay,
-	useHeldKeys,
-	useHotkeyRecorder,
-	useHotkeySequenceRecorder,
+  formatForDisplay,
+  useHeldKeys,
+  useHotkeyRecorder,
+  useHotkeySequenceRecorder,
 } from "@tanstack/react-hotkeys";
 import { useRef, useState } from "react";
 import { Keyboard, Restart, TriangleWarning } from "reicon-react";
 import { useT } from "../i18n/hooks";
 import {
-	COMMAND_MODULES,
-	COMMANDS,
-	type CommandAssignment,
-	type CommandId,
-	DEFAULT_COMMAND_ASSIGNMENTS,
+  COMMAND_MODULES,
+  COMMANDS,
+  type CommandAssignment,
+  type CommandId,
+  DEFAULT_COMMAND_ASSIGNMENTS,
 } from "../lib/commands";
 import { useKeyboardCommands } from "../lib/keyboard-commands";
 import { track } from "../lib/umami";
 
 function getAssignmentKeys(assignment: CommandAssignment): readonly string[] {
-	return assignment.type === "hotkeys"
-		? assignment.hotkeys
-		: assignment.sequence;
+  return assignment.type === "hotkeys"
+    ? assignment.hotkeys
+    : assignment.sequence;
 }
 
 function getKeyedValues(values: readonly string[]) {
-	const occurrences = new Map<string, number>();
+  const occurrences = new Map<string, number>();
 
-	return values.map((value) => {
-		const occurrence = occurrences.get(value) ?? 0;
-		occurrences.set(value, occurrence + 1);
-		return { id: `${value}-${occurrence}`, value };
-	});
+  return values.map((value) => {
+    const occurrence = occurrences.get(value) ?? 0;
+    occurrences.set(value, occurrence + 1);
+    return { id: `${value}-${occurrence}`, value };
+  });
 }
 
 function HotkeyKeycaps({ hotkey }: { hotkey: string }) {
-	const displayKeys = getKeyedValues(
-		formatForDisplay(hotkey).split(/\s+/).filter(Boolean),
-	);
+  const displayKeys = getKeyedValues(
+    formatForDisplay(hotkey).split(/\s+/).filter(Boolean),
+  );
 
-	return (
-		<span className="inline-flex items-center gap-1">
-			{displayKeys.map(({ id, value: key }, displayKeyIndex) => (
-				<span key={id} className="inline-flex items-center gap-1">
-					<kbd className="border-border bg-code text-fg-secondary inline-flex min-h-8 items-center rounded-md border px-2 font-mono text-xs leading-none font-medium shadow-[0_1px_0_var(--color-border)]">
-						{key}
-					</kbd>
-					{displayKeyIndex < displayKeys.length - 1 && (
-						<span className="text-fg-muted text-[0.65rem]" aria-hidden="true">
-							+
-						</span>
-					)}
-				</span>
-			))}
-		</span>
-	);
+  return (
+    <span className="inline-flex items-center gap-1">
+      {displayKeys.map(({ id, value: key }, displayKeyIndex) => (
+        <span key={id} className="inline-flex items-center gap-1">
+          <kbd className="border-border bg-code text-fg-secondary inline-flex min-h-8 items-center rounded-md border px-2 font-mono text-s leading-none font-medium shadow-[0_1px_0_var(--color-border)]">
+            {key}
+          </kbd>
+          {displayKeyIndex < displayKeys.length - 1 && (
+            <span className="text-fg-muted text-[0.65rem]" aria-hidden="true">
+              +
+            </span>
+          )}
+        </span>
+      ))}
+    </span>
+  );
 }
 
 function AssignmentKeycaps({ assignment }: { assignment: CommandAssignment }) {
-	const keys = getAssignmentKeys(assignment);
-	const separator = assignment.type === "hotkeys" ? "/" : "·";
+  const keys = getAssignmentKeys(assignment);
+  const separator = assignment.type === "hotkeys" ? "/" : "·";
 
-	return (
-		<span className="flex min-w-0 flex-wrap items-center justify-end gap-1.5">
-			{getKeyedValues(keys).map(({ id, value: hotkey }, index) => (
-				<span key={id} className="inline-flex items-center gap-1.5">
-					{index > 0 && (
-						<span className="text-fg-muted text-[0.65rem]" aria-hidden="true">
-							{separator}
-						</span>
-					)}
-					<HotkeyKeycaps hotkey={hotkey} />
-				</span>
-			))}
-		</span>
-	);
+  return (
+    <span className="flex min-w-0 flex-wrap items-center justify-end gap-1.5">
+      {getKeyedValues(keys).map(({ id, value: hotkey }, index) => (
+        <span key={id} className="inline-flex items-center gap-1.5">
+          {index > 0 && (
+            <span className="text-fg-muted text-[0.65rem]" aria-hidden="true">
+              {separator}
+            </span>
+          )}
+          <HotkeyKeycaps hotkey={hotkey} />
+        </span>
+      ))}
+    </span>
+  );
 }
 
 function isSameAssignment(
-	left: CommandAssignment,
-	right: CommandAssignment,
+  left: CommandAssignment,
+  right: CommandAssignment,
 ): boolean {
-	if (left.type !== right.type) return false;
-	const leftKeys = left.type === "hotkeys" ? left.hotkeys : left.sequence;
-	const rightKeys = right.type === "hotkeys" ? right.hotkeys : right.sequence;
-	return (
-		leftKeys.length === rightKeys.length &&
-		leftKeys.every((key, index) => key === rightKeys[index])
-	);
+  if (left.type !== right.type) return false;
+  const leftKeys = left.type === "hotkeys" ? left.hotkeys : left.sequence;
+  const rightKeys = right.type === "hotkeys" ? right.hotkeys : right.sequence;
+  return (
+    leftKeys.length === rightKeys.length &&
+    leftKeys.every((key, index) => key === rightKeys[index])
+  );
 }
 
 function HeldKeysIndicator() {
-	const t = useT();
-	const heldKeys = useHeldKeys();
+  const t = useT();
+  const heldKeys = useHeldKeys();
 
-	if (heldKeys.length === 0) return null;
+  if (heldKeys.length === 0) return null;
 
-	return (
-		<div
-			className="border-border bg-code/50 text-fg-secondary flex items-center gap-2 rounded-lg border px-3 py-2 text-xs"
-			aria-live="polite"
-		>
-			<span className="font-semibold">{t.settings.heldKeys}</span>
-			<span className="flex min-w-0 flex-wrap gap-1">
-				{heldKeys.map((key) => (
-					<kbd
-						key={key}
-						className="bg-surface text-fg rounded border border-current/15 px-1.5 py-0.5 font-mono text-[0.7rem]"
-					>
-						{formatForDisplay(key)}
-					</kbd>
-				))}
-			</span>
-		</div>
-	);
+  return (
+    <div
+      className="border-border bg-code/50 text-fg-secondary flex items-center gap-2 rounded-lg border px-3 py-2 text-xs"
+      aria-live="polite"
+    >
+      <span className="font-semibold">{t.settings.heldKeys}</span>
+      <span className="flex min-w-0 flex-wrap gap-1">
+        {heldKeys.map((key) => (
+          <kbd
+            key={key}
+            className="bg-surface text-fg rounded border border-current/15 px-1.5 py-0.5 font-mono text-[0.7rem]"
+          >
+            {formatForDisplay(key)}
+          </kbd>
+        ))}
+      </span>
+    </div>
+  );
 }
 
 function ShortcutBinding({
-	assignment,
-	hasConflict,
-	isRecording,
-	recordedSteps,
-	onStart,
-	onCommit,
-	onCancel,
+  assignment,
+  hasConflict,
+  isRecording,
+  recordedSteps,
+  onStart,
+  onCommit,
+  onCancel,
 }: {
-	assignment: CommandAssignment;
-	hasConflict: boolean;
-	isRecording: boolean;
-	recordedSteps: readonly string[];
-	onStart: () => void;
-	onCommit: () => void;
-	onCancel: () => void;
+  assignment: CommandAssignment;
+  hasConflict: boolean;
+  isRecording: boolean;
+  recordedSteps: readonly string[];
+  onStart: () => void;
+  onCommit: () => void;
+  onCancel: () => void;
 }) {
-	const t = useT();
-	const assignmentKeys = getAssignmentKeys(assignment);
-	const isSequence = assignment.type === "sequence";
-	const isUnassigned = !isRecording && assignmentKeys.length === 0;
+  const t = useT();
+  const assignmentKeys = getAssignmentKeys(assignment);
+  const isSequence = assignment.type === "sequence";
+  const isUnassigned = !isRecording && assignmentKeys.length === 0;
 
-	return (
-		<div className="flex shrink-0 items-stretch gap-2">
-			<button
-				type="button"
-				onClick={onStart}
-				className={`border-border bg-surface text-fg hover:border-accent hover:text-accent-fg focus-visible:ring-accent group-hover/shortcut-card:border-accent flex min-h-10 min-w-0 items-center justify-end gap-3 border border-dashed px-2 py-1.5 text-left transition-[background-color,border-color,color,scale] duration-150 focus-visible:ring-2 focus-visible:outline-none active:scale-[0.98] ${hasConflict ? "rounded-se-lg rounded-ee-none" : "rounded-e-lg"} ${isRecording ? "border-accent bg-accent-light text-accent-fg" : ""}`}
-				aria-label={
-					isRecording ? t.settings.recording : t.settings.editShortcut
-				}
-			>
-				{isRecording ? (
-					recordedSteps.length > 0 ? (
-						<span className="flex min-w-0 flex-wrap items-center justify-end gap-1.5">
-							{getKeyedValues(recordedSteps).map(
-								({ id, value: hotkey }, index) => (
-									<span key={id} className="inline-flex items-center gap-1.5">
-										{index > 0 && (
-											<span
-												className="text-fg-muted text-[0.65rem]"
-												aria-hidden="true"
-											>
-												·
-											</span>
-										)}
-										<HotkeyKeycaps hotkey={hotkey} />
-									</span>
-								),
-							)}
-						</span>
-					) : (
-						<span className="text-fg-muted text-xs font-medium">
-							{t.settings.pressKeys}
-						</span>
-					)
-				) : isUnassigned ? (
-					<span className="text-fg-muted text-xs font-medium">
-						{t.settings.shortcutUnassigned}
-					</span>
-				) : (
-					<AssignmentKeycaps assignment={assignment} />
-				)}
-			</button>
-			{isRecording && isSequence && (
-				<div className="flex items-center gap-1.5">
-					<button
-						type="button"
-						onClick={onCommit}
-						disabled={recordedSteps.length === 0}
-						className="bg-accent text-on-accent hover:bg-accent-hover focus-visible:ring-accent min-h-10 rounded-lg px-3 text-xs font-semibold transition-[background-color,scale] duration-150 focus-visible:ring-2 focus-visible:outline-none active:scale-[0.96] disabled:cursor-not-allowed disabled:opacity-40"
-					>
-						{t.settings.saveShortcut}
-					</button>
-					<button
-						type="button"
-						onClick={onCancel}
-						className="border-border text-fg-secondary hover:bg-surface focus-visible:ring-accent min-h-10 rounded-lg border px-3 text-xs transition-colors focus-visible:ring-2 focus-visible:outline-none"
-					>
-						{t.settings.cancelShortcut}
-					</button>
-				</div>
-			)}
-		</div>
-	);
+  return (
+    <div className="flex shrink-0 items-stretch gap-2">
+      <button
+        type="button"
+        onClick={onStart}
+        className={`border-border bg-surface text-fg hover:border-accent hover:text-accent-fg focus-visible:ring-accent group-hover/shortcut-card:border-accent flex min-h-10 min-w-0 items-center justify-end gap-3 border border-dashed px-2 py-1.5 text-left transition-[background-color,border-color,color,scale] duration-150 focus-visible:ring-2 focus-visible:outline-none active:scale-[0.98] ${hasConflict ? "rounded-se-lg rounded-ee-none" : "rounded-e-lg"} ${isRecording ? "border-accent bg-accent-light text-accent-fg" : ""}`}
+        aria-label={
+          isRecording ? t.settings.recording : t.settings.editShortcut
+        }
+      >
+        {isRecording ? (
+          recordedSteps.length > 0 ? (
+            <span className="flex min-w-0 flex-wrap items-center justify-end gap-1.5">
+              {getKeyedValues(recordedSteps).map(
+                ({ id, value: hotkey }, index) => (
+                  <span key={id} className="inline-flex items-center gap-1.5">
+                    {index > 0 && (
+                      <span
+                        className="text-fg-muted text-[0.65rem]"
+                        aria-hidden="true"
+                      >
+                        ·
+                      </span>
+                    )}
+                    <HotkeyKeycaps hotkey={hotkey} />
+                  </span>
+                ),
+              )}
+            </span>
+          ) : (
+            <span className="text-fg-muted text-xs font-medium">
+              {t.settings.pressKeys}
+            </span>
+          )
+        ) : isUnassigned ? (
+          <span className="text-fg-muted text-xs font-medium">
+            {t.settings.shortcutUnassigned}
+          </span>
+        ) : (
+          <AssignmentKeycaps assignment={assignment} />
+        )}
+      </button>
+      {isRecording && isSequence && (
+        <div className="flex items-center gap-1.5">
+          <button
+            type="button"
+            onClick={onCommit}
+            disabled={recordedSteps.length === 0}
+            className="bg-accent text-on-accent hover:bg-accent-hover focus-visible:ring-accent min-h-10 rounded-lg px-3 text-xs font-semibold transition-[background-color,scale] duration-150 focus-visible:ring-2 focus-visible:outline-none active:scale-[0.96] disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            {t.settings.saveShortcut}
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="border-border text-fg-secondary hover:bg-surface focus-visible:ring-accent min-h-10 rounded-lg border px-3 text-xs transition-colors focus-visible:ring-2 focus-visible:outline-none"
+          >
+            {t.settings.cancelShortcut}
+          </button>
+        </div>
+      )}
+    </div>
+  );
 }
 
 export default function KeyboardShortcutsSection() {
-	const t = useT();
-	const {
-		assignments,
-		conflicts,
-		resetAllAssignments,
-		resetAssignment,
-		setAssignment,
-	} = useKeyboardCommands();
-	const [editingCommandId, setEditingCommandId] = useState<CommandId | null>(
-		null,
-	);
-	const [recordingKind, setRecordingKind] = useState<
-		"hotkeys" | "sequence" | null
-	>(null);
-	const editingCommandRef = useRef<CommandId | null>(null);
+  const t = useT();
+  const {
+    assignments,
+    conflicts,
+    resetAllAssignments,
+    resetAssignment,
+    setAssignment,
+  } = useKeyboardCommands();
+  const [editingCommandId, setEditingCommandId] = useState<CommandId | null>(
+    null,
+  );
+  const [recordingKind, setRecordingKind] = useState<
+    "hotkeys" | "sequence" | null
+  >(null);
+  const editingCommandRef = useRef<CommandId | null>(null);
 
-	function finishRecording() {
-		editingCommandRef.current = null;
-		setEditingCommandId(null);
-		setRecordingKind(null);
-	}
+  function finishRecording() {
+    editingCommandRef.current = null;
+    setEditingCommandId(null);
+    setRecordingKind(null);
+  }
 
-	const hotkeyRecorder = useHotkeyRecorder({
-		onRecord: (hotkey) => {
-			const commandId = editingCommandRef.current;
-			if (!commandId) return;
-			setAssignment(commandId, {
-				type: "hotkeys",
-				hotkeys: hotkey ? [hotkey] : [],
-			});
-			track("keyboard_shortcut_change", {
-				commandId,
-				bindingType: "hotkey",
-			});
-			finishRecording();
-		},
-		onClear: () => {
-			const commandId = editingCommandRef.current;
-			if (!commandId) return;
-			setAssignment(commandId, { type: "hotkeys", hotkeys: [] });
-			track("keyboard_shortcut_change", {
-				commandId,
-				bindingType: "hotkey-cleared",
-			});
-			finishRecording();
-		},
-		onCancel: finishRecording,
-	});
+  const hotkeyRecorder = useHotkeyRecorder({
+    onRecord: (hotkey) => {
+      const commandId = editingCommandRef.current;
+      if (!commandId) return;
+      setAssignment(commandId, {
+        type: "hotkeys",
+        hotkeys: hotkey ? [hotkey] : [],
+      });
+      track("keyboard_shortcut_change", {
+        commandId,
+        bindingType: "hotkey",
+      });
+      finishRecording();
+    },
+    onClear: () => {
+      const commandId = editingCommandRef.current;
+      if (!commandId) return;
+      setAssignment(commandId, { type: "hotkeys", hotkeys: [] });
+      track("keyboard_shortcut_change", {
+        commandId,
+        bindingType: "hotkey-cleared",
+      });
+      finishRecording();
+    },
+    onCancel: finishRecording,
+  });
 
-	const sequenceRecorder = useHotkeySequenceRecorder({
-		onRecord: (sequence) => {
-			const commandId = editingCommandRef.current;
-			if (!commandId) return;
-			setAssignment(commandId, { type: "sequence", sequence });
-			track("keyboard_shortcut_change", {
-				commandId,
-				bindingType: "sequence",
-			});
-			finishRecording();
-		},
-		onClear: () => {
-			const commandId = editingCommandRef.current;
-			if (!commandId) return;
-			setAssignment(commandId, { type: "sequence", sequence: [] });
-			track("keyboard_shortcut_change", {
-				commandId,
-				bindingType: "sequence-cleared",
-			});
-			finishRecording();
-		},
-		onCancel: finishRecording,
-	});
+  const sequenceRecorder = useHotkeySequenceRecorder({
+    onRecord: (sequence) => {
+      const commandId = editingCommandRef.current;
+      if (!commandId) return;
+      setAssignment(commandId, { type: "sequence", sequence });
+      track("keyboard_shortcut_change", {
+        commandId,
+        bindingType: "sequence",
+      });
+      finishRecording();
+    },
+    onClear: () => {
+      const commandId = editingCommandRef.current;
+      if (!commandId) return;
+      setAssignment(commandId, { type: "sequence", sequence: [] });
+      track("keyboard_shortcut_change", {
+        commandId,
+        bindingType: "sequence-cleared",
+      });
+      finishRecording();
+    },
+    onCancel: finishRecording,
+  });
 
-	function startRecording(commandId: CommandId) {
-		const command = COMMANDS.find((item) => item.id === commandId);
-		if (!command) return;
+  function startRecording(commandId: CommandId) {
+    const command = COMMANDS.find((item) => item.id === commandId);
+    if (!command) return;
 
-		hotkeyRecorder.stopRecording();
-		sequenceRecorder.stopRecording();
-		editingCommandRef.current = commandId;
-		setEditingCommandId(commandId);
-		setRecordingKind(command.kind);
-		if (command.kind === "sequence") sequenceRecorder.startRecording();
-		else hotkeyRecorder.startRecording();
-	}
+    hotkeyRecorder.stopRecording();
+    sequenceRecorder.stopRecording();
+    editingCommandRef.current = commandId;
+    setEditingCommandId(commandId);
+    setRecordingKind(command.kind);
+    if (command.kind === "sequence") sequenceRecorder.startRecording();
+    else hotkeyRecorder.startRecording();
+  }
 
-	function cancelRecording() {
-		hotkeyRecorder.stopRecording();
-		sequenceRecorder.stopRecording();
-		finishRecording();
-	}
+  function cancelRecording() {
+    hotkeyRecorder.stopRecording();
+    sequenceRecorder.stopRecording();
+    finishRecording();
+  }
 
-	function resetOne(commandId: CommandId) {
-		if (editingCommandRef.current === commandId) cancelRecording();
-		resetAssignment(commandId);
-	}
+  function resetOne(commandId: CommandId) {
+    if (editingCommandRef.current === commandId) cancelRecording();
+    resetAssignment(commandId);
+  }
 
-	function resetAll() {
-		cancelRecording();
-		resetAllAssignments();
-	}
+  function resetAll() {
+    cancelRecording();
+    resetAllAssignments();
+  }
 
-	const commandsById = new Map(
-		COMMANDS.map((command) => [command.id, command]),
-	);
-	const commandsForModules = (
-		modules: ReadonlyArray<(typeof COMMAND_MODULES)[number]>,
-	) =>
-		modules.flatMap((module) =>
-			module.commands.flatMap((commandId) => {
-				const command = commandsById.get(commandId);
-				return command ? [command] : [];
-			}),
-		);
-	const groupedCommands = [
-		{
-			id: "global",
-			label: t.settings.shortcutScopes.global,
-			commands: commandsForModules(
-				COMMAND_MODULES.filter((module) => module.scope === "global"),
-			),
-		},
-		{
-			id: "practice-exam",
-			label: t.settings.shortcutScopes.practiceExam,
-			commands: commandsForModules(
-				COMMAND_MODULES.filter((module) => module.scope !== "global"),
-			),
-		},
-	];
+  const commandsById = new Map(
+    COMMANDS.map((command) => [command.id, command]),
+  );
+  const commandsForModules = (
+    modules: ReadonlyArray<(typeof COMMAND_MODULES)[number]>,
+  ) =>
+    modules.flatMap((module) =>
+      module.commands.flatMap((commandId) => {
+        const command = commandsById.get(commandId);
+        return command ? [command] : [];
+      }),
+    );
+  const groupedCommands = [
+    {
+      id: "global",
+      label: t.settings.shortcutScopes.global,
+      commands: commandsForModules(
+        COMMAND_MODULES.filter((module) => module.scope === "global"),
+      ),
+    },
+    {
+      id: "practice-exam",
+      label: t.settings.shortcutScopes.practiceExam,
+      commands: commandsForModules(
+        COMMAND_MODULES.filter((module) => module.scope !== "global"),
+      ),
+    },
+  ];
 
-	return (
-		<section className="space-y-5" aria-labelledby="settings-shortcuts-title">
-			<div className="flex items-start justify-between gap-4">
-				<div className="min-w-0">
-					<h2
-						id="settings-shortcuts-title"
-						className="text-fg inline-flex items-center gap-2 text-sm font-semibold"
-					>
-						<Keyboard size={18} aria-hidden="true" />
-						{t.settings.keyboardShortcuts}
-					</h2>
-					<p className="text-fg-muted mt-1 text-xs leading-relaxed">
-						{t.settings.keyboardShortcutsDescription}
-					</p>
-				</div>
-				<button
-					type="button"
-					onClick={resetAll}
-					className="text-accent-fg hover:text-accent-hover focus-visible:ring-accent inline-flex shrink-0 items-center gap-1 rounded-md px-1.5 py-1 text-xs font-semibold transition-colors focus-visible:ring-2 focus-visible:outline-none"
-				>
-					<Restart size={14} aria-hidden="true" />
-					{t.settings.resetShortcuts}
-				</button>
-			</div>
+  return (
+    <section className="space-y-5" aria-labelledby="settings-shortcuts-title">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <h2
+            id="settings-shortcuts-title"
+            className="text-fg inline-flex items-center gap-2 text-sm font-semibold"
+          >
+            <Keyboard size={18} aria-hidden="true" />
+            {t.settings.keyboardShortcuts}
+          </h2>
+          <p className="text-fg-muted mt-1 text-xs leading-relaxed">
+            {t.settings.keyboardShortcutsDescription}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={resetAll}
+          className="text-accent-fg hover:text-accent-hover focus-visible:ring-accent inline-flex shrink-0 items-center gap-1 rounded-md px-1.5 py-1 text-xs font-semibold transition-colors focus-visible:ring-2 focus-visible:outline-none"
+        >
+          <Restart size={14} aria-hidden="true" />
+          {t.settings.resetShortcuts}
+        </button>
+      </div>
 
-			<div className="space-y-5">
-				{groupedCommands.map(({ id, label, commands }) => (
-					<div key={id} className="space-y-2.5">
-						<h3 className="text-fg-muted text-[0.68rem] font-bold tracking-[0.12em] uppercase">
-							{label}
-						</h3>
-						<div className="space-y-2">
-							{commands.map((command) => {
-								const assignment = assignments[command.id];
-								const commandConflicts = conflicts.get(command.id);
-								const isRecording =
-									editingCommandId === command.id &&
-									recordingKind === command.kind;
-								const isDefault = isSameAssignment(
-									assignment,
-									DEFAULT_COMMAND_ASSIGNMENTS[command.id],
-								);
+      <div className="space-y-5">
+        {groupedCommands.map(({ id, label, commands }) => (
+          <div key={id} className="space-y-2.5">
+            <h3 className="text-fg-muted text-[0.68rem] font-bold tracking-[0.12em] uppercase">
+              {label}
+            </h3>
+            <div className="space-y-2">
+              {commands.map((command) => {
+                const assignment = assignments[command.id];
+                const commandConflicts = conflicts.get(command.id);
+                const isRecording =
+                  editingCommandId === command.id &&
+                  recordingKind === command.kind;
+                const isDefault = isSameAssignment(
+                  assignment,
+                  DEFAULT_COMMAND_ASSIGNMENTS[command.id],
+                );
 
-								return (
-									<div
-										key={command.id}
-										className="flex min-w-0 items-start gap-2"
-									>
-										<div className="min-w-0 flex-1">
-											<div className="group/shortcut-card flex min-w-0 items-stretch">
-												<button
-													type="button"
-													onClick={() => startRecording(command.id)}
-													className={`border-e-0 min-w-0 flex-1 cursor-pointer border p-3 text-left transition-[border-color,background-color,scale] hover:border-accent focus-visible:ring-accent focus-visible:z-10 focus-visible:ring-2 focus-visible:outline-none active:scale-[0.98] ${commandConflicts ? "rounded-ss-lg rounded-es-none border-danger-border bg-danger-bg/40" : "rounded-s-lg border-border bg-surface"}`}
-												>
-													<div className="min-w-0">
-														<p className="text-fg text-sm font-medium">
-															{t.settings.shortcutCommands[command.id]}
-														</p>
-														<p className="text-fg-muted mt-0.5 text-[0.68rem]">
-															{command.kind === "sequence"
-																? t.settings.sequenceHint
-																: t.settings.shortcutHint}
-														</p>
-													</div>
-												</button>
-												<ShortcutBinding
-													assignment={assignment}
-													hasConflict={Boolean(commandConflicts)}
-													isRecording={isRecording}
-													recordedSteps={
-														command.kind === "sequence"
-															? sequenceRecorder.steps
-															: []
-													}
-													onStart={() => startRecording(command.id)}
-													onCommit={() => sequenceRecorder.commitRecording()}
-													onCancel={cancelRecording}
-												/>
-											</div>
-											{commandConflicts && (
-												<p className="text-danger-fg flex items-start gap-1.5 rounded-b-lg border border-t-0 border-danger-border bg-danger-bg/40 px-3 py-2 text-xs">
-													<TriangleWarning
-														size={14}
-														aria-hidden="true"
-														className="mt-0.5 shrink-0"
-													/>
-													<span>
-														{t.settings.shortcutConflict}
-														{t.settings.shortcutConflictDescription}
-													</span>
-												</p>
-											)}
-										</div>
-										{!isDefault && !isRecording && (
-											<button
-												type="button"
-												onClick={() => resetOne(command.id)}
-												className="text-fg-muted hover:text-accent-fg focus-visible:ring-accent mt-2 inline-flex size-9 shrink-0 items-center justify-center rounded-lg transition-colors focus-visible:ring-2 focus-visible:outline-none"
-												aria-label={t.settings.resetShortcut}
-												title={t.settings.resetShortcut}
-											>
-												<Restart size={15} aria-hidden="true" />
-											</button>
-										)}
-									</div>
-								);
-							})}
-						</div>
-					</div>
-				))}
-			</div>
+                return (
+                  <div
+                    key={command.id}
+                    className="flex min-w-0 items-start gap-2"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <div className="group/shortcut-card flex min-w-0 items-stretch">
+                        <button
+                          type="button"
+                          onClick={() => startRecording(command.id)}
+                          className={`border-e-0 min-w-0 flex-1 cursor-pointer border p-3 text-left transition-[border-color,background-color,scale] hover:border-accent focus-visible:ring-accent focus-visible:z-10 focus-visible:ring-2 focus-visible:outline-none active:scale-[0.98] ${commandConflicts ? "rounded-ss-lg rounded-es-none border-danger-border bg-danger-bg/40" : "rounded-s-lg border-border bg-surface"}`}
+                        >
+                          <div className="min-w-0">
+                            <p className="text-fg text-sm font-medium">
+                              {t.settings.shortcutCommands[command.id]}
+                            </p>
+                            <p className="text-fg-muted mt-0.5 text-[0.68rem]">
+                              {command.kind === "sequence"
+                                ? t.settings.sequenceHint
+                                : t.settings.shortcutHint}
+                            </p>
+                          </div>
+                        </button>
+                        <ShortcutBinding
+                          assignment={assignment}
+                          hasConflict={Boolean(commandConflicts)}
+                          isRecording={isRecording}
+                          recordedSteps={
+                            command.kind === "sequence"
+                              ? sequenceRecorder.steps
+                              : []
+                          }
+                          onStart={() => startRecording(command.id)}
+                          onCommit={() => sequenceRecorder.commitRecording()}
+                          onCancel={cancelRecording}
+                        />
+                      </div>
+                      {commandConflicts && (
+                        <p className="text-danger-fg flex items-start gap-1.5 rounded-b-lg border border-t-0 border-danger-border bg-danger-bg/40 px-3 py-2 text-xs">
+                          <TriangleWarning
+                            size={14}
+                            aria-hidden="true"
+                            className="mt-0.5 shrink-0"
+                          />
+                          <span>
+                            {t.settings.shortcutConflict}
+                            {t.settings.shortcutConflictDescription}
+                          </span>
+                        </p>
+                      )}
+                    </div>
+                    {!isDefault && !isRecording && (
+                      <button
+                        type="button"
+                        onClick={() => resetOne(command.id)}
+                        className="text-fg-muted hover:text-accent-fg focus-visible:ring-accent mt-2 inline-flex size-9 shrink-0 items-center justify-center rounded-lg transition-colors focus-visible:ring-2 focus-visible:outline-none"
+                        aria-label={t.settings.resetShortcut}
+                        title={t.settings.resetShortcut}
+                      >
+                        <Restart size={15} aria-hidden="true" />
+                      </button>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
 
-			<HeldKeysIndicator />
-		</section>
-	);
+      <HeldKeysIndicator />
+    </section>
+  );
 }

--- a/src/components/LangNotFound.tsx
+++ b/src/components/LangNotFound.tsx
@@ -1,5 +1,5 @@
 import { getRouteApi } from "@tanstack/react-router";
-import { useEffect } from "react";
+import { Suspense, useEffect } from "react";
 import { I18nProvider } from "../i18n/context";
 import { isLang } from "../i18n/context-value";
 import { ThemeProvider } from "../theme/context";
@@ -18,11 +18,13 @@ export default function LangNotFound() {
 
 	return (
 		<ThemeProvider>
-			<I18nProvider initialLang={lang}>
-				<AppChrome>
-					<NotFoundPage />
-				</AppChrome>
-			</I18nProvider>
+			<Suspense fallback={<div aria-busy="true" />}>
+				<I18nProvider initialLang={lang}>
+					<AppChrome>
+						<NotFoundPage />
+					</AppChrome>
+				</I18nProvider>
+			</Suspense>
 		</ThemeProvider>
 	);
 }

--- a/src/components/SessionTracker.tsx
+++ b/src/components/SessionTracker.tsx
@@ -3,6 +3,38 @@ import { useLang } from "../i18n/hooks";
 import { getDistinctId, identify, setSessionData } from "../lib/umami";
 import { useTheme } from "../theme/hooks";
 
+const RECORDER_SCRIPT_ID = "umami-recorder";
+const RECORDER_SRC = "https://analytics.pablopl.dev/recorder.js";
+const UMAMI_WEBSITE_ID = "63168f0e-a1cf-4ec6-a0c4-58fc7d57a0f4";
+const RECORDER_DELAY_MS = 5000;
+
+function scheduleAfterIdle(callback: () => void): () => void {
+	const browserWindow = window as Window & {
+		requestIdleCallback?: (
+			callback: () => void,
+			options?: { timeout: number },
+		) => number;
+		cancelIdleCallback?: (id: number) => void;
+	};
+	let cancelIdle = () => {};
+	const delayId = setTimeout(() => {
+		const idleCallback = browserWindow.requestIdleCallback;
+		if (idleCallback) {
+			const idleId = idleCallback(callback, { timeout: 3000 });
+			cancelIdle = () => browserWindow.cancelIdleCallback?.(idleId);
+			return;
+		}
+
+		const idleTimeoutId = setTimeout(callback, 1500);
+		cancelIdle = () => clearTimeout(idleTimeoutId);
+	}, RECORDER_DELAY_MS);
+
+	return () => {
+		clearTimeout(delayId);
+		cancelIdle();
+	};
+}
+
 export default function SessionTracker() {
 	const { lang } = useLang();
 	const { theme } = useTheme();
@@ -15,6 +47,19 @@ export default function SessionTracker() {
 	useEffect(() => {
 		setSessionData({ lang, theme });
 	}, [lang, theme]);
+
+	useEffect(() => {
+		return scheduleAfterIdle(() => {
+			if (document.getElementById(RECORDER_SCRIPT_ID)) return;
+
+			const script = document.createElement("script");
+			script.id = RECORDER_SCRIPT_ID;
+			script.src = RECORDER_SRC;
+			script.async = true;
+			script.dataset.websiteId = UMAMI_WEBSITE_ID;
+			document.head.appendChild(script);
+		});
+	}, []);
 
 	return null;
 }

--- a/src/components/SettingsGeneralPanel.tsx
+++ b/src/components/SettingsGeneralPanel.tsx
@@ -64,11 +64,11 @@ export default function SettingsGeneralPanel() {
 	const navigate = useNavigate();
 	const [volume, setVolumeState] = useState(getStoredSoundVolume);
 
-	function handleLanguageChange(event: ChangeEvent<HTMLSelectElement>) {
+	async function handleLanguageChange(event: ChangeEvent<HTMLSelectElement>) {
 		const nextLang = event.target.value as Lang;
 		if (nextLang === lang) return;
 		playSound("toggle");
-		setLang(nextLang);
+		await setLang(nextLang);
 		trackEvent("lang_toggle", { lang: nextLang, source: "settings" });
 		const nextPath = replaceLangInPath(location.pathname, nextLang);
 		navigate({

--- a/src/components/SettingsGeneralPanel.tsx
+++ b/src/components/SettingsGeneralPanel.tsx
@@ -9,6 +9,7 @@ import {
 } from "reicon-react";
 import type { Lang } from "../i18n/context";
 import { useLang, useT } from "../i18n/hooks";
+import { getLanguageDownloadMessage } from "../i18n/language-download";
 import { replaceLangInPath } from "../lib/lang-link-utils";
 import {
 	DEFAULT_SOUND_VOLUME,
@@ -27,6 +28,56 @@ const languageOptions: ReadonlyArray<{ value: Lang; label: string }> = [
 	{ value: "en", label: "🇬🇧 Inglés" },
 	{ value: "gl", label: "🧜🏻‍♀️ Galego" },
 ];
+
+const LANGUAGE_PROGRESS_MAX = 69;
+const LANGUAGE_PROGRESS_DURATION_MS = 320;
+const LANGUAGE_PROGRESS_HOLD_MS = 80;
+const LANGUAGE_COMPLETION_DISPLAY_MS = 120;
+
+function animateLanguageDownload(setProgress: (progress: number) => void) {
+	let intervalId: number | undefined;
+	let resolveProgressMax: (() => void) | undefined;
+	let progressMaxReached = false;
+	const progressMax = new Promise<void>((resolve) => {
+		resolveProgressMax = resolve;
+	});
+	const startedAt = performance.now();
+
+	function finishProgressAnimation() {
+		if (progressMaxReached) return;
+		progressMaxReached = true;
+		resolveProgressMax?.();
+	}
+
+	function tick() {
+		const elapsed = performance.now() - startedAt;
+		const progress = Math.min(
+			LANGUAGE_PROGRESS_MAX,
+			Math.round(
+				(elapsed / LANGUAGE_PROGRESS_DURATION_MS) * LANGUAGE_PROGRESS_MAX,
+			),
+		);
+		setProgress(progress);
+
+		if (progress >= LANGUAGE_PROGRESS_MAX) {
+			if (intervalId !== undefined) window.clearInterval(intervalId);
+			intervalId = undefined;
+			finishProgressAnimation();
+		}
+	}
+
+	tick();
+	intervalId = window.setInterval(tick, 16);
+
+	return {
+		progressMax,
+		stop() {
+			if (intervalId !== undefined) window.clearInterval(intervalId);
+			intervalId = undefined;
+			finishProgressAnimation();
+		},
+	};
+}
 
 function isTheme(value: string): value is Theme {
 	return themeOrder.some((theme) => theme === value);
@@ -63,15 +114,46 @@ export default function SettingsGeneralPanel() {
 	const location = useLocation();
 	const navigate = useNavigate();
 	const [volume, setVolumeState] = useState(getStoredSoundVolume);
+	const [isChangingLanguage, setIsChangingLanguage] = useState(false);
+	const [languageDownload, setLanguageDownload] = useState<{
+		lang: Lang;
+		progress: number;
+	} | null>(null);
 
 	async function handleLanguageChange(event: ChangeEvent<HTMLSelectElement>) {
 		const nextLang = event.target.value as Lang;
-		if (nextLang === lang) return;
+		if (nextLang === lang || isChangingLanguage) return;
 		playSound("toggle");
-		await setLang(nextLang);
+		setIsChangingLanguage(true);
+		setLanguageDownload({ lang: nextLang, progress: 0 });
+		const progressAnimation = animateLanguageDownload((progress) =>
+			setLanguageDownload((current) =>
+				current ? { ...current, progress } : current,
+			),
+		);
+
+		try {
+			await Promise.all([setLang(nextLang), progressAnimation.progressMax]);
+		} catch {
+			progressAnimation.stop();
+			setLanguageDownload(null);
+			setIsChangingLanguage(false);
+			return;
+		}
+
+		progressAnimation.stop();
+		await new Promise<void>((resolve) =>
+			window.setTimeout(resolve, LANGUAGE_PROGRESS_HOLD_MS),
+		);
+		setLanguageDownload({ lang: nextLang, progress: 100 });
+		await new Promise<void>((resolve) =>
+			window.setTimeout(resolve, LANGUAGE_COMPLETION_DISPLAY_MS),
+		);
+		setLanguageDownload(null);
+		setIsChangingLanguage(false);
 		trackEvent("lang_toggle", { lang: nextLang, source: "settings" });
 		const nextPath = replaceLangInPath(location.pathname, nextLang);
-		navigate({
+		await navigate({
 			to: nextPath as never,
 			search: location.search as never,
 			hash: location.hash,
@@ -111,6 +193,18 @@ export default function SettingsGeneralPanel() {
 
 	return (
 		<div className="space-y-8">
+			{languageDownload && (
+				<output
+					aria-atomic="true"
+					aria-live="polite"
+					className="border-accent bg-accent/10 text-accent-fg animate-fade-in block rounded-xl border-2 px-3 py-2 text-sm font-semibold"
+				>
+					{getLanguageDownloadMessage(
+						languageDownload.lang,
+						languageDownload.progress,
+					)}
+				</output>
+			)}
 			<div>
 				<h2
 					id="settings-general-title"
@@ -136,6 +230,7 @@ export default function SettingsGeneralPanel() {
 						id="settings-language"
 						name="language"
 						value={lang}
+						disabled={isChangingLanguage}
 						onChange={handleLanguageChange}
 						className="border-border bg-surface text-fg focus-visible:ring-accent min-h-11 w-full cursor-pointer rounded-lg border-2 px-3 text-base transition-[border-color,box-shadow,background-color] focus-visible:ring-2 focus-visible:outline-none"
 					>

--- a/src/components/SettingsGeneralPanel.tsx
+++ b/src/components/SettingsGeneralPanel.tsx
@@ -10,6 +10,7 @@ import {
 import type { Lang } from "../i18n/context";
 import { useLang, useT } from "../i18n/hooks";
 import { getLanguageDownloadMessage } from "../i18n/language-download";
+import { isLanguageCached } from "../i18n/translation-loader";
 import { replaceLangInPath } from "../lib/lang-link-utils";
 import {
 	DEFAULT_SOUND_VOLUME,
@@ -125,31 +126,42 @@ export default function SettingsGeneralPanel() {
 		if (nextLang === lang || isChangingLanguage) return;
 		playSound("toggle");
 		setIsChangingLanguage(true);
-		setLanguageDownload({ lang: nextLang, progress: 0 });
-		const progressAnimation = animateLanguageDownload((progress) =>
-			setLanguageDownload((current) =>
-				current ? { ...current, progress } : current,
-			),
-		);
+		const languagePromise = setLang(nextLang);
 
-		try {
-			await Promise.all([setLang(nextLang), progressAnimation.progressMax]);
-		} catch {
+		if (isLanguageCached(nextLang)) {
+			try {
+				await languagePromise;
+			} catch {
+				setIsChangingLanguage(false);
+				return;
+			}
+		} else {
+			setLanguageDownload({ lang: nextLang, progress: 0 });
+			const progressAnimation = animateLanguageDownload((progress) =>
+				setLanguageDownload((current) =>
+					current ? { ...current, progress } : current,
+				),
+			);
+
+			try {
+				await Promise.all([languagePromise, progressAnimation.progressMax]);
+			} catch {
+				progressAnimation.stop();
+				setLanguageDownload(null);
+				setIsChangingLanguage(false);
+				return;
+			}
+
 			progressAnimation.stop();
+			await new Promise<void>((resolve) =>
+				window.setTimeout(resolve, LANGUAGE_PROGRESS_HOLD_MS),
+			);
+			setLanguageDownload({ lang: nextLang, progress: 100 });
+			await new Promise<void>((resolve) =>
+				window.setTimeout(resolve, LANGUAGE_COMPLETION_DISPLAY_MS),
+			);
 			setLanguageDownload(null);
-			setIsChangingLanguage(false);
-			return;
 		}
-
-		progressAnimation.stop();
-		await new Promise<void>((resolve) =>
-			window.setTimeout(resolve, LANGUAGE_PROGRESS_HOLD_MS),
-		);
-		setLanguageDownload({ lang: nextLang, progress: 100 });
-		await new Promise<void>((resolve) =>
-			window.setTimeout(resolve, LANGUAGE_COMPLETION_DISPLAY_MS),
-		);
-		setLanguageDownload(null);
 		setIsChangingLanguage(false);
 		trackEvent("lang_toggle", { lang: nextLang, source: "settings" });
 		const nextPath = replaceLangInPath(location.pathname, nextLang);

--- a/src/components/TopicCard.tsx
+++ b/src/components/TopicCard.tsx
@@ -90,7 +90,6 @@ export default function TopicCard({
 	return (
 		<Link
 			to={`/${subjectId}/practice/${topic.key}`}
-			preload={false}
 			rel="nofollow"
 			data-cuelume-hover="tick"
 			data-cuelume-press

--- a/src/hooks/useTopicQuestions.ts
+++ b/src/hooks/useTopicQuestions.ts
@@ -17,26 +17,47 @@ type TopicLoadState =
 
 const EMPTY_QUESTIONS: Question[] = [];
 
+export interface InitialTopicQuestions {
+	questions: Question[];
+	megatopicLabel: string | undefined;
+}
+
 export function useTopicQuestions(
 	subject: SubjectMeta | undefined,
 	topic: string | undefined,
+	initialData?: InitialTopicQuestions,
 ) {
 	const requestKey = subject && topic ? `${subject.id}/${topic}` : null;
-	const [loadState, setLoadState] = useState<TopicLoadState>({
-		key: null,
-		status: "idle",
-	});
+	const [loadState, setLoadState] = useState<TopicLoadState>(() =>
+		requestKey && initialData
+			? {
+					key: requestKey,
+					status: "ready",
+					questions: initialData.questions,
+					megatopicLabel: initialData.megatopicLabel,
+				}
+			: { key: null, status: "idle" },
+	);
 	const [retryToken, setRetryToken] = useState(0);
+	const hasInitialData = Boolean(requestKey && initialData);
 	const currentLoadState =
 		loadState.key === requestKey
 			? loadState
-			: requestKey
-				? { key: requestKey, status: "loading" as const }
-				: { key: null, status: "idle" as const };
+			: hasInitialData && initialData
+				? {
+						key: requestKey,
+						status: "ready" as const,
+						questions: initialData.questions,
+						megatopicLabel: initialData.megatopicLabel,
+					}
+				: requestKey
+					? { key: requestKey, status: "loading" as const }
+					: { key: null, status: "idle" as const };
 	const loadAttemptKey = requestKey ? `${requestKey}:${retryToken}` : null;
 
 	useEffect(() => {
 		if (!subject || !topic || !requestKey || !loadAttemptKey) return;
+		if (initialData && retryToken === 0) return;
 
 		let cancelled = false;
 		setLoadState({ key: requestKey, status: "loading" });
@@ -60,7 +81,7 @@ export function useTopicQuestions(
 		return () => {
 			cancelled = true;
 		};
-	}, [loadAttemptKey, requestKey, subject, topic]);
+	}, [initialData, loadAttemptKey, requestKey, retryToken, subject, topic]);
 
 	const retry = useCallback(() => {
 		if (!requestKey) return;

--- a/src/i18n/context-value.ts
+++ b/src/i18n/context-value.ts
@@ -1,5 +1,5 @@
 import { createContext } from "react";
-import { en, type Translations } from "./en";
+import type { Translations } from "./en";
 
 export type Lang = "en" | "es" | "gl";
 
@@ -10,11 +10,7 @@ export function isLang(value: string | undefined): value is Lang {
 export interface I18nContextType {
 	t: Translations;
 	lang: Lang;
-	setLang: (lang: Lang) => void;
+	setLang: (lang: Lang) => Promise<void>;
 }
 
-export const I18nContext = createContext<I18nContextType>({
-	t: en,
-	lang: "en",
-	setLang: () => {},
-});
+export const I18nContext = createContext<I18nContextType | null>(null);

--- a/src/i18n/context.tsx
+++ b/src/i18n/context.tsx
@@ -38,7 +38,10 @@ export function I18nProvider({
 	children: ReactNode;
 	initialLang?: Lang;
 }) {
-	const initialTranslations = use(loadTranslations(initialLang));
+	const [initialTranslationsPromise] = useState(() =>
+		loadTranslations(initialLang),
+	);
+	const initialTranslations = use(initialTranslationsPromise);
 	const [state, setState] = useState(() => ({
 		lang: initialLang,
 		translations: initialTranslations,

--- a/src/i18n/context.tsx
+++ b/src/i18n/context.tsx
@@ -4,6 +4,7 @@ import {
 	useCallback,
 	useEffect,
 	useMemo,
+	useRef,
 	useState,
 } from "react";
 import { I18nContext, type Lang } from "./context-value";
@@ -42,9 +43,35 @@ export function I18nProvider({
 		lang: initialLang,
 		translations: initialTranslations,
 	}));
+	const pendingLanguageRef = useRef<{
+		lang: Lang;
+		routeLang: Lang;
+	} | null>(null);
+	const activeState = useMemo(() => {
+		const pendingLanguage = pendingLanguageRef.current;
+		const canUseState =
+			state.lang === initialLang ||
+			(pendingLanguage?.lang === state.lang &&
+				pendingLanguage.routeLang === initialLang);
+
+		return canUseState
+			? state
+			: { lang: initialLang, translations: initialTranslations };
+	}, [initialLang, initialTranslations, state]);
 
 	useEffect(() => {
-		if (state.lang === initialLang) return;
+		if (state.lang === initialLang) {
+			pendingLanguageRef.current = null;
+			return;
+		}
+
+		const pendingLanguage = pendingLanguageRef.current;
+		if (
+			pendingLanguage?.lang === state.lang &&
+			pendingLanguage.routeLang === initialLang
+		) {
+			return;
+		}
 
 		let active = true;
 		void loadTranslations(initialLang).then((translations) => {
@@ -56,19 +83,27 @@ export function I18nProvider({
 		};
 	}, [initialLang, state.lang]);
 
-	const setLang = useCallback(async (l: Lang) => {
-		const translations = await loadTranslations(l);
-		setState({ lang: l, translations });
-		try {
-			localStorage.setItem("lang", l);
-		} catch {
-			/* localStorage unavailable */
-		}
-	}, []);
+	const setLang = useCallback(
+		async (l: Lang) => {
+			const translations = await loadTranslations(l);
+			pendingLanguageRef.current = { lang: l, routeLang: initialLang };
+			setState({ lang: l, translations });
+			try {
+				localStorage.setItem("lang", l);
+			} catch {
+				/* localStorage unavailable */
+			}
+		},
+		[initialLang],
+	);
 
 	const value = useMemo(
-		() => ({ t: state.translations, lang: state.lang, setLang }),
-		[state, setLang],
+		() => ({
+			t: activeState.translations,
+			lang: activeState.lang,
+			setLang,
+		}),
+		[activeState, setLang],
 	);
 
 	return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;

--- a/src/i18n/context.tsx
+++ b/src/i18n/context.tsx
@@ -1,18 +1,34 @@
 import {
 	type ReactNode,
+	use,
 	useCallback,
 	useEffect,
 	useMemo,
 	useState,
 } from "react";
 import { I18nContext, type Lang } from "./context-value";
-import { en, type Translations } from "./en";
-import { es } from "./es";
-import { gl } from "./gl";
+import type { Translations } from "./en";
 
 export type { Lang } from "./context-value";
 
-const translations: Record<Lang, Translations> = { en, es, gl };
+type TranslationLoader = () => Promise<Translations>;
+
+const translationLoaders: Record<Lang, TranslationLoader> = {
+	en: () => import("./en").then(({ en }) => en),
+	es: () => import("./es").then(({ es }) => es),
+	gl: () => import("./gl").then(({ gl }) => gl),
+};
+
+const translationPromises = new Map<Lang, Promise<Translations>>();
+
+function loadTranslations(lang: Lang) {
+	const existingPromise = translationPromises.get(lang);
+	if (existingPromise) return existingPromise;
+
+	const promise = translationLoaders[lang]();
+	translationPromises.set(lang, promise);
+	return promise;
+}
 
 export function I18nProvider({
 	children,
@@ -21,16 +37,28 @@ export function I18nProvider({
 	children: ReactNode;
 	initialLang?: Lang;
 }) {
-	const [lang, setLangState] = useState<Lang>(initialLang);
+	const initialTranslations = use(loadTranslations(initialLang));
+	const [state, setState] = useState(() => ({
+		lang: initialLang,
+		translations: initialTranslations,
+	}));
 
 	useEffect(() => {
-		setLangState((currentLang) =>
-			currentLang === initialLang ? currentLang : initialLang,
-		);
-	}, [initialLang]);
+		if (state.lang === initialLang) return;
 
-	const setLang = useCallback((l: Lang) => {
-		setLangState(l);
+		let active = true;
+		void loadTranslations(initialLang).then((translations) => {
+			if (active) setState({ lang: initialLang, translations });
+		});
+
+		return () => {
+			active = false;
+		};
+	}, [initialLang, state.lang]);
+
+	const setLang = useCallback(async (l: Lang) => {
+		const translations = await loadTranslations(l);
+		setState({ lang: l, translations });
 		try {
 			localStorage.setItem("lang", l);
 		} catch {
@@ -39,8 +67,8 @@ export function I18nProvider({
 	}, []);
 
 	const value = useMemo(
-		() => ({ t: translations[lang], lang, setLang }),
-		[lang, setLang],
+		() => ({ t: state.translations, lang: state.lang, setLang }),
+		[state, setLang],
 	);
 
 	return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;

--- a/src/i18n/context.tsx
+++ b/src/i18n/context.tsx
@@ -8,28 +8,9 @@ import {
 	useState,
 } from "react";
 import { I18nContext, type Lang } from "./context-value";
-import type { Translations } from "./en";
+import { loadTranslations } from "./translation-loader";
 
 export type { Lang } from "./context-value";
-
-type TranslationLoader = () => Promise<Translations>;
-
-const translationLoaders: Record<Lang, TranslationLoader> = {
-	en: () => import("./en").then(({ en }) => en),
-	es: () => import("./es").then(({ es }) => es),
-	gl: () => import("./gl").then(({ gl }) => gl),
-};
-
-const translationPromises = new Map<Lang, Promise<Translations>>();
-
-function loadTranslations(lang: Lang) {
-	const existingPromise = translationPromises.get(lang);
-	if (existingPromise) return existingPromise;
-
-	const promise = translationLoaders[lang]();
-	translationPromises.set(lang, promise);
-	return promise;
-}
 
 export function I18nProvider({
 	children,

--- a/src/i18n/hooks.ts
+++ b/src/i18n/hooks.ts
@@ -1,11 +1,19 @@
 import { use } from "react";
 import { I18nContext } from "./context-value";
 
+function useI18nContext() {
+	const context = use(I18nContext);
+	if (!context) {
+		throw new Error("useI18nContext must be used inside I18nProvider");
+	}
+	return context;
+}
+
 export function useT() {
-	return use(I18nContext).t;
+	return useI18nContext().t;
 }
 
 export function useLang() {
-	const ctx = use(I18nContext);
+	const ctx = useI18nContext();
 	return { lang: ctx.lang, setLang: ctx.setLang };
 }

--- a/src/i18n/language-download.ts
+++ b/src/i18n/language-download.ts
@@ -1,0 +1,11 @@
+import type { Lang } from "./context-value";
+
+const languageDownloadLabels: Record<Lang, string> = {
+	en: "Downloading language...",
+	es: "Descargando idioma...",
+	gl: "Descargando idioma...",
+};
+
+export function getLanguageDownloadMessage(lang: Lang, progress: number) {
+	return `${languageDownloadLabels[lang]} ${progress}%`;
+}

--- a/src/i18n/translation-loader.ts
+++ b/src/i18n/translation-loader.ts
@@ -1,0 +1,29 @@
+import type { Lang } from "./context-value";
+import type { Translations } from "./en";
+
+type TranslationLoader = () => Promise<Translations>;
+
+const translationLoaders: Record<Lang, TranslationLoader> = {
+	en: () => import("./en").then(({ en }) => en),
+	es: () => import("./es").then(({ es }) => es),
+	gl: () => import("./gl").then(({ gl }) => gl),
+};
+
+const translationPromises = new Map<Lang, Promise<Translations>>();
+const loadedTranslations = new Set<Lang>();
+
+export function loadTranslations(lang: Lang) {
+	const existingPromise = translationPromises.get(lang);
+	if (existingPromise) return existingPromise;
+
+	const promise = translationLoaders[lang]().then((translations) => {
+		loadedTranslations.add(lang);
+		return translations;
+	});
+	translationPromises.set(lang, promise);
+	return promise;
+}
+
+export function isLanguageCached(lang: Lang) {
+	return loadedTranslations.has(lang);
+}

--- a/src/lib/markdown-preload.ts
+++ b/src/lib/markdown-preload.ts
@@ -1,0 +1,73 @@
+import type { ComponentProps } from "react";
+import type ReactMarkdown from "react-markdown";
+
+export type MathPlugins = {
+	remark: NonNullable<
+		ComponentProps<typeof ReactMarkdown>["remarkPlugins"]
+	>[number];
+	rehype: NonNullable<
+		ComponentProps<typeof ReactMarkdown>["rehypePlugins"]
+	>[number];
+};
+
+let mathPluginsPromise: Promise<MathPlugins> | undefined;
+let loadedMathPlugins: MathPlugins | null = null;
+let syntaxHighlighterPromise:
+	| ReturnType<typeof importSyntaxHighlighter>
+	| undefined;
+let syntaxHighlighterLoaded = false;
+
+function importSyntaxHighlighter() {
+	return import("./MarkdownSyntaxHighlighter");
+}
+
+export function containsMathSyntax(value: string): boolean {
+	return /(^|[^\\])(?:\${1,2}|\\(?:\(|\[))/.test(value);
+}
+
+export function loadMathPlugins(): Promise<MathPlugins> {
+	mathPluginsPromise ??= Promise.all([
+		import("remark-math"),
+		import("rehype-katex"),
+		import("katex/dist/katex-swap.min.css"),
+	])
+		.then(([remarkMath, rehypeKatex]) => ({
+			remark: remarkMath.default,
+			rehype: rehypeKatex.default,
+		}))
+		.then((plugins) => {
+			loadedMathPlugins = plugins;
+			return plugins;
+		});
+	return mathPluginsPromise;
+}
+
+export function getLoadedMathPlugins(): MathPlugins | null {
+	return loadedMathPlugins;
+}
+
+export function loadSyntaxHighlighter() {
+	syntaxHighlighterPromise ??= importSyntaxHighlighter().then((module) => {
+		syntaxHighlighterLoaded = true;
+		return module;
+	});
+	return syntaxHighlighterPromise;
+}
+
+export function isSyntaxHighlighterLoaded(): boolean {
+	return syntaxHighlighterLoaded;
+}
+
+export async function preloadMarkdownDependencies(
+	contents: string[],
+): Promise<void> {
+	const content = contents.join("\n");
+	const dependencies: Promise<unknown>[] = [];
+
+	if (containsMathSyntax(content)) dependencies.push(loadMathPlugins());
+	if (/```[\w-]+[\s\S]*?```/.test(content)) {
+		dependencies.push(loadSyntaxHighlighter());
+	}
+
+	await Promise.all(dependencies);
+}

--- a/src/lib/markdown.tsx
+++ b/src/lib/markdown.tsx
@@ -2,21 +2,47 @@ import type { ComponentProps, ReactNode } from "react";
 import { Component, lazy, Suspense, useEffect, useRef, useState } from "react";
 import type { ExtraProps } from "react-markdown";
 import ReactMarkdown from "react-markdown";
-import rehypeKatex from "rehype-katex";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
-import remarkMath from "remark-math";
-import "katex/dist/katex.min.css";
+import "../markdown.css";
+import type { MathPlugins } from "./markdown-preload";
+import {
+	containsMathSyntax,
+	getLoadedMathPlugins,
+	isSyntaxHighlighterLoaded,
+	loadMathPlugins,
+	loadSyntaxHighlighter,
+} from "./markdown-preload";
 
-const SyntaxHighlighter = lazy(() => import("./MarkdownSyntaxHighlighter"));
+const SyntaxHighlighter = lazy(() => loadSyntaxHighlighter());
 
 // A single newline is an intentional line break in question data. Markdown's
 // default soft-break behavior would otherwise make it depend on the field or
 // its surrounding CSS whether the line break is visible.
-const fullRemarkPlugins = [remarkGfm, remarkMath, remarkBreaks];
-const inlineRemarkPlugins = [remarkGfm, remarkMath, remarkBreaks];
-const rehypePlugins = [rehypeKatex];
-const inlineRehypePlugins = [rehypeKatex];
+const basicRemarkPlugins = [remarkGfm, remarkBreaks];
+const basicRehypePlugins: [] = [];
+
+function useMathPlugins(children: string): MathPlugins | null {
+	const needsMath = containsMathSyntax(children);
+	const [mathPlugins, setMathPlugins] = useState<MathPlugins | null>(() =>
+		needsMath ? getLoadedMathPlugins() : null,
+	);
+
+	useEffect(() => {
+		if (!needsMath) return;
+
+		let mounted = true;
+		loadMathPlugins().then((plugins) => {
+			if (mounted) setMathPlugins(plugins);
+		});
+
+		return () => {
+			mounted = false;
+		};
+	}, [needsMath]);
+
+	return needsMath ? mathPlugins : null;
+}
 
 const codeFont =
 	'"Cascadia Code Variable", "Cascadia Code", Consolas, "Courier New", monospace';
@@ -199,6 +225,44 @@ class CodeHighlightErrorBoundary extends Component<
 	}
 }
 
+function DeferredCodeHighlight({
+	code,
+	language,
+}: {
+	code: string;
+	language: string;
+}) {
+	const [isReady, setIsReady] = useState(isSyntaxHighlighterLoaded);
+
+	useEffect(() => {
+		if (isSyntaxHighlighterLoaded()) return;
+		const timeoutId = window.setTimeout(() => setIsReady(true), 1000);
+		return () => window.clearTimeout(timeoutId);
+	}, []);
+
+	if (!isReady) return <PlainCodeContent code={code} />;
+
+	return (
+		<CodeHighlightErrorBoundary fallback={<PlainCodeContent code={code} />}>
+			<Suspense fallback={<PlainCodeContent code={code} />}>
+				<SyntaxHighlighter
+					PreTag="pre"
+					language={language}
+					style={codeStyle}
+					customStyle={{
+						margin: 0,
+						padding: "1rem",
+						borderRadius: 0,
+						background: "transparent",
+					}}
+				>
+					{code}
+				</SyntaxHighlighter>
+			</Suspense>
+		</CodeHighlightErrorBoundary>
+	);
+}
+
 function getCodeLanguage(node: ExtraProps["node"]): string | undefined {
 	const child = node?.children[0];
 	if (child?.type !== "element" || child.tagName !== "code") {
@@ -286,23 +350,7 @@ function CodeRenderer({ className, children }: ComponentProps<"code">) {
 				</span>
 			</div>
 			<div className="overflow-x-auto text-sm leading-relaxed">
-				<CodeHighlightErrorBoundary fallback={<PlainCodeContent code={code} />}>
-					<Suspense fallback={<PlainCodeContent code={code} />}>
-						<SyntaxHighlighter
-							PreTag="pre"
-							language={prismLanguage}
-							style={codeStyle}
-							customStyle={{
-								margin: 0,
-								padding: "1rem",
-								borderRadius: 0,
-								background: "transparent",
-							}}
-						>
-							{code}
-						</SyntaxHighlighter>
-					</Suspense>
-				</CodeHighlightErrorBoundary>
+				<DeferredCodeHighlight code={code} language={prismLanguage} />
 			</div>
 		</div>
 	);
@@ -315,13 +363,18 @@ export function Markdown({
 	children: string;
 	className?: string;
 }) {
+	const mathPlugins = useMathPlugins(children);
 	if (!children) return null;
+	const remarkPlugins = mathPlugins
+		? [...basicRemarkPlugins, mathPlugins.remark]
+		: basicRemarkPlugins;
+	const rehypePlugins = mathPlugins ? [mathPlugins.rehype] : basicRehypePlugins;
 	return (
 		<div
 			className={`markdown-body prose prose-sm max-w-none ${className ?? ""}`}
 		>
 			<ReactMarkdown
-				remarkPlugins={fullRemarkPlugins}
+				remarkPlugins={remarkPlugins}
 				rehypePlugins={rehypePlugins}
 				components={{
 					pre: MarkdownPre,
@@ -354,11 +407,16 @@ export function Markdown({
 }
 
 export function InlineMarkdown({ children }: { children: string }) {
+	const mathPlugins = useMathPlugins(children);
 	if (!children) return null;
+	const remarkPlugins = mathPlugins
+		? [...basicRemarkPlugins, mathPlugins.remark]
+		: basicRemarkPlugins;
+	const rehypePlugins = mathPlugins ? [mathPlugins.rehype] : basicRehypePlugins;
 	return (
 		<ReactMarkdown
-			remarkPlugins={inlineRemarkPlugins}
-			rehypePlugins={inlineRehypePlugins}
+			remarkPlugins={remarkPlugins}
+			rehypePlugins={rehypePlugins}
 			allowedElements={[
 				"a",
 				"code",

--- a/src/lib/route-preloads.ts
+++ b/src/lib/route-preloads.ts
@@ -1,0 +1,15 @@
+import type { Question } from "../data/types";
+import { preloadMarkdownDependencies } from "./markdown-preload";
+
+function questionContent(questions: Question[]): string[] {
+	return questions.map((question) => JSON.stringify(question));
+}
+
+export async function preloadSimulatorDependencies(
+	questions: Question[],
+): Promise<void> {
+	await Promise.all([
+		import("./tour").then(({ preloadTour }) => preloadTour()),
+		preloadMarkdownDependencies(questionContent(questions)),
+	]);
+}

--- a/src/lib/tour.ts
+++ b/src/lib/tour.ts
@@ -1,5 +1,4 @@
-import { type DriveStep, driver, type PopoverDOM } from "driver.js";
-import "driver.js/dist/driver.css";
+import type { DriveStep, PopoverDOM } from "driver.js";
 
 const PRACTICE_TOUR_KEY = "has-seen-practice-tour";
 const EXAM_TOUR_KEY = "has-seen-exam-tour";
@@ -8,6 +7,18 @@ export interface TourButtonTexts {
 	next: string;
 	previous: string;
 	done: string;
+}
+
+async function loadDriver() {
+	const [{ driver }] = await Promise.all([
+		import("driver.js"),
+		import("driver.js/dist/driver.css"),
+	]);
+	return driver;
+}
+
+export async function preloadTour(): Promise<void> {
+	await loadDriver();
 }
 
 function hasSeenTour(key: string): boolean {
@@ -48,11 +59,14 @@ function cleanDriverTargetAria(element: Element | undefined): void {
 	window.setTimeout(() => removeDriverTargetAria(element), 0);
 }
 
-export function startPracticeTour(
+async function startTour(
+	key: string,
 	steps: DriveStep[],
 	buttonTexts: TourButtonTexts,
-): boolean {
-	if (hasSeenTour(PRACTICE_TOUR_KEY)) return false;
+): Promise<boolean> {
+	if (hasSeenTour(key)) return false;
+	const driver = await loadDriver();
+	if (hasSeenTour(key)) return false;
 	const driverObj = driver({
 		showProgress: true,
 		animate: !prefersReducedMotion(),
@@ -64,30 +78,22 @@ export function startPracticeTour(
 		onHighlighted: cleanDriverTargetAria,
 		onPopoverRender: (popover, { driver: driverObj }) =>
 			addTourSounds(popover, driverObj.isLastStep()),
-		onDestroyed: () => markTourSeen(PRACTICE_TOUR_KEY),
+		onDestroyed: () => markTourSeen(key),
 	});
 	driverObj.drive();
 	return true;
 }
 
+export function startPracticeTour(
+	steps: DriveStep[],
+	buttonTexts: TourButtonTexts,
+): Promise<boolean> {
+	return startTour(PRACTICE_TOUR_KEY, steps, buttonTexts);
+}
+
 export function startExamTour(
 	steps: DriveStep[],
 	buttonTexts: TourButtonTexts,
-): boolean {
-	if (hasSeenTour(EXAM_TOUR_KEY)) return false;
-	const driverObj = driver({
-		showProgress: true,
-		animate: !prefersReducedMotion(),
-		popoverClass: "tour-popover",
-		nextBtnText: buttonTexts.next,
-		prevBtnText: buttonTexts.previous,
-		doneBtnText: buttonTexts.done,
-		steps,
-		onHighlighted: cleanDriverTargetAria,
-		onPopoverRender: (popover, { driver: driverObj }) =>
-			addTourSounds(popover, driverObj.isLastStep()),
-		onDestroyed: () => markTourSeen(EXAM_TOUR_KEY),
-	});
-	driverObj.drive();
-	return true;
+): Promise<boolean> {
+	return startTour(EXAM_TOUR_KEY, steps, buttonTexts);
 }

--- a/src/markdown.css
+++ b/src/markdown.css
@@ -1,0 +1,140 @@
+@reference "./styles.css";
+@plugin "@tailwindcss/typography";
+
+.prose {
+	--tw-prose-body: var(--color-fg-secondary);
+	--tw-prose-headings: var(--color-fg);
+	--tw-prose-lead: var(--color-fg-secondary);
+	--tw-prose-links: var(--color-accent-fg);
+	--tw-prose-bold: var(--color-fg);
+	--tw-prose-counters: var(--color-fg-muted);
+	--tw-prose-bullets: var(--color-border);
+	--tw-prose-hr: var(--color-border);
+	--tw-prose-quotes: var(--color-fg-secondary);
+	--tw-prose-quote-borders: var(--color-border);
+	--tw-prose-captions: var(--color-fg-muted);
+	--tw-prose-code: var(--color-code-fg);
+	--tw-prose-pre-code: var(--color-code-block-fg);
+	--tw-prose-pre-bg: var(--color-code-block);
+	--tw-prose-th-borders: var(--color-border);
+	--tw-prose-td-borders: var(--color-border);
+}
+
+/* ── Question-card Markdown ──
+   The typography plugin is tuned for article-length prose. Question content
+   is denser and mixes prompts, lists, formulas, and code blocks, so keep its
+   rhythm explicit and shared across every Markdown field. */
+.markdown-body {
+	overflow-wrap: break-word;
+	line-height: 1.5;
+}
+
+.markdown-body > :first-child {
+	margin-block-start: 0;
+}
+
+.markdown-body > :last-child {
+	margin-block-end: 0;
+}
+
+.markdown-body :where(p) {
+	margin-block: 0;
+	text-wrap: pretty;
+}
+
+.markdown-body :where(p + p) {
+	margin-block-start: 0.75em;
+}
+
+.markdown-body :where(h1, h2, h3, h4) {
+	font-weight: 700;
+	text-wrap: balance;
+}
+
+.markdown-body :where(h1) {
+	margin-block: 0 0.5em;
+	font-size: 1.5em;
+	line-height: 1.2;
+}
+
+.markdown-body :where(h2) {
+	margin-block: 1em 0.45em;
+	font-size: 1.25em;
+	line-height: 1.25;
+}
+
+.markdown-body :where(h3) {
+	margin-block: 0.9em 0.35em;
+	font-size: 1.125em;
+	line-height: 1.3;
+}
+
+.markdown-body :where(h4) {
+	margin-block: 0.8em 0.3em;
+	font-size: 1em;
+	line-height: 1.35;
+}
+
+.markdown-body :where(ul, ol) {
+	margin-block: 0.75em;
+	padding-inline-start: 1.5em;
+}
+
+.markdown-body :where(li) {
+	margin-block: 0.25em;
+}
+
+.markdown-body :where(li > ul, li > ol) {
+	margin-block: 0.35em;
+}
+
+.markdown-body :where(blockquote) {
+	margin-block: 0.75em;
+	border-inline-start: 0.2em solid var(--color-border);
+	padding-inline-start: 1em;
+	color: var(--color-fg-secondary);
+}
+
+.markdown-body :where(hr) {
+	margin-block: 1.25em;
+	border: 0;
+	border-block-start: 1px solid var(--color-border);
+}
+
+.markdown-body :where(a) {
+	text-decoration-thickness: from-font;
+	text-underline-offset: 0.15em;
+	text-underline-position: from-font;
+}
+
+.markdown-body :where(.markdown-code-block) {
+	max-inline-size: 100%;
+	margin-block: 0.75em;
+}
+
+.markdown-body :where(.markdown-table) {
+	margin-block: 0.75em;
+}
+
+.markdown-body :where(.markdown-code-block pre) {
+	max-inline-size: 100%;
+}
+
+.markdown-body :where(.footnotes) {
+	margin-block-start: 1em;
+	font-size: 0.9em;
+}
+
+.markdown-body :where(.footnotes ol) {
+	margin-block: 0.5em 0;
+}
+
+.markdown-body :where(.footnotes li) {
+	margin-block: 0.35em;
+}
+
+.markdown-body :where(input[type="checkbox"]) {
+	margin-inline-end: 0.5em;
+	vertical-align: middle;
+	accent-color: var(--color-accent);
+}

--- a/src/pages/ExamSimulation.tsx
+++ b/src/pages/ExamSimulation.tsx
@@ -1124,23 +1124,42 @@ function loadExamData(subjectId: string, examId: string) {
 	return promise;
 }
 
-function useExamData(subject: ExamSubject | undefined, examId?: string) {
+function useExamData(
+	subject: ExamSubject | undefined,
+	examId?: string,
+	initialData?: LoadedExamData,
+) {
 	const requestKey = subject && examId ? `${subject.id}/${examId}` : null;
-	const [loadState, setLoadState] = useState<ExamLoadState>({
-		key: null,
-		status: "idle",
-	});
+	const [loadState, setLoadState] = useState<ExamLoadState>(() =>
+		requestKey && initialData
+			? {
+					key: requestKey,
+					status: "ready",
+					questions: initialData.questions,
+					megatopicLabels: initialData.megatopicLabels,
+				}
+			: { key: null, status: "idle" },
+	);
 	const [retryToken, setRetryToken] = useState(0);
+	const hasInitialData = Boolean(requestKey && initialData);
 	const currentLoadState =
 		loadState.key === requestKey
 			? loadState
-			: requestKey
-				? { key: requestKey, status: "loading" as const }
-				: { key: null, status: "idle" as const };
+			: hasInitialData && initialData
+				? {
+						key: requestKey,
+						status: "ready" as const,
+						questions: initialData.questions,
+						megatopicLabels: initialData.megatopicLabels,
+					}
+				: requestKey
+					? { key: requestKey, status: "loading" as const }
+					: { key: null, status: "idle" as const };
 	const loadAttemptKey = requestKey ? `${requestKey}:${retryToken}` : null;
 
 	useEffect(() => {
 		if (!subject || !examId || !requestKey || !loadAttemptKey) return;
+		if (initialData && retryToken === 0) return;
 
 		let cancelled = false;
 		setLoadState({ key: requestKey, status: "loading" });
@@ -1163,7 +1182,7 @@ function useExamData(subject: ExamSubject | undefined, examId?: string) {
 		return () => {
 			cancelled = true;
 		};
-	}, [examId, loadAttemptKey, requestKey, subject]);
+	}, [examId, initialData, loadAttemptKey, requestKey, retryToken, subject]);
 
 	const retry = useCallback(() => {
 		if (!requestKey) return;
@@ -1189,12 +1208,25 @@ export default function ExamSimulation() {
 	const navigate = useNavigate();
 	const t = useT();
 	const langTo = useLangTo();
-	const { exam: routeExam, stats } = examRouteApi.useLoaderData();
+	const {
+		exam: routeExam,
+		stats,
+		questions: initialQuestions,
+		megatopicLabels: initialMegatopicLabels,
+	} = examRouteApi.useLoaderData();
+	const initialExamData = useMemo(
+		() => ({
+			questions: initialQuestions,
+			megatopicLabels: initialMegatopicLabels,
+		}),
+		[initialMegatopicLabels, initialQuestions],
+	);
 
 	const subject = subjectId ? getSubject(subjectId) : undefined;
 	const { questions, status, megatopicLabels, retry } = useExamData(
 		subject,
 		examId,
+		initialExamData,
 	);
 	const examInfo = routeExam;
 	const questionCount = stats.examQuestionCounts[examId || ""] ?? 0;

--- a/src/pages/PracticeTopic.tsx
+++ b/src/pages/PracticeTopic.tsx
@@ -1,4 +1,4 @@
-import { useParams } from "@tanstack/react-router";
+import { getRouteApi, useParams } from "@tanstack/react-router";
 import {
 	useCallback,
 	useEffect,
@@ -45,6 +45,7 @@ import { track } from "../lib/umami";
 import { getSubject } from "../subjects";
 
 const minScrollRangeForCompactScore = 256;
+const practiceRouteApi = getRouteApi("/$lang/$subjectId_/practice_/$topic");
 
 interface PracticePlayerProps {
 	subject: NonNullable<ReturnType<typeof getSubject>>;
@@ -946,6 +947,15 @@ function PracticeTopicContent({
 
 export default function PracticeTopic() {
 	const { subjectId, topic } = useParams({ strict: false });
+	const { questions: initialQuestions, megatopicLabel: initialMegatopicLabel } =
+		practiceRouteApi.useLoaderData();
+	const initialTopicData = useMemo(
+		() => ({
+			questions: initialQuestions,
+			megatopicLabel: initialMegatopicLabel,
+		}),
+		[initialMegatopicLabel, initialQuestions],
+	);
 	const subject = subjectId ? getSubject(subjectId) : undefined;
 	const { selectedExamIds } = useExamSelection(subject);
 	const topicInfo = useMemo(
@@ -957,7 +967,7 @@ export default function PracticeTopic() {
 		megatopicLabel,
 		status,
 		retry,
-	} = useTopicQuestions(subject, topic);
+	} = useTopicQuestions(subject, topic, initialTopicData);
 	const questions = useMemo(
 		() => filterQuestionsByExamSelection(allTopicQuestions, selectedExamIds),
 		[allTopicQuestions, selectedExamIds],

--- a/src/pages/SubjectHome.tsx
+++ b/src/pages/SubjectHome.tsx
@@ -517,7 +517,6 @@ function ExamCard({
 	return (
 		<Link
 			to={`/${subject.id}/exam/${exam.id}`}
-			preload={false}
 			rel="nofollow"
 			data-cuelume-hover="tick"
 			data-cuelume-press

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -101,13 +101,19 @@ const LangSubjectIdExamExamIdRoute = LangSubjectIdExamExamIdRouteImport.update({
   id: '/$subjectId_/exam/$examId',
   path: '/$subjectId/exam/$examId',
   getParentRoute: () => LangRoute,
-} as any)
+} as any).lazy(() =>
+  import('./routes/$lang.$subjectId_.exam.$examId.lazy').then((d) => d.Route),
+)
 const LangSubjectIdPracticeTopicRoute =
   LangSubjectIdPracticeTopicRouteImport.update({
     id: '/$subjectId_/practice_/$topic',
     path: '/$subjectId/practice/$topic',
     getParentRoute: () => LangRoute,
-  } as any)
+  } as any).lazy(() =>
+    import('./routes/$lang.$subjectId_.practice_.$topic.lazy').then(
+      (d) => d.Route,
+    ),
+  )
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute

--- a/src/routes/$lang.$subjectId.tsx
+++ b/src/routes/$lang.$subjectId.tsx
@@ -17,13 +17,13 @@ export const Route = createFileRoute("/$lang/$subjectId")({
 		};
 	},
 	staleTime: Infinity,
-	head: ({ params, loaderData }) => {
+	head: async ({ params, loaderData }) => {
 		const subject = getSubject(params.subjectId);
 		if (!subject) return {};
 
 		const lang = isLang(params.lang) ? params.lang : "es";
 		return createPageHead(
-			buildSubjectMeta(lang, subject, {
+			await buildSubjectMeta(lang, subject, {
 				questionCount: loaderData?.stats.questionCount ?? 0,
 			}),
 			isIndexableSubject(subject.id),

--- a/src/routes/$lang.$subjectId_.exam.$examId.lazy.tsx
+++ b/src/routes/$lang.$subjectId_.exam.$examId.lazy.tsx
@@ -1,0 +1,7 @@
+import { createLazyFileRoute } from "@tanstack/react-router";
+import ExamSimulation, { ExamSimulationPending } from "../pages/ExamSimulation";
+
+export const Route = createLazyFileRoute("/$lang/$subjectId_/exam/$examId")({
+	component: ExamSimulation,
+	pendingComponent: ExamSimulationPending,
+});

--- a/src/routes/$lang.$subjectId_.exam.$examId.tsx
+++ b/src/routes/$lang.$subjectId_.exam.$examId.tsx
@@ -1,20 +1,39 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { isLang } from "../i18n/context-value";
-import ExamSimulation, { ExamSimulationPending } from "../pages/ExamSimulation";
+import { preloadSimulatorDependencies } from "../lib/route-preloads";
 import { createPageHead } from "../seo/head";
 import { buildExamMeta } from "../seo/meta";
+import { getQuestionsByExam, getTopicMegaTopicLabel } from "../subjects";
 import { examRouteData } from "./-route-data";
 
 export const Route = createFileRoute("/$lang/$subjectId_/exam/$examId")({
 	pendingMs: 0,
 	pendingMinMs: 300,
-	pendingComponent: ExamSimulationPending,
-	loader: ({ params }) => examRouteData(params.subjectId, params.examId),
-	head: ({ params, loaderData }) => {
+	loader: async ({ params }) => {
+		const routeData = examRouteData(params.subjectId, params.examId);
+		const questions = await getQuestionsByExam(params.subjectId, params.examId);
+		const entriesPromise = Promise.all(
+			[...new Set(questions.map((question) => question.topic))].map(
+				async (topic) =>
+					[
+						topic,
+						await getTopicMegaTopicLabel(params.subjectId, topic),
+					] as const,
+			),
+		);
+		const dependenciesPromise = preloadSimulatorDependencies(questions);
+		const [entries] = await Promise.all([entriesPromise, dependenciesPromise]);
+		const megatopicLabels: Record<string, string> = {};
+		for (const [topic, label] of entries) {
+			if (label != null) megatopicLabels[topic] = label;
+		}
+		return { ...routeData, questions, megatopicLabels };
+	},
+	head: async ({ params, loaderData }) => {
 		if (!loaderData) return {};
 		const lang = isLang(params.lang) ? params.lang : "es";
 		return createPageHead(
-			buildExamMeta(
+			await buildExamMeta(
 				lang,
 				loaderData.subject,
 				loaderData.exam,
@@ -23,5 +42,4 @@ export const Route = createFileRoute("/$lang/$subjectId_/exam/$examId")({
 			false,
 		);
 	},
-	component: ExamSimulation,
 });

--- a/src/routes/$lang.$subjectId_.practice_.$topic.lazy.tsx
+++ b/src/routes/$lang.$subjectId_.practice_.$topic.lazy.tsx
@@ -1,0 +1,9 @@
+import { createLazyFileRoute } from "@tanstack/react-router";
+import PracticeTopic, { PracticeTopicPending } from "../pages/PracticeTopic";
+
+export const Route = createLazyFileRoute("/$lang/$subjectId_/practice_/$topic")(
+	{
+		component: PracticeTopic,
+		pendingComponent: PracticeTopicPending,
+	},
+);

--- a/src/routes/$lang.$subjectId_.practice_.$topic.tsx
+++ b/src/routes/$lang.$subjectId_.practice_.$topic.tsx
@@ -1,20 +1,29 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { isLang } from "../i18n/context-value";
-import PracticeTopic, { PracticeTopicPending } from "../pages/PracticeTopic";
+import { preloadSimulatorDependencies } from "../lib/route-preloads";
 import { createPageHead } from "../seo/head";
 import { buildTopicMeta } from "../seo/meta";
+import { getQuestionsByTopic, getTopicMegaTopicLabel } from "../subjects";
 import { topicRouteData } from "./-route-data";
 
 export const Route = createFileRoute("/$lang/$subjectId_/practice_/$topic")({
 	pendingMs: 0,
 	pendingMinMs: 300,
-	pendingComponent: PracticeTopicPending,
-	loader: ({ params }) => topicRouteData(params.subjectId, params.topic),
-	head: ({ params, loaderData }) => {
+	loader: async ({ params }) => {
+		const routeData = topicRouteData(params.subjectId, params.topic);
+		const [questions, megatopicLabel] = await Promise.all([
+			getQuestionsByTopic(params.subjectId, params.topic),
+			getTopicMegaTopicLabel(params.subjectId, params.topic),
+		]);
+		await preloadSimulatorDependencies(questions);
+
+		return { ...routeData, questions, megatopicLabel };
+	},
+	head: async ({ params, loaderData }) => {
 		if (!loaderData) return {};
 		const lang = isLang(params.lang) ? params.lang : "es";
 		return createPageHead(
-			buildTopicMeta(
+			await buildTopicMeta(
 				lang,
 				loaderData.subject,
 				loaderData.topic,
@@ -23,5 +32,4 @@ export const Route = createFileRoute("/$lang/$subjectId_/practice_/$topic")({
 			false,
 		);
 	},
-	component: PracticeTopic,
 });

--- a/src/routes/$lang.index.tsx
+++ b/src/routes/$lang.index.tsx
@@ -14,9 +14,9 @@ export const Route = createFileRoute("/$lang/")({
 	ssr: ssrDuringBuildPrerender,
 	loader: homepageRouteData,
 	staleTime: Infinity,
-	head: ({ params }) => {
+	head: async ({ params }) => {
 		const lang = isLang(params.lang) ? params.lang : "es";
-		return createPageHead(buildHomeMeta(lang));
+		return createPageHead(await buildHomeMeta(lang));
 	},
 	component: HomeRoute,
 });

--- a/src/routes/$lang.privacy.tsx
+++ b/src/routes/$lang.privacy.tsx
@@ -7,9 +7,9 @@ import { buildPrivacyMeta } from "../seo/meta";
 
 export const Route = createFileRoute("/$lang/privacy")({
 	ssr: ssrDuringBuildPrerender,
-	head: ({ params }) => {
+	head: async ({ params }) => {
 		const lang = isLang(params.lang) ? params.lang : "es";
-		return createPageHead(buildPrivacyMeta(lang), false);
+		return createPageHead(await buildPrivacyMeta(lang), false);
 	},
 	component: PrivacyPolicy,
 });

--- a/src/routes/$lang.tsx
+++ b/src/routes/$lang.tsx
@@ -4,7 +4,7 @@ import {
 	Outlet,
 	redirect,
 } from "@tanstack/react-router";
-import { useEffect } from "react";
+import { Suspense, useEffect } from "react";
 import AppChrome from "../components/AppChrome";
 import LangNotFound from "../components/LangNotFound";
 import { I18nProvider } from "../i18n/context";
@@ -62,9 +62,9 @@ export const Route = createFileRoute("/$lang")({
 			replace: true,
 		});
 	},
-	head: ({ params }) => {
+	head: async ({ params }) => {
 		const lang = isLang(params.lang) ? params.lang : "es";
-		return createNoIndexHead(buildNotFoundMeta(lang));
+		return createNoIndexHead(await buildNotFoundMeta(lang));
 	},
 	component: LangLayout,
 	notFoundComponent: LangNotFound,
@@ -82,11 +82,24 @@ function LangLayout() {
 
 	return (
 		<ThemeProvider>
-			<I18nProvider initialLang={lang}>
-				<AppChrome>
-					<Outlet />
-				</AppChrome>
-			</I18nProvider>
+			<Suspense fallback={<LanguageLoadingFallback />}>
+				<I18nProvider initialLang={lang}>
+					<AppChrome>
+						<Outlet />
+					</AppChrome>
+				</I18nProvider>
+			</Suspense>
 		</ThemeProvider>
+	);
+}
+
+function LanguageLoadingFallback() {
+	return (
+		<main
+			className="bg-surface text-fg flex min-h-screen min-h-svh min-h-dvh items-center justify-center font-sans"
+			aria-busy="true"
+		>
+			<div className="text-fg-muted text-sm">…</div>
+		</main>
 	);
 }

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -9,6 +9,7 @@ import {
 import { TanStackRouterDevtoolsPanel } from "@tanstack/react-router-devtools";
 
 import "../bones/registry";
+import onestFontUrl from "@fontsource-variable/onest/files/onest-latin-wght-normal.woff2?url";
 import { isLang, type Lang } from "../i18n/context-value";
 import { ssrDuringBuildPrerender } from "../lib/ssr";
 import appCss from "../styles.css?url";
@@ -47,6 +48,13 @@ export const Route = createRootRoute({
 			{
 				rel: "stylesheet",
 				href: appCss,
+			},
+			{
+				rel: "preload",
+				as: "font",
+				type: "font/woff2",
+				href: onestFontUrl,
+				crossOrigin: "anonymous",
 			},
 			{
 				rel: "preconnect",
@@ -91,12 +99,6 @@ export const Route = createRootRoute({
 				"data-performance": "true",
 				"data-domains": "pe.pablopl.dev",
 				"data-do-not-track": "true",
-				defer: true,
-			},
-			{
-				id: "umami-recorder",
-				src: "https://analytics.pablopl.dev/recorder.js",
-				"data-website-id": "63168f0e-a1cf-4ec6-a0c4-58fc7d57a0f4",
 				defer: true,
 			},
 		],

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -7,7 +7,8 @@ import { buildHomeMeta, DEFAULT_LANG } from "../seo/meta";
 
 export const Route = createFileRoute("/")({
 	ssr: ssrDuringBuildPrerender,
-	head: () => createRedirectFallbackHead(buildHomeMeta(DEFAULT_LANG)),
+	head: async () =>
+		createRedirectFallbackHead(await buildHomeMeta(DEFAULT_LANG)),
 	component: RootFallback,
 });
 

--- a/src/seo/meta.ts
+++ b/src/seo/meta.ts
@@ -1,9 +1,7 @@
 import type { Exam, SubjectMeta, Topic } from "../data/types";
 import type { Lang } from "../i18n/context";
-import { en } from "../i18n/en";
-import { es } from "../i18n/es";
-import { gl } from "../i18n/gl";
 import { hasAuthorizedExamContent } from "../lib/content-policy";
+import { loadSeoTranslations } from "./translations";
 
 export const BASE_URL = "https://pe.pablopl.dev";
 export const LANGS = ["en", "es", "gl"] as const;
@@ -51,10 +49,8 @@ export interface SubjectStats {
 	examTotalPoints?: Record<string, number>;
 }
 
-const translations = { en, es, gl } as const;
-
 function t(lang: Lang) {
-	return translations[lang];
+	return loadSeoTranslations(lang);
 }
 
 export function buildCanonicalPath(
@@ -140,7 +136,7 @@ function breadcrumbJsonLd(
 	};
 }
 
-function makePageMeta(
+async function makePageMeta(
 	lang: Lang,
 	pathWithoutLang: string,
 	title: string,
@@ -148,7 +144,8 @@ function makePageMeta(
 	ogImage: string,
 	graph: unknown[],
 	lastmod: string = SITEMAP_LASTMOD.global,
-): PageMetaData {
+): Promise<PageMetaData> {
+	const tr = await t(lang);
 	const meta = langMeta[lang];
 	const canonicalUrl = fullUrl(buildCanonicalPath(lang, pathWithoutLang));
 	return {
@@ -160,7 +157,7 @@ function makePageMeta(
 		description,
 		socialTitle: title,
 		socialDescription: description,
-		siteName: t(lang).seo.siteName,
+		siteName: tr.seo.siteName,
 		canonicalUrl,
 		ogImage: fullUrl(ogImage),
 		ogImageType: imageType(ogImage),
@@ -175,8 +172,8 @@ function makePageMeta(
 	};
 }
 
-export function buildHomeMeta(lang: Lang): PageMetaData {
-	const tr = t(lang);
+export async function buildHomeMeta(lang: Lang): Promise<PageMetaData> {
+	const tr = await t(lang);
 	const title = appendBrand(tr.seo.homeTitle, tr.seo.siteName);
 	const description = tr.seo.homeMetaDescription;
 	const canonicalUrl = fullUrl(buildCanonicalPath(lang, "/"));
@@ -221,8 +218,8 @@ export function buildHomeMeta(lang: Lang): PageMetaData {
 	);
 }
 
-export function buildPrivacyMeta(lang: Lang): PageMetaData {
-	const tr = t(lang);
+export async function buildPrivacyMeta(lang: Lang): Promise<PageMetaData> {
+	const tr = await t(lang);
 	const title = appendBrand(tr.footer.privacyTitle, tr.seo.siteName);
 	const description = tr.seo.privacyMetaDescription;
 	const pathWithoutLang = "/privacy";
@@ -239,20 +236,20 @@ export function buildPrivacyMeta(lang: Lang): PageMetaData {
 	]);
 }
 
-export function buildNotFoundMeta(lang: Lang) {
-	const tr = t(lang);
+export async function buildNotFoundMeta(lang: Lang) {
+	const tr = await t(lang);
 	return {
 		title: appendBrand(tr.subjectHome.notFound, tr.seo.siteName),
 		description: tr.seo.defaultDescription,
 	};
 }
 
-export function buildSubjectMeta(
+export async function buildSubjectMeta(
 	lang: Lang,
 	subject: SubjectMeta,
 	stats: SubjectStats = {},
-): PageMetaData {
-	const tr = t(lang);
+): Promise<PageMetaData> {
+	const tr = await t(lang);
 	const pathWithoutLang = `/${subject.id}`;
 	const availableExamCount = subject.exams.filter(
 		(exam) => !exam.deleteRights,
@@ -317,13 +314,13 @@ export function buildSubjectMeta(
 	);
 }
 
-export function buildTopicMeta(
+export async function buildTopicMeta(
 	lang: Lang,
 	subject: SubjectMeta,
 	topic: Topic,
 	stats: SubjectStats = {},
-): PageMetaData {
-	const tr = t(lang);
+): Promise<PageMetaData> {
+	const tr = await t(lang);
 	const pathWithoutLang = `/${subject.id}/practice/${topic.key}`;
 	const count = stats.topicQuestionCounts?.[topic.key];
 	const questionLabel =
@@ -402,13 +399,13 @@ export function buildTopicMeta(
 	);
 }
 
-export function buildExamMeta(
+export async function buildExamMeta(
 	lang: Lang,
 	subject: SubjectMeta,
 	exam: Exam,
 	stats: SubjectStats = {},
-): PageMetaData {
-	const tr = t(lang);
+): Promise<PageMetaData> {
+	const tr = await t(lang);
 	const pathWithoutLang = `/${subject.id}/exam/${exam.id}`;
 	const count = stats.examQuestionCounts?.[exam.id];
 	const hasAuthorizedExams = hasAuthorizedExamContent(subject);

--- a/src/seo/translation-types.ts
+++ b/src/seo/translation-types.ts
@@ -1,0 +1,49 @@
+export interface Faq {
+	question: string;
+	answer: string;
+}
+
+export interface SeoTranslations {
+	home: {
+		faqTitle: string;
+		faqs: readonly Faq[];
+	};
+	subjectHome: {
+		notFound: string;
+	};
+	footer: {
+		privacyTitle: string;
+	};
+	seo: {
+		siteName: string;
+		questionSingular: string;
+		questionPlural: string;
+		examSingular: string;
+		examPlural: string;
+		compilationSingular: string;
+		compilationPlural: string;
+		privacyMetaDescription: string;
+		homeTitle: string;
+		homeMetaDescription: string;
+		defaultDescription: string;
+		subjectAuthorizedTitle: string;
+		subjectCommunityTitle: string;
+		subjectAuthorizedDescription: string;
+		subjectCommunityDescription: string;
+		topicAuthorizedTitle: string;
+		topicCommunityTitle: string;
+		topicAuthorizedDescription: string;
+		topicCommunityDescription: string;
+		topicAuthorizedDescriptionShort: string;
+		topicCommunityDescriptionShort: string;
+		examAuthorizedTitle: string;
+		examPracticeTitle: string;
+		examAuthorizedShortTitle: string;
+		examPracticeShortTitle: string;
+		examAuthorizedDescription: string;
+		examPracticeDescription: string;
+		examAuthorizedDescriptionShort: string;
+		examPracticeDescriptionShort: string;
+		questionCountSuffix: string;
+	};
+}

--- a/src/seo/translations.ts
+++ b/src/seo/translations.ts
@@ -1,0 +1,24 @@
+import type { Lang } from "../i18n/context-value";
+import type { SeoTranslations } from "./translation-types";
+
+type SeoTranslationLoader = () => Promise<SeoTranslations>;
+
+const seoTranslationLoaders: Record<Lang, SeoTranslationLoader> = {
+	en: () =>
+		import("./translations/en").then(({ seoTranslations }) => seoTranslations),
+	es: () =>
+		import("./translations/es").then(({ seoTranslations }) => seoTranslations),
+	gl: () =>
+		import("./translations/gl").then(({ seoTranslations }) => seoTranslations),
+};
+
+const seoTranslationPromises = new Map<Lang, Promise<SeoTranslations>>();
+
+export function loadSeoTranslations(lang: Lang): Promise<SeoTranslations> {
+	const existingPromise = seoTranslationPromises.get(lang);
+	if (existingPromise) return existingPromise;
+
+	const promise = seoTranslationLoaders[lang]();
+	seoTranslationPromises.set(lang, promise);
+	return promise;
+}

--- a/src/seo/translations/en.ts
+++ b/src/seo/translations/en.ts
@@ -1,0 +1,110 @@
+import type { SeoTranslations } from "../translation-types";
+
+export const seoTranslations = {
+	home: {
+		faqTitle: "Frequently asked questions",
+		faqs: [
+			{
+				question: "What will I find on Pásame Exámenes?",
+				answer:
+					"Pásame Exámenes is an open-source platform for practicing questions from degree subjects at the Faculty of Computer Science of A Coruña (FIC), organized by topic and timed sessions.",
+			},
+			{
+				question: "How do I start practicing a subject?",
+				answer:
+					"Open a subject card, then choose a topic, practice set, or exam from its page.",
+			},
+			{
+				question: "What's the difference between topic practice and an exam?",
+				answer:
+					"Topic practice focuses on one part of the syllabus. Exam mode and timed practice simulate a complete session with a time limit.",
+			},
+			{
+				question: "Which question formats can I practice?",
+				answer:
+					"You can practice multiple-choice, text, matching, fill-in-the-blank, and multi-part questions. Multiple-choice and matching questions are graded automatically; open-ended questions are self-graded with help from the model answer.",
+			},
+			{
+				question: "What are model answers for?",
+				answer:
+					"They are reference solutions that help you review and assess your answers. They come from original materials or from people who contribute to the project.",
+			},
+			{
+				question: "Where is my progress stored?",
+				answer:
+					"The site stores your progress, attempts, preferences, and recently visited subjects in your browser's local storage. You do not need an account, but the data is not synced between devices and is removed when you clear this site's data.",
+			},
+			{
+				question: "Why do some questions repeat?",
+				answer:
+					"A question may repeat or closely resemble one from another exam session or compilation. The app marks these matches so you can see how much of the syllabus you are covering. We try to detect them accurately, but some may go unnoticed.",
+			},
+			{
+				question: "How are the questions and documents sourced?",
+				answer:
+					"Each subject page lists its sources. Some use authorized exams, while others use compilations or community materials. If a PDF or original material is available, we link it from the relevant page with its licensing information. Questions are extracted automatically, so errors are possible. If you find one, report it so we can fix it.",
+			},
+			{
+				question: "How reliable are the answers?",
+				answer:
+					"We review and correct answers continuously. If you spot an error, report it from the question so we can fix it. Unlike Daypo tests or compilations uploaded to Wuolah, errors here can be corrected. We have already reviewed many answers from well-known compilations. Linus's Law sums it up: with enough people looking, errors eventually surface.",
+			},
+			{
+				question: "Who is behind the project?",
+				answer:
+					"I'm Pablo Portas López, and I maintain the project with help from everyone who wants to contribute. I built this website to offer a more current, transparent, ad-free, open-source way to prepare for exams. I hope you find it useful.",
+			},
+		],
+	},
+	subjectHome: {
+		notFound: "Subject Not Found",
+	},
+	footer: {
+		privacyTitle: "Privacy Policy",
+	},
+	seo: {
+		siteName: "Pásame Exámenes",
+		questionSingular: "question",
+		questionPlural: "questions",
+		examSingular: "exam",
+		examPlural: "exams",
+		compilationSingular: "compilation",
+		compilationPlural: "compilations",
+		privacyMetaDescription:
+			"This page describes the types of data Pásame Exámenes collects and how and where that data is processed.",
+		homeTitle: "Practice FIC Exam Questions by Topic",
+		homeMetaDescription:
+			"Practice FIC exam questions by topic or in timed sets. Check your answers, review model solutions, and prepare for exams.",
+		defaultDescription:
+			"Practice FIC exam questions with self-grading and model solutions. Choose a topic or timed set and start studying.",
+		subjectAuthorizedTitle: "{subjectName}: exam questions",
+		subjectCommunityTitle: "{subjectName}: compilations",
+		subjectAuthorizedDescription:
+			"Practice {count}{subjectName} {questionLabel} from {examCount} {examLabel}. Check your answers and review model solutions.",
+		subjectCommunityDescription:
+			"Practice {count}{subjectName} {questionLabel} from {examCount} {compilationLabel}. Check your answers and review model solutions.",
+		topicAuthorizedTitle: "{topicName}: {subjectName}",
+		topicCommunityTitle: "{topicName}: {subjectName}",
+		topicAuthorizedDescription:
+			"Practice {count}{topicName} {questionLabel} from {subjectName}. Review model answers.",
+		topicCommunityDescription:
+			"Practice {count}{topicName} {questionLabel} from {subjectName}. Review model answers.",
+		topicAuthorizedDescriptionShort:
+			"Practice {count}{topicName} {questionLabel}. Review model answers.",
+		topicCommunityDescriptionShort:
+			"Practice {count}{topicName} {questionLabel}. Review model answers.",
+		examAuthorizedTitle: "{examName}: {subjectName} | simulator",
+		examPracticeTitle: "{examName}: {subjectName} | practice",
+		examAuthorizedShortTitle: "{examName}: simulator",
+		examPracticeShortTitle: "{examName}: practice",
+		examAuthorizedDescription:
+			"Practice the {examName} {subjectName} exam{questionCount}. It lasts {durationMinutes} minutes and includes model answers.",
+		examPracticeDescription:
+			"Practice the {examName} {subjectName} compilation{questionCount}. It lasts {durationMinutes} minutes and includes model answers.",
+		examAuthorizedDescriptionShort:
+			"Practice the {examName} exam{questionCount}. It lasts {durationMinutes} minutes and includes model answers.",
+		examPracticeDescriptionShort:
+			"Practice the {examName} compilation{questionCount}. It lasts {durationMinutes} minutes and includes model answers.",
+		questionCountSuffix: " with {count} {questionLabel}",
+	},
+} as const satisfies SeoTranslations;

--- a/src/seo/translations/es.ts
+++ b/src/seo/translations/es.ts
@@ -1,0 +1,110 @@
+import type { SeoTranslations } from "../translation-types";
+
+export const seoTranslations = {
+	home: {
+		faqTitle: "Preguntas frecuentes",
+		faqs: [
+			{
+				question: "¿Qué encontrarás en Pásame Exámenes?",
+				answer:
+					"Pásame Exámenes es una plataforma de código abierto para practicar preguntas de las asignaturas de los grados de la Facultade de Informática da Coruña (FIC), organizadas por temas y sesiones cronometradas.",
+			},
+			{
+				question: "¿Cómo empiezo a practicar una asignatura?",
+				answer:
+					"Abre la tarjeta de una asignatura y elige un tema, una práctica o un examen desde su página.",
+			},
+			{
+				question: "¿Practicar por tema o hacer un examen?",
+				answer:
+					"La práctica por tema se centra en un bloque concreto. El modo examen y la práctica cronometrada simulan una sesión completa con tiempo limitado.",
+			},
+			{
+				question: "¿Qué formatos de preguntas puedo practicar?",
+				answer:
+					"Puedes practicar preguntas tipo test, de texto, de emparejamiento, de rellenar huecos y con varias partes. Las de test y emparejamiento se corrigen automáticamente; las preguntas abiertas se autoevalúan con ayuda de la respuesta modelo.",
+			},
+			{
+				question: "¿Para qué sirven las respuestas modelo?",
+				answer:
+					"Son soluciones de referencia que te ayudan a revisar y valorar tus respuestas. Proceden de materiales originales o de las aportaciones de personas colaboradoras.",
+			},
+			{
+				question: "¿Dónde se guarda mi progreso?",
+				answer:
+					"La web guarda el progreso, los intentos, las preferencias y las asignaturas visitadas en el almacenamiento local de tu navegador. No necesitas una cuenta, pero los datos no se sincronizan entre dispositivos y desaparecen al borrar los datos de este sitio.",
+			},
+			{
+				question: "¿Por qué se repiten algunas preguntas?",
+				answer:
+					"Una pregunta puede repetirse o parecerse mucho a otra de distintas convocatorias o recopilatorios. La aplicación marca estas coincidencias para que sepas cuánto del temario estás cubriendo. Intentamos detectarlas con precisión, aunque alguna puede pasar desapercibida.",
+			},
+			{
+				question: "¿Cuál es el origen de las preguntas y los documentos?",
+				answer:
+					"La página de cada asignatura indica sus fuentes. Algunas usan exámenes autorizados y otras recopilatorios o materiales comunitarios. Si hay un PDF o material original, lo enlazamos desde la página correspondiente con su información de licencia. Las preguntas se extraen automáticamente, por lo que pueden contener errores. Si encuentras uno, repórtalo para que podamos corregirlo.",
+			},
+			{
+				question: "¿Hasta qué punto son fiables las respuestas?",
+				answer:
+					"Revisamos y corregimos las respuestas de forma continua. Si detectas un error, repórtalo desde la pregunta para que podamos solucionarlo. A diferencia de los tests de Daypo o de los recopilatorios subidos a Wuolah, aquí los errores se pueden corregir. Ya hemos revisado muchas respuestas de recopilatorios conocidos. La ley de Linus resume la idea: con suficientes personas revisando, los errores acaban por aparecer.",
+			},
+			{
+				question: "¿Quién está detrás del proyecto?",
+				answer:
+					"Soy Pablo Portas López y mantengo el proyecto con la ayuda de todas las personas que quieren colaborar. Creé esta web para ofrecer una forma más actual, transparente, sin anuncios y de código abierto de preparar los exámenes. Espero que te resulte útil.",
+			},
+		],
+	},
+	subjectHome: {
+		notFound: "Asignatura no encontrada",
+	},
+	footer: {
+		privacyTitle: "Política de privacidad",
+	},
+	seo: {
+		siteName: "Pásame Exámenes",
+		questionSingular: "pregunta",
+		questionPlural: "preguntas",
+		examSingular: "examen",
+		examPlural: "exámenes",
+		compilationSingular: "recopilatorio",
+		compilationPlural: "recopilatorios",
+		privacyMetaDescription:
+			"Aquí se describen los tipos de datos que Pásame Exámenes recopila y la forma y el lugar del tratamiento de dichos datos.",
+		homeTitle: "Practica preguntas de exámenes de la FIC",
+		homeMetaDescription:
+			"Practica preguntas de exámenes de la FIC por tema o con simulacros cronometrados. Comprueba tus respuestas y consulta soluciones modelo.",
+		defaultDescription:
+			"Practica preguntas de exámenes de la FIC con autocorrección y soluciones modelo. Elige un tema o un simulacro y empieza a estudiar.",
+		subjectAuthorizedTitle: "{subjectName}: preguntas de examen",
+		subjectCommunityTitle: "{subjectName}: recopilatorios",
+		subjectAuthorizedDescription:
+			"Practica {count}{questionLabel} de {subjectName} de {examCount} {examLabel}. Comprueba tus respuestas y consulta soluciones modelo.",
+		subjectCommunityDescription:
+			"Practica {count}{questionLabel} de {subjectName} de {examCount} {compilationLabel}. Comprueba tus respuestas y consulta soluciones modelo.",
+		topicAuthorizedTitle: "{topicName}: {subjectName}",
+		topicCommunityTitle: "{topicName}: {subjectName}",
+		topicAuthorizedDescription:
+			"Practica {count}{questionLabel} de {topicName} de {subjectName}. Revisa las respuestas modelo.",
+		topicCommunityDescription:
+			"Practica {count}{questionLabel} de {topicName} de {subjectName}. Revisa las respuestas modelo.",
+		topicAuthorizedDescriptionShort:
+			"Practica {count}{questionLabel} de {topicName}. Revisa las respuestas modelo.",
+		topicCommunityDescriptionShort:
+			"Practica {count}{questionLabel} de {topicName}. Revisa las respuestas modelo.",
+		examAuthorizedTitle: "{examName}: {subjectName} | simulador",
+		examPracticeTitle: "{examName}: {subjectName} | práctica",
+		examAuthorizedShortTitle: "{examName}: simulador",
+		examPracticeShortTitle: "{examName}: práctica",
+		examAuthorizedDescription:
+			"Practica el examen {examName} de {subjectName}{questionCount}. Dura {durationMinutes} minutos e incluye respuestas modelo.",
+		examPracticeDescription:
+			"Practica el recopilatorio {examName} de {subjectName}{questionCount}. Dura {durationMinutes} minutos e incluye respuestas modelo.",
+		examAuthorizedDescriptionShort:
+			"Practica el examen {examName}{questionCount}. Dura {durationMinutes} minutos e incluye respuestas modelo.",
+		examPracticeDescriptionShort:
+			"Practica el recopilatorio {examName}{questionCount}. Dura {durationMinutes} minutos e incluye respuestas modelo.",
+		questionCountSuffix: " con {count} {questionLabel}",
+	},
+} as const satisfies SeoTranslations;

--- a/src/seo/translations/gl.ts
+++ b/src/seo/translations/gl.ts
@@ -1,0 +1,111 @@
+import type { SeoTranslations } from "../translation-types";
+
+export const seoTranslations = {
+	home: {
+		faqTitle: "Preguntas frecuentes",
+		faqs: [
+			{
+				question: "Que podes atopar en Pásame Exámenes?",
+				answer:
+					"Pásame Exámenes é unha plataforma de código aberto para practicar preguntas das materias dos graos da Facultade de Informática da Coruña (FIC), organizadas por temas e sesións cronometradas.",
+			},
+			{
+				question: "Como comezo a practicar unha materia?",
+				answer:
+					"Abre a tarxeta dunha materia e escolle un tema, unha práctica ou un exame desde a súa páxina.",
+			},
+			{
+				question:
+					"Que diferenza hai entre practicar por tema e facer un exame?",
+				answer:
+					"A práctica por tema céntrase nun bloque concreto. O modo exame e a práctica cronometrada simulan unha sesión completa cun tempo limitado.",
+			},
+			{
+				question: "Que formatos de preguntas podo practicar?",
+				answer:
+					"Podes practicar preguntas tipo test, de texto, de emparellamento, de encher ocos e con varias partes. As de test e emparellamento corríxense automaticamente; as preguntas abertas autoavalíanse coa axuda da resposta modelo.",
+			},
+			{
+				question: "Para que serven as respostas modelo?",
+				answer:
+					"Son solucións de referencia que che axudan a revisar e valorar as túas respostas. Proceden de materiais orixinais ou das achegas das persoas colaboradoras.",
+			},
+			{
+				question: "Onde se garda o meu progreso?",
+				answer:
+					"A web garda o progreso, os intentos, as preferencias e as materias visitadas no almacenamento local do teu navegador. Non necesitas unha conta, pero os datos non se sincronizan entre dispositivos e desaparecen ao borrar os datos deste sitio.",
+			},
+			{
+				question: "Por que se repiten algunhas preguntas?",
+				answer:
+					"Unha pregunta pode repetirse ou parecerse moito a outra de distintas convocatorias ou recompilacións. A aplicación marca estas coincidencias para que saibas canto do temario estás cubrindo. Tentamos detectalas con precisión, aínda que algunha pode pasar desapercibida.",
+			},
+			{
+				question: "Cal é a orixe das preguntas e dos documentos?",
+				answer:
+					"A páxina de cada materia indica as súas fontes. Algunhas usan exames autorizados e outras recompilacións ou materiais comunitarios. Se hai un PDF ou material orixinal, enlazámolo desde a páxina correspondente coa súa información de licenza. As preguntas extráense automaticamente, polo que poden conter erros. Se atopas un, repórtao para que poidamos corrixilo.",
+			},
+			{
+				question: "Que fiabilidade teñen as respostas?",
+				answer:
+					"Revisamos e corriximos as respostas de forma continua. Se detectas un erro, repórtao desde a pregunta para que poidamos solucionalo. A diferenza dos tests de Daypo ou das recompilacións subidas a Wuolah, aquí os erros pódense corrixir. Xa revisamos moitas respostas de recompilacións coñecidas. A lei de Linus resume a idea: con suficientes persoas revisando, os erros acaban por aparecer.",
+			},
+			{
+				question: "Quen está detrás do proxecto?",
+				answer:
+					"Son Pablo Portas López e manteño o proxecto coa axuda de todas as persoas que queren colaborar. Creei esta web para ofrecer unha forma máis actual, transparente, sen anuncios e de código aberto de preparar os exames. Espero que che sexa útil.",
+			},
+		],
+	},
+	subjectHome: {
+		notFound: "Materia non atopada",
+	},
+	footer: {
+		privacyTitle: "Política de privacidade",
+	},
+	seo: {
+		siteName: "Pásame Exámenes",
+		questionSingular: "pregunta",
+		questionPlural: "preguntas",
+		examSingular: "exame",
+		examPlural: "exames",
+		compilationSingular: "recompilación",
+		compilationPlural: "recompilacións",
+		privacyMetaDescription:
+			"Aquí descríbense os tipos de datos que Pásame Exámenes recompila e a forma e o lugar do tratamento destes datos.",
+		homeTitle: "Practica preguntas de exames da FIC",
+		homeMetaDescription:
+			"Practica preguntas de exames da FIC por tema ou con simulacións cronometradas. Comproba as túas respostas e consulta solucións modelo.",
+		defaultDescription:
+			"Practica preguntas de exames da FIC con autocorrección e solucións modelo. Escolle un tema ou unha simulación e comeza a estudar.",
+		subjectAuthorizedTitle: "{subjectName}: preguntas de exame",
+		subjectCommunityTitle: "{subjectName}: recompilacións",
+		subjectAuthorizedDescription:
+			"Practica {count}{questionLabel} de {subjectName} de {examCount} {examLabel}. Comproba as túas respostas e consulta solucións modelo.",
+		subjectCommunityDescription:
+			"Practica {count}{questionLabel} de {subjectName} de {examCount} {compilationLabel}. Comproba as túas respostas e consulta solucións modelo.",
+		topicAuthorizedTitle: "{topicName}: {subjectName}",
+		topicCommunityTitle: "{topicName}: {subjectName}",
+		topicAuthorizedDescription:
+			"Practica {count}{questionLabel} de {topicName} de {subjectName}. Consulta respostas modelo.",
+		topicCommunityDescription:
+			"Practica {count}{questionLabel} de {topicName} de {subjectName}. Consulta respostas modelo.",
+		topicAuthorizedDescriptionShort:
+			"Practica {count}{questionLabel} de {topicName}. Consulta respostas modelo.",
+		topicCommunityDescriptionShort:
+			"Practica {count}{questionLabel} de {topicName}. Consulta respostas modelo.",
+		examAuthorizedTitle: "{examName}: {subjectName} | simulador",
+		examPracticeTitle: "{examName}: {subjectName} | práctica",
+		examAuthorizedShortTitle: "{examName}: simulador",
+		examPracticeShortTitle: "{examName}: práctica",
+		examAuthorizedDescription:
+			"Practica o exame {examName} de {subjectName}{questionCount}. Dura {durationMinutes} minutos e inclúe respostas modelo.",
+		examPracticeDescription:
+			"Practica a recompilación {examName} de {subjectName}{questionCount}. Dura {durationMinutes} minutos e inclúe respostas modelo.",
+		examAuthorizedDescriptionShort:
+			"Practica o exame {examName}{questionCount}. Dura {durationMinutes} minutos e inclúe respostas modelo.",
+		examPracticeDescriptionShort:
+			"Practica a recompilación {examName}{questionCount}. Dura {durationMinutes} minutos e inclúe respostas modelo.",
+		questionCountSuffix: " con {count} {questionLabel}",
+	},
+} as const satisfies SeoTranslations;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,645 +1,674 @@
-/* Fontsource emits the @font-face rules with font-display: swap. Keep the
-   font CSS in the application stylesheet so it follows the same load path. */
-@import "@fontsource-variable/cascadia-code";
-@import "@fontsource-variable/onest";
+/* Keep the two application font faces in the main stylesheet so Vite emits
+   their selected Latin files with the same load path as the rest of the CSS. */
 @import "tailwindcss";
 @import "tailwind-animations";
-@plugin "@tailwindcss/typography";
+
+/* The app uses Western European Latin text in both families. Keep the
+   variable fonts to one normal Latin face so the browser can select every
+   used weight without shipping unused scripts or an italic file. */
+@font-face {
+    font-family: "Cascadia Code Variable";
+    font-style: normal;
+    font-display: swap;
+    font-weight: 200 700;
+    src: url("@fontsource-variable/cascadia-code/files/cascadia-code-latin-wght-normal.woff2")
+        format("woff2-variations");
+    unicode-range:
+        U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+        U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193,
+        U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+    font-family: "Onest Variable";
+    font-style: normal;
+    font-display: swap;
+    font-weight: 100 900;
+    src: url("@fontsource-variable/onest/files/onest-latin-wght-normal.woff2")
+        format("woff2-variations");
+    unicode-range:
+        U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+        U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193,
+        U+2212, U+2215, U+FEFF, U+FFFD;
+}
 
 html {
-  scroll-behavior: smooth;
-  color-scheme: light dark;
-  accent-color: var(--color-accent);
-  caret-color: var(--color-accent);
-  min-height: 100%;
-  overscroll-behavior: none;
-  -webkit-tap-highlight-color: transparent;
+    scroll-behavior: smooth;
+    color-scheme: light dark;
+    accent-color: var(--color-accent);
+    caret-color: var(--color-accent);
+    min-height: 100%;
+    overscroll-behavior: none;
+    -webkit-tap-highlight-color: transparent;
 }
 
 html[data-theme="light"] {
-  color-scheme: light;
+    color-scheme: light;
 }
 
 html[data-theme="dark"] {
-  color-scheme: dark;
+    color-scheme: dark;
 }
 
 html[data-theme="princess"] {
-  color-scheme: light;
+    color-scheme: light;
 }
 
 html[data-theme="latte"] {
-  color-scheme: light;
+    color-scheme: light;
 }
 
 html[data-theme="frappe"],
 html[data-theme="macchiato"],
 html[data-theme="mocha"] {
-  color-scheme: dark;
+    color-scheme: dark;
 }
 
 html[data-theme="system"] {
-  color-scheme: light dark;
+    color-scheme: light dark;
 }
 
 .question-card-brand-mark {
-  mask: url("/mono-favicon.svg") center / contain no-repeat;
-  -webkit-mask: url("/mono-favicon.svg") center / contain no-repeat;
+    mask: url("/mono-favicon.svg") center / contain no-repeat;
+    -webkit-mask: url("/mono-favicon.svg") center / contain no-repeat;
 }
 
 .footer-github-icon {
-  display: inline-block;
-  width: 1rem;
-  height: 1rem;
-  flex-shrink: 0;
-  background-color: currentColor;
-  mask: url("/github-icon.svg") center / contain no-repeat;
-  -webkit-mask: url("/github-icon.svg") center / contain no-repeat;
+    display: inline-block;
+    width: 1rem;
+    height: 1rem;
+    flex-shrink: 0;
+    background-color: currentColor;
+    mask: url("/github-icon.svg") center / contain no-repeat;
+    -webkit-mask: url("/github-icon.svg") center / contain no-repeat;
 }
 
 /* ── iOS safe-area / overscroll helpers ── */
 html,
 body {
-  /* Match the header/footer surface so the Safari toolbar/safe-area background
+    /* Match the header/footer surface so the Safari toolbar/safe-area background
      has the same color as the surrounding chrome. Safari 26 no longer uses
      `theme-color` for this surface, so keep the value updated on <html>. */
-  background-color: var(--browser-chrome-color, var(--color-surface-alt));
-  min-height: 100%;
-  overscroll-behavior: none;
+    background-color: var(--browser-chrome-color, var(--color-surface-alt));
+    min-height: 100%;
+    overscroll-behavior: none;
 }
 
 /* ── Mobile interaction defaults ──
    Keep native scrolling and text selection where they are useful, while
    making controls respond immediately and avoiding iOS's input zoom. */
 :where(button, a, [role="button"]) {
-  -webkit-tap-highlight-color: transparent;
-  touch-action: manipulation;
+    -webkit-tap-highlight-color: transparent;
+    touch-action: manipulation;
 }
 
 :where(button, [role="button"]) {
-  user-select: none;
-  -webkit-user-select: none;
+    user-select: none;
+    -webkit-user-select: none;
 }
 
 /* ── FAQ disclosures ── */
 .faq-summary {
-  -webkit-user-select: none;
-  user-select: none;
+    -webkit-user-select: none;
+    user-select: none;
 }
 
 .faq-summary::-webkit-details-marker {
-  display: none;
+    display: none;
 }
 
 .faq-chevron {
-  transition: transform 0.2s ease-out;
+    transition: transform 0.2s ease-out;
 }
 
 .faq-item[open] .faq-chevron {
-  transform: rotate(180deg);
+    transform: rotate(180deg);
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .faq-chevron {
-    transition: none;
-  }
+    .faq-chevron {
+        transition: none;
+    }
 }
 
 :is(
-  textarea,
-  select,
-  input[type="text"],
-  input[type="search"],
-  input[type="email"],
-  input[type="url"],
-  input[type="tel"],
-  input[type="number"],
-  input[type="password"]
+    textarea,
+    select,
+    input[type="text"],
+    input[type="search"],
+    input[type="email"],
+    input[type="url"],
+    input[type="tel"],
+    input[type="number"],
+    input[type="password"]
 ) {
-  /* iOS zooms focused controls below 16px, even when the page is otherwise
+    /* iOS zooms focused controls below 16px, even when the page is otherwise
      correctly configured. */
-  font-size: 1rem;
+    font-size: 1rem;
 }
 
 @media (pointer: coarse) {
-  :where(button, a, [role="button"]):active:not(:disabled) {
-    opacity: 0.88;
-  }
+    :where(button, a, [role="button"]):active:not(:disabled) {
+        opacity: 0.88;
+    }
 }
 
 /* Keep the question index a native two-axis touch surface so mobile browsers
    can provide their normal horizontal momentum and vertical page scrolling. */
 .question-nav-scroll {
-  touch-action: pan-x pan-y;
-  overscroll-behavior-x: contain;
+    touch-action: pan-x pan-y;
+    overscroll-behavior-x: contain;
 }
 
 .safe-area-top {
-  padding-block-start: env(safe-area-inset-top);
+    padding-block-start: env(safe-area-inset-top);
 }
 
 .sticky-player-header {
-  top: env(safe-area-inset-top);
+    top: env(safe-area-inset-top);
 }
 
 @media (min-width: 640px) {
-  .sticky-player-header {
-    top: 3.5rem;
-  }
+    .sticky-player-header {
+        top: 3.5rem;
+    }
 }
 
 /* ── Semantic theme tokens ──
    Values are authored in OKLCH. `light-dark()` keeps the contract in one
    place while the `data-theme` attribute controls the browser appearance. */
 @theme {
-  --font-sans: "Onest Variable", sans-serif;
-  --font-mono: "Cascadia Code Variable", monospace;
-  --color-surface: light-dark(
-    oklch(0.985 0.002 247.839),
-    oklch(0.21 0.032 264.665)
-  );
-  --color-surface-alt: light-dark(oklch(1 0 0), oklch(0.278 0.03 256.848));
-  --color-fg: light-dark(oklch(0.21 0.032 264.665), oklch(0.985 0.002 247.839));
-  --color-fg-secondary: light-dark(
-    oklch(0.446 0.026 256.802),
-    oklch(0.872 0.009 258.338)
-  );
-  --color-fg-muted: light-dark(
-    oklch(0.526 0.026 260.676),
-    oklch(0.714 0.019 261.325)
-  );
-  --color-border: light-dark(
-    oklch(0.928 0.006 264.531),
-    oklch(0.373 0.031 259.733)
-  );
-  --color-card-footer: light-dark(
-    oklch(0.965 0.008 264.531),
-    oklch(0.295 0.03 259.733)
-  );
-  --color-card-footer-border: light-dark(
-    oklch(0.9 0.01 264.531),
-    oklch(0.405 0.035 259.733)
-  );
+    --font-sans: "Onest Variable", sans-serif;
+    --font-mono: "Cascadia Code Variable", monospace;
+    --color-surface: light-dark(
+        oklch(0.985 0.002 247.839),
+        oklch(0.21 0.032 264.665)
+    );
+    --color-surface-alt: light-dark(oklch(1 0 0), oklch(0.278 0.03 256.848));
+    --color-fg: light-dark(
+        oklch(0.21 0.032 264.665),
+        oklch(0.985 0.002 247.839)
+    );
+    --color-fg-secondary: light-dark(
+        oklch(0.446 0.026 256.802),
+        oklch(0.872 0.009 258.338)
+    );
+    --color-fg-muted: light-dark(
+        oklch(0.526 0.026 260.676),
+        oklch(0.714 0.019 261.325)
+    );
+    --color-border: light-dark(
+        oklch(0.928 0.006 264.531),
+        oklch(0.373 0.031 259.733)
+    );
+    --color-card-footer: light-dark(
+        oklch(0.965 0.008 264.531),
+        oklch(0.295 0.03 259.733)
+    );
+    --color-card-footer-border: light-dark(
+        oklch(0.9 0.01 264.531),
+        oklch(0.405 0.035 259.733)
+    );
 
-  /* Accent has separate contracts for solid controls, links and hover. */
-  --color-accent: light-dark(
-    oklch(0.527 0.137 150.069),
-    oklch(0.723 0.192 149.579)
-  );
-  --color-on-accent: light-dark(oklch(1 0 0), oklch(0.266 0.063 152.934));
-  --color-accent-light: light-dark(
-    oklch(0.982 0.018 155.826),
-    oklch(0.266 0.063 152.934)
-  );
-  --color-accent-fg: light-dark(
-    oklch(0.448 0.108 151.328),
-    oklch(0.871 0.136 154.449)
-  );
-  --color-accent-hover: light-dark(
-    oklch(0.448 0.108 151.328),
-    oklch(0.8 0.182 151.711)
-  );
-  --color-accent-border: light-dark(
-    oklch(0.925 0.081 155.995),
-    oklch(0.448 0.108 151.328)
-  );
+    /* Accent has separate contracts for solid controls, links and hover. */
+    --color-accent: light-dark(
+        oklch(0.527 0.137 150.069),
+        oklch(0.723 0.192 149.579)
+    );
+    --color-on-accent: light-dark(oklch(1 0 0), oklch(0.266 0.063 152.934));
+    --color-accent-light: light-dark(
+        oklch(0.982 0.018 155.826),
+        oklch(0.266 0.063 152.934)
+    );
+    --color-accent-fg: light-dark(
+        oklch(0.448 0.108 151.328),
+        oklch(0.871 0.136 154.449)
+    );
+    --color-accent-hover: light-dark(
+        oklch(0.448 0.108 151.328),
+        oklch(0.8 0.182 151.711)
+    );
+    --color-accent-border: light-dark(
+        oklch(0.925 0.081 155.995),
+        oklch(0.448 0.108 151.328)
+    );
 
-  /* Code surfaces and syntax roles. */
-  --color-code: light-dark(
-    oklch(0.967 0.003 264.542),
-    oklch(0.373 0.031 259.733)
-  );
-  --color-code-fg: light-dark(
-    oklch(0.21 0.032 264.665),
-    oklch(0.985 0.002 247.839)
-  );
-  --color-code-block: light-dark(
-    oklch(0.967 0.003 264.542),
-    oklch(0.13 0.027 261.692)
-  );
-  --color-code-block-fg: light-dark(
-    oklch(0.21 0.032 264.665),
-    oklch(0.985 0.002 247.839)
-  );
-  --color-code-comment: light-dark(
-    oklch(0.446 0.026 256.802),
-    oklch(0.714 0.019 261.325)
-  );
-  --color-code-punctuation: light-dark(
-    oklch(0.446 0.026 256.802),
-    oklch(0.872 0.009 258.338)
-  );
-  --color-code-keyword: light-dark(
-    oklch(0.457 0.215 277.023),
-    oklch(0.785 0.104 274.713)
-  );
-  --color-code-string: light-dark(
-    oklch(0.448 0.108 151.328),
-    oklch(0.871 0.136 154.449)
-  );
-  --color-code-number: light-dark(
-    oklch(0.553 0.174 38.402),
-    oklch(0.837 0.117 66.29)
-  );
-  --color-code-function: light-dark(
-    oklch(0.488 0.217 264.376),
-    oklch(0.809 0.096 251.813)
-  );
-  --color-code-operator: light-dark(
-    oklch(0.505 0.19 27.518),
-    oklch(0.808 0.103 19.571)
-  );
-  --color-code-property: light-dark(
-    oklch(0.52 0.094 223.128),
-    oklch(0.865 0.115 207.078)
-  );
-  --color-code-class: light-dark(
-    oklch(0.496 0.237 301.924),
-    oklch(0.827 0.108 306.383)
-  );
+    /* Code surfaces and syntax roles. */
+    --color-code: light-dark(
+        oklch(0.967 0.003 264.542),
+        oklch(0.373 0.031 259.733)
+    );
+    --color-code-fg: light-dark(
+        oklch(0.21 0.032 264.665),
+        oklch(0.985 0.002 247.839)
+    );
+    --color-code-block: light-dark(
+        oklch(0.967 0.003 264.542),
+        oklch(0.13 0.027 261.692)
+    );
+    --color-code-block-fg: light-dark(
+        oklch(0.21 0.032 264.665),
+        oklch(0.985 0.002 247.839)
+    );
+    --color-code-comment: light-dark(
+        oklch(0.446 0.026 256.802),
+        oklch(0.714 0.019 261.325)
+    );
+    --color-code-punctuation: light-dark(
+        oklch(0.446 0.026 256.802),
+        oklch(0.872 0.009 258.338)
+    );
+    --color-code-keyword: light-dark(
+        oklch(0.457 0.215 277.023),
+        oklch(0.785 0.104 274.713)
+    );
+    --color-code-string: light-dark(
+        oklch(0.448 0.108 151.328),
+        oklch(0.871 0.136 154.449)
+    );
+    --color-code-number: light-dark(
+        oklch(0.553 0.174 38.402),
+        oklch(0.837 0.117 66.29)
+    );
+    --color-code-function: light-dark(
+        oklch(0.488 0.217 264.376),
+        oklch(0.809 0.096 251.813)
+    );
+    --color-code-operator: light-dark(
+        oklch(0.505 0.19 27.518),
+        oklch(0.808 0.103 19.571)
+    );
+    --color-code-property: light-dark(
+        oklch(0.52 0.094 223.128),
+        oklch(0.865 0.115 207.078)
+    );
+    --color-code-class: light-dark(
+        oklch(0.496 0.237 301.924),
+        oklch(0.827 0.108 306.383)
+    );
 
-  /* Informational, destructive, reward and warning states. */
-  --color-info: light-dark(
-    oklch(0.488 0.217 264.376),
-    oklch(0.809 0.096 251.813)
-  );
-  --color-on-info: light-dark(oklch(1 0 0), oklch(0.282 0.087 267.935));
-  --color-info-hover: light-dark(
-    oklch(0.424 0.181 265.638),
-    oklch(0.882 0.057 254.128)
-  );
-  --color-info-light: light-dark(
-    oklch(0.97 0.014 254.604),
-    oklch(0.282 0.087 267.935)
-  );
-  --color-info-fg: light-dark(
-    oklch(0.424 0.181 265.638),
-    oklch(0.809 0.096 251.813)
-  );
-  --color-info-border: light-dark(
-    oklch(0.882 0.057 254.128),
-    oklch(0.379 0.138 265.522)
-  );
+    /* Informational, destructive, reward and warning states. */
+    --color-info: light-dark(
+        oklch(0.488 0.217 264.376),
+        oklch(0.809 0.096 251.813)
+    );
+    --color-on-info: light-dark(oklch(1 0 0), oklch(0.282 0.087 267.935));
+    --color-info-hover: light-dark(
+        oklch(0.424 0.181 265.638),
+        oklch(0.882 0.057 254.128)
+    );
+    --color-info-light: light-dark(
+        oklch(0.97 0.014 254.604),
+        oklch(0.282 0.087 267.935)
+    );
+    --color-info-fg: light-dark(
+        oklch(0.424 0.181 265.638),
+        oklch(0.809 0.096 251.813)
+    );
+    --color-info-border: light-dark(
+        oklch(0.882 0.057 254.128),
+        oklch(0.379 0.138 265.522)
+    );
 
-  --color-danger: light-dark(
-    oklch(0.505 0.19 27.518),
-    oklch(0.808 0.103 19.571)
-  );
-  --color-on-danger: light-dark(oklch(1 0 0), oklch(0.258 0.089 26.042));
-  --color-danger-hover: light-dark(
-    oklch(0.444 0.161 26.899),
-    oklch(0.885 0.059 18.334)
-  );
-  --color-danger-light: light-dark(
-    oklch(0.971 0.013 17.38),
-    oklch(0.258 0.089 26.042)
-  );
-  --color-danger-fg: light-dark(
-    oklch(0.444 0.161 26.899),
-    oklch(0.808 0.103 19.571)
-  );
-  --color-danger-border: light-dark(
-    oklch(0.885 0.059 18.334),
-    oklch(0.396 0.133 25.723)
-  );
+    --color-danger: light-dark(
+        oklch(0.505 0.19 27.518),
+        oklch(0.808 0.103 19.571)
+    );
+    --color-on-danger: light-dark(oklch(1 0 0), oklch(0.258 0.089 26.042));
+    --color-danger-hover: light-dark(
+        oklch(0.444 0.161 26.899),
+        oklch(0.885 0.059 18.334)
+    );
+    --color-danger-light: light-dark(
+        oklch(0.971 0.013 17.38),
+        oklch(0.258 0.089 26.042)
+    );
+    --color-danger-fg: light-dark(
+        oklch(0.444 0.161 26.899),
+        oklch(0.808 0.103 19.571)
+    );
+    --color-danger-border: light-dark(
+        oklch(0.885 0.059 18.334),
+        oklch(0.396 0.133 25.723)
+    );
 
-  --color-reward: light-dark(
-    oklch(0.473 0.125 46.201),
-    oklch(0.837 0.164 84.429)
-  );
-  --color-on-reward: light-dark(oklch(1 0 0), oklch(0.279 0.074 45.635));
-  --color-reward-hover: light-dark(
-    oklch(0.414 0.105 45.904),
-    oklch(0.924 0.115 95.746)
-  );
-  --color-reward-light: light-dark(
-    oklch(0.987 0.021 95.277),
-    oklch(0.279 0.074 45.635)
-  );
-  --color-reward-fg: light-dark(
-    oklch(0.473 0.125 46.201),
-    oklch(0.837 0.164 84.429)
-  );
-  --color-reward-border: light-dark(
-    oklch(0.924 0.115 95.746),
-    oklch(0.414 0.105 45.904)
-  );
+    --color-reward: light-dark(
+        oklch(0.473 0.125 46.201),
+        oklch(0.837 0.164 84.429)
+    );
+    --color-on-reward: light-dark(oklch(1 0 0), oklch(0.279 0.074 45.635));
+    --color-reward-hover: light-dark(
+        oklch(0.414 0.105 45.904),
+        oklch(0.924 0.115 95.746)
+    );
+    --color-reward-light: light-dark(
+        oklch(0.987 0.021 95.277),
+        oklch(0.279 0.074 45.635)
+    );
+    --color-reward-fg: light-dark(
+        oklch(0.473 0.125 46.201),
+        oklch(0.837 0.164 84.429)
+    );
+    --color-reward-border: light-dark(
+        oklch(0.924 0.115 95.746),
+        oklch(0.414 0.105 45.904)
+    );
 
-  --color-github-star: light-dark(
-    oklch(0.54 0.14 91.507),
-    oklch(0.79 0.139 85.237)
-  );
+    --color-github-star: light-dark(
+        oklch(0.54 0.14 91.507),
+        oklch(0.79 0.139 85.237)
+    );
 
-  --color-warning-bg: light-dark(
-    oklch(0.987 0.021 95.277),
-    oklch(0.279 0.074 45.635)
-  );
-  --color-warning-fg: light-dark(
-    oklch(0.473 0.125 46.201),
-    oklch(0.924 0.115 95.746)
-  );
-  --color-warning-border: light-dark(
-    oklch(0.924 0.115 95.746),
-    oklch(0.414 0.105 45.904)
-  );
+    --color-warning-bg: light-dark(
+        oklch(0.987 0.021 95.277),
+        oklch(0.279 0.074 45.635)
+    );
+    --color-warning-fg: light-dark(
+        oklch(0.473 0.125 46.201),
+        oklch(0.924 0.115 95.746)
+    );
+    --color-warning-border: light-dark(
+        oklch(0.924 0.115 95.746),
+        oklch(0.414 0.105 45.904)
+    );
 
-  --color-contribute-bg: light-dark(
-    oklch(0.97 0.014 254.604),
-    oklch(0.282 0.087 267.935)
-  );
-  --color-contribute-fg: light-dark(
-    oklch(0.488 0.217 264.376),
-    oklch(0.809 0.096 251.813)
-  );
-  --color-contribute-border: light-dark(
-    oklch(0.809 0.096 251.813),
-    oklch(0.379 0.138 265.522)
-  );
-  --color-contribute-hover-bg: light-dark(
-    oklch(0.932 0.032 255.585),
-    oklch(0.379 0.138 265.522)
-  );
-  --color-contribute-hover-border: light-dark(
-    oklch(0.714 0.143 254.624),
-    oklch(0.488 0.217 264.376)
-  );
+    --color-contribute-bg: light-dark(
+        oklch(0.97 0.014 254.604),
+        oklch(0.282 0.087 267.935)
+    );
+    --color-contribute-fg: light-dark(
+        oklch(0.488 0.217 264.376),
+        oklch(0.809 0.096 251.813)
+    );
+    --color-contribute-border: light-dark(
+        oklch(0.809 0.096 251.813),
+        oklch(0.379 0.138 265.522)
+    );
+    --color-contribute-hover-bg: light-dark(
+        oklch(0.932 0.032 255.585),
+        oklch(0.379 0.138 265.522)
+    );
+    --color-contribute-hover-border: light-dark(
+        oklch(0.714 0.143 254.624),
+        oklch(0.488 0.217 264.376)
+    );
 
-  --color-overlay: light-dark(oklch(0 0 0 / 0.5), oklch(0 0 0 / 0.65));
-  --color-shadow: light-dark(oklch(0 0 0 / 0.14), oklch(0 0 0 / 0.45));
-  --color-mask: light-dark(oklch(0 0 0), oklch(1 0 0));
-  --color-selection-bg: light-dark(
-    oklch(0.527 0.137 150.069 / 0.25),
-    oklch(0.723 0.192 149.579 / 0.35)
-  );
-  --color-selection-fg: light-dark(
-    oklch(0.21 0.032 264.665),
-    oklch(0.985 0.002 247.839)
-  );
+    --color-overlay: light-dark(oklch(0 0 0 / 0.5), oklch(0 0 0 / 0.65));
+    --color-shadow: light-dark(oklch(0 0 0 / 0.14), oklch(0 0 0 / 0.45));
+    --color-mask: light-dark(oklch(0 0 0), oklch(1 0 0));
+    --color-selection-bg: light-dark(
+        oklch(0.527 0.137 150.069 / 0.25),
+        oklch(0.723 0.192 149.579 / 0.35)
+    );
+    --color-selection-fg: light-dark(
+        oklch(0.21 0.032 264.665),
+        oklch(0.985 0.002 247.839)
+    );
 
-  /* Topic category roles. These are categories, not theme palettes. */
-  --color-topic-blue-bg: light-dark(
-    oklch(0.97 0.014 254.604),
-    oklch(0.282 0.087 267.935)
-  );
-  --color-topic-blue-border: light-dark(
-    oklch(0.546 0.215 262.881),
-    oklch(0.714 0.143 254.624)
-  );
-  --color-topic-blue-hover: light-dark(
-    oklch(0.488 0.217 264.376),
-    oklch(0.809 0.096 251.813)
-  );
-  --color-topic-indigo-bg: light-dark(
-    oklch(0.962 0.018 272.314),
-    oklch(0.257 0.086 281.288)
-  );
-  --color-topic-indigo-border: light-dark(
-    oklch(0.511 0.23 276.966),
-    oklch(0.68 0.158 276.935)
-  );
-  --color-topic-indigo-hover: light-dark(
-    oklch(0.457 0.215 277.023),
-    oklch(0.785 0.104 274.713)
-  );
-  --color-topic-green-bg: light-dark(
-    oklch(0.982 0.018 155.826),
-    oklch(0.266 0.063 152.934)
-  );
-  --color-topic-green-border: light-dark(
-    oklch(0.627 0.17 149.214),
-    oklch(0.8 0.182 151.711)
-  );
-  --color-topic-green-hover: light-dark(
-    oklch(0.527 0.137 150.069),
-    oklch(0.871 0.136 154.449)
-  );
-  --color-topic-purple-bg: light-dark(
-    oklch(0.977 0.014 308.299),
-    oklch(0.291 0.143 302.717)
-  );
-  --color-topic-purple-border: light-dark(
-    oklch(0.558 0.252 302.321),
-    oklch(0.722 0.177 305.504)
-  );
-  --color-topic-purple-hover: light-dark(
-    oklch(0.496 0.237 301.924),
-    oklch(0.827 0.108 306.383)
-  );
-  --color-topic-pink-bg: light-dark(
-    oklch(0.971 0.014 343.198),
-    oklch(0.284 0.105 3.907)
-  );
-  --color-topic-pink-border: light-dark(
-    oklch(0.592 0.218 0.584),
-    oklch(0.725 0.175 349.761)
-  );
-  --color-topic-pink-hover: light-dark(
-    oklch(0.525 0.199 3.958),
-    oklch(0.823 0.11 346.018)
-  );
-  --color-topic-amber-bg: light-dark(
-    oklch(0.987 0.021 95.277),
-    oklch(0.279 0.074 45.635)
-  );
-  --color-topic-amber-border: light-dark(
-    oklch(0.555 0.146 48.998),
-    oklch(0.837 0.164 84.429)
-  );
-  --color-topic-amber-hover: light-dark(
-    oklch(0.473 0.125 46.201),
-    oklch(0.924 0.115 95.746)
-  );
-  --color-topic-red-bg: light-dark(
-    oklch(0.971 0.013 17.38),
-    oklch(0.258 0.089 26.042)
-  );
-  --color-topic-red-border: light-dark(
-    oklch(0.577 0.215 27.325),
-    oklch(0.711 0.166 22.216)
-  );
-  --color-topic-red-hover: light-dark(
-    oklch(0.505 0.19 27.518),
-    oklch(0.808 0.103 19.571)
-  );
-  --color-topic-cyan-bg: light-dark(
-    oklch(0.984 0.019 200.873),
-    oklch(0.302 0.054 229.695)
-  );
-  --color-topic-cyan-border: light-dark(
-    oklch(0.609 0.111 221.723),
-    oklch(0.797 0.134 211.53)
-  );
-  --color-topic-cyan-hover: light-dark(
-    oklch(0.52 0.094 223.128),
-    oklch(0.865 0.115 207.078)
-  );
-  --color-topic-orange-bg: light-dark(
-    oklch(0.98 0.016 73.684),
-    oklch(0.266 0.076 36.259)
-  );
-  --color-topic-orange-border: light-dark(
-    oklch(0.646 0.194 41.116),
-    oklch(0.758 0.159 55.934)
-  );
-  --color-topic-orange-hover: light-dark(
-    oklch(0.553 0.174 38.402),
-    oklch(0.837 0.117 66.29)
-  );
+    /* Topic category roles. These are categories, not theme palettes. */
+    --color-topic-blue-bg: light-dark(
+        oklch(0.97 0.014 254.604),
+        oklch(0.282 0.087 267.935)
+    );
+    --color-topic-blue-border: light-dark(
+        oklch(0.546 0.215 262.881),
+        oklch(0.714 0.143 254.624)
+    );
+    --color-topic-blue-hover: light-dark(
+        oklch(0.488 0.217 264.376),
+        oklch(0.809 0.096 251.813)
+    );
+    --color-topic-indigo-bg: light-dark(
+        oklch(0.962 0.018 272.314),
+        oklch(0.257 0.086 281.288)
+    );
+    --color-topic-indigo-border: light-dark(
+        oklch(0.511 0.23 276.966),
+        oklch(0.68 0.158 276.935)
+    );
+    --color-topic-indigo-hover: light-dark(
+        oklch(0.457 0.215 277.023),
+        oklch(0.785 0.104 274.713)
+    );
+    --color-topic-green-bg: light-dark(
+        oklch(0.982 0.018 155.826),
+        oklch(0.266 0.063 152.934)
+    );
+    --color-topic-green-border: light-dark(
+        oklch(0.627 0.17 149.214),
+        oklch(0.8 0.182 151.711)
+    );
+    --color-topic-green-hover: light-dark(
+        oklch(0.527 0.137 150.069),
+        oklch(0.871 0.136 154.449)
+    );
+    --color-topic-purple-bg: light-dark(
+        oklch(0.977 0.014 308.299),
+        oklch(0.291 0.143 302.717)
+    );
+    --color-topic-purple-border: light-dark(
+        oklch(0.558 0.252 302.321),
+        oklch(0.722 0.177 305.504)
+    );
+    --color-topic-purple-hover: light-dark(
+        oklch(0.496 0.237 301.924),
+        oklch(0.827 0.108 306.383)
+    );
+    --color-topic-pink-bg: light-dark(
+        oklch(0.971 0.014 343.198),
+        oklch(0.284 0.105 3.907)
+    );
+    --color-topic-pink-border: light-dark(
+        oklch(0.592 0.218 0.584),
+        oklch(0.725 0.175 349.761)
+    );
+    --color-topic-pink-hover: light-dark(
+        oklch(0.525 0.199 3.958),
+        oklch(0.823 0.11 346.018)
+    );
+    --color-topic-amber-bg: light-dark(
+        oklch(0.987 0.021 95.277),
+        oklch(0.279 0.074 45.635)
+    );
+    --color-topic-amber-border: light-dark(
+        oklch(0.555 0.146 48.998),
+        oklch(0.837 0.164 84.429)
+    );
+    --color-topic-amber-hover: light-dark(
+        oklch(0.473 0.125 46.201),
+        oklch(0.924 0.115 95.746)
+    );
+    --color-topic-red-bg: light-dark(
+        oklch(0.971 0.013 17.38),
+        oklch(0.258 0.089 26.042)
+    );
+    --color-topic-red-border: light-dark(
+        oklch(0.577 0.215 27.325),
+        oklch(0.711 0.166 22.216)
+    );
+    --color-topic-red-hover: light-dark(
+        oklch(0.505 0.19 27.518),
+        oklch(0.808 0.103 19.571)
+    );
+    --color-topic-cyan-bg: light-dark(
+        oklch(0.984 0.019 200.873),
+        oklch(0.302 0.054 229.695)
+    );
+    --color-topic-cyan-border: light-dark(
+        oklch(0.609 0.111 221.723),
+        oklch(0.797 0.134 211.53)
+    );
+    --color-topic-cyan-hover: light-dark(
+        oklch(0.52 0.094 223.128),
+        oklch(0.865 0.115 207.078)
+    );
+    --color-topic-orange-bg: light-dark(
+        oklch(0.98 0.016 73.684),
+        oklch(0.266 0.076 36.259)
+    );
+    --color-topic-orange-border: light-dark(
+        oklch(0.646 0.194 41.116),
+        oklch(0.758 0.159 55.934)
+    );
+    --color-topic-orange-hover: light-dark(
+        oklch(0.553 0.174 38.402),
+        oklch(0.837 0.117 66.29)
+    );
 
-  /* Feedback roles. */
-  --color-correct-bg: light-dark(
-    oklch(0.982 0.018 155.826),
-    oklch(0.266 0.063 152.934)
-  );
-  --color-correct-border: light-dark(
-    oklch(0.925 0.081 155.995),
-    oklch(0.448 0.108 151.328)
-  );
-  --color-correct-fg: light-dark(
-    oklch(0.448 0.108 151.328),
-    oklch(0.871 0.136 154.449)
-  );
-  --color-incorrect-bg: light-dark(
-    oklch(0.971 0.013 17.38),
-    oklch(0.258 0.089 26.042)
-  );
-  --color-incorrect-border: light-dark(
-    oklch(0.885 0.059 18.334),
-    oklch(0.396 0.133 25.723)
-  );
-  --color-incorrect-fg: light-dark(
-    oklch(0.444 0.161 26.899),
-    oklch(0.808 0.103 19.571)
-  );
-  --color-pending-bg: light-dark(
-    oklch(0.97 0.014 254.604),
-    oklch(0.282 0.087 267.935)
-  );
-  --color-pending-border: light-dark(
-    oklch(0.882 0.057 254.128),
-    oklch(0.379 0.138 265.522)
-  );
-  --color-pending-fg: light-dark(
-    oklch(0.424 0.181 265.638),
-    oklch(0.809 0.096 251.813)
-  );
+    /* Feedback roles. */
+    --color-correct-bg: light-dark(
+        oklch(0.982 0.018 155.826),
+        oklch(0.266 0.063 152.934)
+    );
+    --color-correct-border: light-dark(
+        oklch(0.925 0.081 155.995),
+        oklch(0.448 0.108 151.328)
+    );
+    --color-correct-fg: light-dark(
+        oklch(0.448 0.108 151.328),
+        oklch(0.871 0.136 154.449)
+    );
+    --color-incorrect-bg: light-dark(
+        oklch(0.971 0.013 17.38),
+        oklch(0.258 0.089 26.042)
+    );
+    --color-incorrect-border: light-dark(
+        oklch(0.885 0.059 18.334),
+        oklch(0.396 0.133 25.723)
+    );
+    --color-incorrect-fg: light-dark(
+        oklch(0.444 0.161 26.899),
+        oklch(0.808 0.103 19.571)
+    );
+    --color-pending-bg: light-dark(
+        oklch(0.97 0.014 254.604),
+        oklch(0.282 0.087 267.935)
+    );
+    --color-pending-border: light-dark(
+        oklch(0.882 0.057 254.128),
+        oklch(0.379 0.138 265.522)
+    );
+    --color-pending-fg: light-dark(
+        oklch(0.424 0.181 265.638),
+        oklch(0.809 0.096 251.813)
+    );
 }
 
 /* ── Princess theme ──
    A warm, high-contrast light appearance. It keeps the browser in light mode
    while replacing every semantic role instead of recoloring components ad hoc. */
 html[data-theme="princess"] {
-  --color-surface: oklch(0.975 0.008 15);
-  --color-surface-alt: oklch(0.99 0.003 15);
-  --color-fg: oklch(0.24 0.055 335);
-  --color-fg-secondary: oklch(0.43 0.04 335);
-  --color-fg-muted: oklch(0.48 0.035 335);
-  --color-border: oklch(0.89 0.03 350);
-  --color-card-footer: oklch(0.95 0.025 350);
-  --color-card-footer-border: oklch(0.84 0.055 350);
+    --color-surface: oklch(0.975 0.008 15);
+    --color-surface-alt: oklch(0.99 0.003 15);
+    --color-fg: oklch(0.24 0.055 335);
+    --color-fg-secondary: oklch(0.43 0.04 335);
+    --color-fg-muted: oklch(0.48 0.035 335);
+    --color-border: oklch(0.89 0.03 350);
+    --color-card-footer: oklch(0.95 0.025 350);
+    --color-card-footer-border: oklch(0.84 0.055 350);
 
-  /* Rose is the theme accent. The foreground pair is intentionally darker
+    /* Rose is the theme accent. The foreground pair is intentionally darker
      than the solid action so links and labels retain AA contrast. */
-  --color-accent: oklch(0.5 0.18 350);
-  --color-on-accent: oklch(1 0 0);
-  --color-accent-light: oklch(0.95 0.025 350);
-  --color-accent-fg: oklch(0.43 0.16 350);
-  --color-accent-hover: oklch(0.37 0.14 350);
-  --color-accent-border: oklch(0.72 0.12 350);
+    --color-accent: oklch(0.5 0.18 350);
+    --color-on-accent: oklch(1 0 0);
+    --color-accent-light: oklch(0.95 0.025 350);
+    --color-accent-fg: oklch(0.43 0.16 350);
+    --color-accent-hover: oklch(0.37 0.14 350);
+    --color-accent-border: oklch(0.72 0.12 350);
 
-  /* Warm code surfaces and syntax roles. */
-  --color-code: oklch(0.955 0.012 345);
-  --color-code-fg: oklch(0.24 0.055 335);
-  --color-code-block: oklch(0.945 0.02 345);
-  --color-code-block-fg: oklch(0.24 0.055 335);
-  --color-code-comment: oklch(0.43 0.04 335);
-  --color-code-punctuation: oklch(0.48 0.035 335);
-  --color-code-keyword: oklch(0.45 0.16 300);
-  --color-code-string: oklch(0.43 0.16 350);
-  --color-code-number: oklch(0.43 0.09 70);
-  --color-code-function: oklch(0.45 0.14 260);
-  --color-code-operator: oklch(0.45 0.14 25);
-  --color-code-property: oklch(0.45 0.07 210);
-  --color-code-class: oklch(0.45 0.15 320);
+    /* Warm code surfaces and syntax roles. */
+    --color-code: oklch(0.955 0.012 345);
+    --color-code-fg: oklch(0.24 0.055 335);
+    --color-code-block: oklch(0.945 0.02 345);
+    --color-code-block-fg: oklch(0.24 0.055 335);
+    --color-code-comment: oklch(0.43 0.04 335);
+    --color-code-punctuation: oklch(0.48 0.035 335);
+    --color-code-keyword: oklch(0.45 0.16 300);
+    --color-code-string: oklch(0.43 0.16 350);
+    --color-code-number: oklch(0.43 0.09 70);
+    --color-code-function: oklch(0.45 0.14 260);
+    --color-code-operator: oklch(0.45 0.14 25);
+    --color-code-property: oklch(0.45 0.07 210);
+    --color-code-class: oklch(0.45 0.15 320);
 
-  /* Informational state. */
-  --color-info: oklch(0.49 0.19 265);
-  --color-on-info: oklch(1 0 0);
-  --color-info-hover: oklch(0.38 0.15 265);
-  --color-info-light: oklch(0.965 0.012 265);
-  --color-info-fg: oklch(0.42 0.16 265);
-  --color-info-border: oklch(0.76 0.12 265);
+    /* Informational state. */
+    --color-info: oklch(0.49 0.19 265);
+    --color-on-info: oklch(1 0 0);
+    --color-info-hover: oklch(0.38 0.15 265);
+    --color-info-light: oklch(0.965 0.012 265);
+    --color-info-fg: oklch(0.42 0.16 265);
+    --color-info-border: oklch(0.76 0.12 265);
 
-  /* Destructive state. */
-  --color-danger: oklch(0.5 0.18 25);
-  --color-on-danger: oklch(1 0 0);
-  --color-danger-hover: oklch(0.39 0.15 25);
-  --color-danger-light: oklch(0.965 0.01 25);
-  --color-danger-fg: oklch(0.42 0.16 25);
-  --color-danger-border: oklch(0.76 0.11 25);
+    /* Destructive state. */
+    --color-danger: oklch(0.5 0.18 25);
+    --color-on-danger: oklch(1 0 0);
+    --color-danger-hover: oklch(0.39 0.15 25);
+    --color-danger-light: oklch(0.965 0.01 25);
+    --color-danger-fg: oklch(0.42 0.16 25);
+    --color-danger-border: oklch(0.76 0.11 25);
 
-  /* Reward and contribution states. */
-  --color-reward: oklch(0.5 0.1 65);
-  --color-on-reward: oklch(1 0 0);
-  --color-reward-hover: oklch(0.4 0.08 65);
-  --color-reward-light: oklch(0.97 0.02 90);
-  --color-reward-fg: oklch(0.43 0.08 65);
-  --color-reward-border: oklch(0.77 0.08 80);
-  --color-github-star: oklch(0.54 0.14 91.507);
-  --color-warning-bg: oklch(0.97 0.02 90);
-  --color-warning-fg: oklch(0.43 0.08 65);
-  --color-warning-border: oklch(0.77 0.08 80);
-  --color-contribute-bg: oklch(0.965 0.012 265);
-  --color-contribute-fg: oklch(0.42 0.16 265);
-  --color-contribute-border: oklch(0.76 0.12 265);
-  --color-contribute-hover-bg: oklch(0.925 0.025 265);
-  --color-contribute-hover-border: oklch(0.66 0.14 265);
+    /* Reward and contribution states. */
+    --color-reward: oklch(0.5 0.1 65);
+    --color-on-reward: oklch(1 0 0);
+    --color-reward-hover: oklch(0.4 0.08 65);
+    --color-reward-light: oklch(0.97 0.02 90);
+    --color-reward-fg: oklch(0.43 0.08 65);
+    --color-reward-border: oklch(0.77 0.08 80);
+    --color-github-star: oklch(0.54 0.14 91.507);
+    --color-warning-bg: oklch(0.97 0.02 90);
+    --color-warning-fg: oklch(0.43 0.08 65);
+    --color-warning-border: oklch(0.77 0.08 80);
+    --color-contribute-bg: oklch(0.965 0.012 265);
+    --color-contribute-fg: oklch(0.42 0.16 265);
+    --color-contribute-border: oklch(0.76 0.12 265);
+    --color-contribute-hover-bg: oklch(0.925 0.025 265);
+    --color-contribute-hover-border: oklch(0.66 0.14 265);
 
-  --color-overlay: oklch(0 0 0 / 0.5);
-  --color-shadow: oklch(0.25 0.05 335 / 0.16);
-  --color-mask: oklch(0 0 0);
-  --color-selection-bg: oklch(0.5 0.18 350 / 0.25);
-  --color-selection-fg: oklch(0.24 0.055 335);
+    --color-overlay: oklch(0 0 0 / 0.5);
+    --color-shadow: oklch(0.25 0.05 335 / 0.16);
+    --color-mask: oklch(0 0 0);
+    --color-selection-bg: oklch(0.5 0.18 350 / 0.25);
+    --color-selection-fg: oklch(0.24 0.055 335);
 
-  /* Topic category roles remain colorful, with slightly warmer pastels. */
-  --color-topic-blue-bg: oklch(0.97 0.012 255);
-  --color-topic-blue-border: oklch(0.546 0.18 263);
-  --color-topic-blue-hover: oklch(0.488 0.18 264);
-  --color-topic-indigo-bg: oklch(0.962 0.014 272);
-  --color-topic-indigo-border: oklch(0.511 0.2 277);
-  --color-topic-indigo-hover: oklch(0.457 0.18 277);
-  --color-topic-green-bg: oklch(0.982 0.014 156);
-  --color-topic-green-border: oklch(0.627 0.15 149);
-  --color-topic-green-hover: oklch(0.527 0.14 150);
-  --color-topic-purple-bg: oklch(0.977 0.012 308);
-  --color-topic-purple-border: oklch(0.558 0.22 302);
-  --color-topic-purple-hover: oklch(0.496 0.2 302);
-  --color-topic-pink-bg: oklch(0.971 0.012 343);
-  --color-topic-pink-border: oklch(0.592 0.19 1);
-  --color-topic-pink-hover: oklch(0.525 0.17 4);
-  --color-topic-amber-bg: oklch(0.987 0.016 95);
-  --color-topic-amber-border: oklch(0.555 0.12 49);
-  --color-topic-amber-hover: oklch(0.473 0.1 46);
-  --color-topic-red-bg: oklch(0.971 0.012 17);
-  --color-topic-red-border: oklch(0.577 0.18 27);
-  --color-topic-red-hover: oklch(0.505 0.17 27);
-  --color-topic-cyan-bg: oklch(0.984 0.015 201);
-  --color-topic-cyan-border: oklch(0.609 0.1 222);
-  --color-topic-cyan-hover: oklch(0.52 0.09 223);
-  --color-topic-orange-bg: oklch(0.98 0.014 74);
-  --color-topic-orange-border: oklch(0.646 0.17 41);
-  --color-topic-orange-hover: oklch(0.553 0.15 38);
+    /* Topic category roles remain colorful, with slightly warmer pastels. */
+    --color-topic-blue-bg: oklch(0.97 0.012 255);
+    --color-topic-blue-border: oklch(0.546 0.18 263);
+    --color-topic-blue-hover: oklch(0.488 0.18 264);
+    --color-topic-indigo-bg: oklch(0.962 0.014 272);
+    --color-topic-indigo-border: oklch(0.511 0.2 277);
+    --color-topic-indigo-hover: oklch(0.457 0.18 277);
+    --color-topic-green-bg: oklch(0.982 0.014 156);
+    --color-topic-green-border: oklch(0.627 0.15 149);
+    --color-topic-green-hover: oklch(0.527 0.14 150);
+    --color-topic-purple-bg: oklch(0.977 0.012 308);
+    --color-topic-purple-border: oklch(0.558 0.22 302);
+    --color-topic-purple-hover: oklch(0.496 0.2 302);
+    --color-topic-pink-bg: oklch(0.971 0.012 343);
+    --color-topic-pink-border: oklch(0.592 0.19 1);
+    --color-topic-pink-hover: oklch(0.525 0.17 4);
+    --color-topic-amber-bg: oklch(0.987 0.016 95);
+    --color-topic-amber-border: oklch(0.555 0.12 49);
+    --color-topic-amber-hover: oklch(0.473 0.1 46);
+    --color-topic-red-bg: oklch(0.971 0.012 17);
+    --color-topic-red-border: oklch(0.577 0.18 27);
+    --color-topic-red-hover: oklch(0.505 0.17 27);
+    --color-topic-cyan-bg: oklch(0.984 0.015 201);
+    --color-topic-cyan-border: oklch(0.609 0.1 222);
+    --color-topic-cyan-hover: oklch(0.52 0.09 223);
+    --color-topic-orange-bg: oklch(0.98 0.014 74);
+    --color-topic-orange-border: oklch(0.646 0.17 41);
+    --color-topic-orange-hover: oklch(0.553 0.15 38);
 
-  /* Answer feedback. */
-  --color-correct-bg: oklch(0.982 0.014 156);
-  --color-correct-border: oklch(0.925 0.07 156);
-  --color-correct-fg: oklch(0.448 0.1 151);
-  --color-incorrect-bg: oklch(0.971 0.012 17);
-  --color-incorrect-border: oklch(0.885 0.055 18);
-  --color-incorrect-fg: oklch(0.444 0.15 27);
-  --color-pending-bg: oklch(0.965 0.012 265);
-  --color-pending-border: oklch(0.76 0.12 265);
-  --color-pending-fg: oklch(0.42 0.16 265);
+    /* Answer feedback. */
+    --color-correct-bg: oklch(0.982 0.014 156);
+    --color-correct-border: oklch(0.925 0.07 156);
+    --color-correct-fg: oklch(0.448 0.1 151);
+    --color-incorrect-bg: oklch(0.971 0.012 17);
+    --color-incorrect-border: oklch(0.885 0.055 18);
+    --color-incorrect-fg: oklch(0.444 0.15 27);
+    --color-pending-bg: oklch(0.965 0.012 265);
+    --color-pending-border: oklch(0.76 0.12 265);
+    --color-pending-fg: oklch(0.42 0.16 265);
 }
 
 /* ── Catppuccin Latte ──
@@ -647,829 +676,691 @@ html[data-theme="princess"] {
    foreground roles are lowered in lightness so the pastel palette remains
    readable at WCAG AA contrast. */
 html[data-theme="latte"] {
-  --color-surface: oklch(0.958 0.006 264.532);
-  --color-surface-alt: oklch(0.906 0.012 264.507);
-  --color-fg: oklch(0.435 0.043 279.325);
-  --color-fg-secondary: oklch(0.492 0.038 279.299);
-  --color-fg-muted: oklch(0.5 0.034 279.084);
-  --color-border: oklch(0.857 0.014 268.476);
-  --color-card-footer: oklch(0.933 0.009 264.521);
-  --color-card-footer-border: oklch(0.808 0.017 271.198);
+    --color-surface: oklch(0.958 0.006 264.532);
+    --color-surface-alt: oklch(0.906 0.012 264.507);
+    --color-fg: oklch(0.435 0.043 279.325);
+    --color-fg-secondary: oklch(0.492 0.038 279.299);
+    --color-fg-muted: oklch(0.5 0.034 279.084);
+    --color-border: oklch(0.857 0.014 268.476);
+    --color-card-footer: oklch(0.933 0.009 264.521);
+    --color-card-footer-border: oklch(0.808 0.017 271.198);
 
-  --color-accent: oklch(0.555 0.25 297.016);
-  --color-on-accent: oklch(0.958 0.006 264.532);
-  --color-accent-light: oklch(0.857 0.014 268.476);
-  --color-accent-fg: oklch(0.43 0.18 262.087);
-  --color-accent-hover: oklch(0.46 0.2 297.016);
-  --color-accent-border: oklch(0.664 0.175 273.135);
+    --color-accent: oklch(0.555 0.25 297.016);
+    --color-on-accent: oklch(0.958 0.006 264.532);
+    --color-accent-light: oklch(0.857 0.014 268.476);
+    --color-accent-fg: oklch(0.43 0.18 262.087);
+    --color-accent-hover: oklch(0.46 0.2 297.016);
+    --color-accent-border: oklch(0.664 0.175 273.135);
 
-  --color-code: oklch(0.906 0.012 264.507);
-  --color-code-fg: oklch(0.435 0.043 279.325);
-  --color-code-block: oklch(0.906 0.012 264.507);
-  --color-code-block-fg: oklch(0.435 0.043 279.325);
-  --color-code-comment: oklch(0.492 0.038 279.299);
-  --color-code-punctuation: oklch(0.492 0.038 279.299);
-  --color-code-keyword: oklch(0.5 0.2 297.016);
-  --color-code-string: oklch(0.44 0.13 140.445);
-  --color-code-number: oklch(0.48 0.12 42.429);
-  --color-code-function: oklch(0.46 0.18 262.087);
-  --color-code-operator: oklch(0.46 0.09 235.382);
-  --color-code-property: oklch(0.44 0.06 201.105);
-  --color-code-class: oklch(0.47 0.16 338.433);
+    --color-code: oklch(0.906 0.012 264.507);
+    --color-code-fg: oklch(0.435 0.043 279.325);
+    --color-code-block: oklch(0.906 0.012 264.507);
+    --color-code-block-fg: oklch(0.435 0.043 279.325);
+    --color-code-comment: oklch(0.492 0.038 279.299);
+    --color-code-punctuation: oklch(0.492 0.038 279.299);
+    --color-code-keyword: oklch(0.5 0.2 297.016);
+    --color-code-string: oklch(0.44 0.13 140.445);
+    --color-code-number: oklch(0.48 0.12 42.429);
+    --color-code-function: oklch(0.46 0.18 262.087);
+    --color-code-operator: oklch(0.46 0.09 235.382);
+    --color-code-property: oklch(0.44 0.06 201.105);
+    --color-code-class: oklch(0.47 0.16 338.433);
 
-  --color-info: oklch(0.559 0.226 262.087);
-  --color-on-info: oklch(1 0 0);
-  --color-info-hover: oklch(0.48 0.2 262.087);
-  --color-info-light: oklch(0.965 0.012 262.087);
-  --color-info-fg: oklch(0.43 0.18 262.087);
-  --color-info-border: oklch(0.559 0.226 262.087);
+    --color-info: oklch(0.559 0.226 262.087);
+    --color-on-info: oklch(1 0 0);
+    --color-info-hover: oklch(0.48 0.2 262.087);
+    --color-info-light: oklch(0.965 0.012 262.087);
+    --color-info-fg: oklch(0.43 0.18 262.087);
+    --color-info-border: oklch(0.559 0.226 262.087);
 
-  --color-danger: oklch(0.55 0.216 19.809);
-  --color-on-danger: oklch(1 0 0);
-  --color-danger-hover: oklch(0.48 0.18 19.809);
-  --color-danger-light: oklch(0.965 0.012 19.809);
-  --color-danger-fg: oklch(0.43 0.17 19.809);
-  --color-danger-border: oklch(0.55 0.216 19.809);
+    --color-danger: oklch(0.55 0.216 19.809);
+    --color-on-danger: oklch(1 0 0);
+    --color-danger-hover: oklch(0.48 0.18 19.809);
+    --color-danger-light: oklch(0.965 0.012 19.809);
+    --color-danger-fg: oklch(0.43 0.17 19.809);
+    --color-danger-border: oklch(0.55 0.216 19.809);
 
-  --color-reward: oklch(0.714 0.149 67.777);
-  --color-on-reward: oklch(0.32 0.03 279.325);
-  --color-reward-hover: oklch(0.72 0.12 67.777);
-  --color-reward-light: oklch(0.965 0.02 67.777);
-  --color-reward-fg: oklch(0.43 0.08 67.777);
-  --color-reward-border: oklch(0.714 0.149 67.777);
-  --color-github-star: oklch(0.43 0.08 67.777);
-  --color-warning-bg: var(--color-reward-light);
-  --color-warning-fg: var(--color-reward-fg);
-  --color-warning-border: var(--color-reward-border);
+    --color-reward: oklch(0.714 0.149 67.777);
+    --color-on-reward: oklch(0.32 0.03 279.325);
+    --color-reward-hover: oklch(0.72 0.12 67.777);
+    --color-reward-light: oklch(0.965 0.02 67.777);
+    --color-reward-fg: oklch(0.43 0.08 67.777);
+    --color-reward-border: oklch(0.714 0.149 67.777);
+    --color-github-star: oklch(0.43 0.08 67.777);
+    --color-warning-bg: var(--color-reward-light);
+    --color-warning-fg: var(--color-reward-fg);
+    --color-warning-border: var(--color-reward-border);
 
-  --color-contribute-bg: var(--color-info-light);
-  --color-contribute-fg: var(--color-info-fg);
-  --color-contribute-border: var(--color-info-border);
-  --color-contribute-hover-bg: oklch(0.94 0.012 262.087);
-  --color-contribute-hover-border: oklch(0.48 0.2 262.087);
+    --color-contribute-bg: var(--color-info-light);
+    --color-contribute-fg: var(--color-info-fg);
+    --color-contribute-border: var(--color-info-border);
+    --color-contribute-hover-bg: oklch(0.94 0.012 262.087);
+    --color-contribute-hover-border: oklch(0.48 0.2 262.087);
 
-  --color-overlay: oklch(0 0 0 / 0.5);
-  --color-shadow: oklch(0 0 0 / 0.14);
-  --color-mask: oklch(0 0 0);
-  --color-selection-bg: oklch(0.555 0.25 297.016 / 0.25);
-  --color-selection-fg: oklch(0.435 0.043 279.325);
+    --color-overlay: oklch(0 0 0 / 0.5);
+    --color-shadow: oklch(0 0 0 / 0.14);
+    --color-mask: oklch(0 0 0);
+    --color-selection-bg: oklch(0.555 0.25 297.016 / 0.25);
+    --color-selection-fg: oklch(0.435 0.043 279.325);
 
-  --color-topic-blue-bg: oklch(0.972 0.008 262.087);
-  --color-topic-blue-border: oklch(0.48 0.18 262.087);
-  --color-topic-blue-hover: oklch(0.42 0.16 262.087);
-  --color-topic-indigo-bg: oklch(0.972 0.008 273.135);
-  --color-topic-indigo-border: oklch(0.48 0.17 273.135);
-  --color-topic-indigo-hover: oklch(0.42 0.15 273.135);
-  --color-topic-green-bg: oklch(0.972 0.008 140.445);
-  --color-topic-green-border: oklch(0.5 0.13 140.445);
-  --color-topic-green-hover: oklch(0.45 0.12 140.445);
-  --color-topic-purple-bg: oklch(0.972 0.008 297.016);
-  --color-topic-purple-border: oklch(0.48 0.2 297.016);
-  --color-topic-purple-hover: oklch(0.42 0.18 297.016);
-  --color-topic-pink-bg: oklch(0.972 0.008 338.433);
-  --color-topic-pink-border: oklch(0.55 0.14 338.433);
-  --color-topic-pink-hover: oklch(0.49 0.13 338.433);
-  --color-topic-amber-bg: oklch(0.972 0.008 67.777);
-  --color-topic-amber-border: oklch(0.55 0.1 67.777);
-  --color-topic-amber-hover: oklch(0.49 0.09 67.777);
-  --color-topic-red-bg: oklch(0.972 0.008 19.809);
-  --color-topic-red-border: oklch(0.48 0.17 19.809);
-  --color-topic-red-hover: oklch(0.42 0.15 19.809);
-  --color-topic-cyan-bg: oklch(0.972 0.008 201.105);
-  --color-topic-cyan-border: oklch(0.5 0.07 201.105);
-  --color-topic-cyan-hover: oklch(0.44 0.06 201.105);
-  --color-topic-orange-bg: oklch(0.972 0.008 42.429);
-  --color-topic-orange-border: oklch(0.55 0.15 42.429);
-  --color-topic-orange-hover: oklch(0.49 0.13 42.429);
+    --color-topic-blue-bg: oklch(0.972 0.008 262.087);
+    --color-topic-blue-border: oklch(0.48 0.18 262.087);
+    --color-topic-blue-hover: oklch(0.42 0.16 262.087);
+    --color-topic-indigo-bg: oklch(0.972 0.008 273.135);
+    --color-topic-indigo-border: oklch(0.48 0.17 273.135);
+    --color-topic-indigo-hover: oklch(0.42 0.15 273.135);
+    --color-topic-green-bg: oklch(0.972 0.008 140.445);
+    --color-topic-green-border: oklch(0.5 0.13 140.445);
+    --color-topic-green-hover: oklch(0.45 0.12 140.445);
+    --color-topic-purple-bg: oklch(0.972 0.008 297.016);
+    --color-topic-purple-border: oklch(0.48 0.2 297.016);
+    --color-topic-purple-hover: oklch(0.42 0.18 297.016);
+    --color-topic-pink-bg: oklch(0.972 0.008 338.433);
+    --color-topic-pink-border: oklch(0.55 0.14 338.433);
+    --color-topic-pink-hover: oklch(0.49 0.13 338.433);
+    --color-topic-amber-bg: oklch(0.972 0.008 67.777);
+    --color-topic-amber-border: oklch(0.55 0.1 67.777);
+    --color-topic-amber-hover: oklch(0.49 0.09 67.777);
+    --color-topic-red-bg: oklch(0.972 0.008 19.809);
+    --color-topic-red-border: oklch(0.48 0.17 19.809);
+    --color-topic-red-hover: oklch(0.42 0.15 19.809);
+    --color-topic-cyan-bg: oklch(0.972 0.008 201.105);
+    --color-topic-cyan-border: oklch(0.5 0.07 201.105);
+    --color-topic-cyan-hover: oklch(0.44 0.06 201.105);
+    --color-topic-orange-bg: oklch(0.972 0.008 42.429);
+    --color-topic-orange-border: oklch(0.55 0.15 42.429);
+    --color-topic-orange-hover: oklch(0.49 0.13 42.429);
 
-  --color-correct-bg: oklch(0.965 0.022 140.445);
-  --color-correct-border: oklch(0.78 0.1 140.445);
-  --color-correct-fg: oklch(0.43 0.12 140.445);
-  --color-incorrect-bg: oklch(0.965 0.012 19.809);
-  --color-incorrect-border: oklch(0.78 0.1 19.809);
-  --color-incorrect-fg: oklch(0.43 0.16 19.809);
-  --color-pending-bg: oklch(0.965 0.012 262.087);
-  --color-pending-border: oklch(0.78 0.1 262.087);
-  --color-pending-fg: oklch(0.43 0.18 262.087);
+    --color-correct-bg: oklch(0.965 0.022 140.445);
+    --color-correct-border: oklch(0.78 0.1 140.445);
+    --color-correct-fg: oklch(0.43 0.12 140.445);
+    --color-incorrect-bg: oklch(0.965 0.012 19.809);
+    --color-incorrect-border: oklch(0.78 0.1 19.809);
+    --color-incorrect-fg: oklch(0.43 0.16 19.809);
+    --color-pending-bg: oklch(0.965 0.012 262.087);
+    --color-pending-border: oklch(0.78 0.1 262.087);
+    --color-pending-fg: oklch(0.43 0.18 262.087);
 }
 
 /* ── Catppuccin Frappé ── */
 html[data-theme="frappe"] {
-  --color-surface: oklch(0.329 0.032 274.758);
-  --color-surface-alt: oklch(0.272 0.026 275.115);
-  --color-fg: oklch(0.862 0.053 273.347);
-  --color-fg-secondary: oklch(0.808 0.051 272.678);
-  --color-fg-muted: oklch(0.808 0.051 272.678);
-  --color-border: oklch(0.46 0.037 272.966);
-  --color-card-footer: oklch(0.297 0.029 276.214);
-  --color-card-footer-border: oklch(0.521 0.039 273.999);
+    --color-surface: oklch(0.329 0.032 274.758);
+    --color-surface-alt: oklch(0.272 0.026 275.115);
+    --color-fg: oklch(0.862 0.053 273.347);
+    --color-fg-secondary: oklch(0.808 0.051 272.678);
+    --color-fg-muted: oklch(0.808 0.051 272.678);
+    --color-border: oklch(0.46 0.037 272.966);
+    --color-card-footer: oklch(0.297 0.029 276.214);
+    --color-card-footer-border: oklch(0.521 0.039 273.999);
 
-  --color-accent: oklch(0.765 0.111 311.744);
-  --color-on-accent: oklch(0.329 0.032 274.758);
-  --color-accent-light: oklch(0.272 0.026 275.115);
-  --color-accent-fg: oklch(0.742 0.104 265.663);
-  --color-accent-hover: oklch(0.81 0.076 283.74);
-  --color-accent-border: oklch(0.81 0.076 283.74);
+    --color-accent: oklch(0.765 0.111 311.744);
+    --color-on-accent: oklch(0.329 0.032 274.758);
+    --color-accent-light: oklch(0.272 0.026 275.115);
+    --color-accent-fg: oklch(0.742 0.104 265.663);
+    --color-accent-hover: oklch(0.81 0.076 283.74);
+    --color-accent-border: oklch(0.81 0.076 283.74);
 
-  --color-code: oklch(0.272 0.026 275.115);
-  --color-code-fg: oklch(0.862 0.053 273.347);
-  --color-code-block: oklch(0.272 0.026 275.115);
-  --color-code-block-fg: oklch(0.862 0.053 273.347);
-  --color-code-comment: oklch(0.697 0.046 273.777);
-  --color-code-punctuation: oklch(0.697 0.046 273.777);
-  --color-code-keyword: oklch(0.765 0.111 311.744);
-  --color-code-string: oklch(0.812 0.107 133.392);
-  --color-code-number: oklch(0.773 0.111 47.726);
-  --color-code-function: oklch(0.742 0.104 265.663);
-  --color-code-operator: oklch(0.826 0.059 209.756);
-  --color-code-property: oklch(0.783 0.073 184.645);
-  --color-code-class: oklch(0.85 0.089 336.263);
+    --color-code: oklch(0.272 0.026 275.115);
+    --color-code-fg: oklch(0.862 0.053 273.347);
+    --color-code-block: oklch(0.272 0.026 275.115);
+    --color-code-block-fg: oklch(0.862 0.053 273.347);
+    --color-code-comment: oklch(0.697 0.046 273.777);
+    --color-code-punctuation: oklch(0.697 0.046 273.777);
+    --color-code-keyword: oklch(0.765 0.111 311.744);
+    --color-code-string: oklch(0.812 0.107 133.392);
+    --color-code-number: oklch(0.773 0.111 47.726);
+    --color-code-function: oklch(0.742 0.104 265.663);
+    --color-code-operator: oklch(0.826 0.059 209.756);
+    --color-code-property: oklch(0.783 0.073 184.645);
+    --color-code-class: oklch(0.85 0.089 336.263);
 
-  --color-info: oklch(0.742 0.104 265.663);
-  --color-on-info: oklch(0.329 0.032 274.758);
-  --color-info-hover: oklch(0.81 0.076 283.74);
-  --color-info-light: oklch(0.364 0.045 265.663);
-  --color-info-fg: oklch(0.742 0.104 265.663);
-  --color-info-border: oklch(0.742 0.104 265.663);
+    --color-info: oklch(0.742 0.104 265.663);
+    --color-on-info: oklch(0.329 0.032 274.758);
+    --color-info-hover: oklch(0.81 0.076 283.74);
+    --color-info-light: oklch(0.364 0.045 265.663);
+    --color-info-fg: oklch(0.742 0.104 265.663);
+    --color-info-border: oklch(0.742 0.104 265.663);
 
-  --color-danger: oklch(0.717 0.124 19.386);
-  --color-on-danger: oklch(0.329 0.032 274.758);
-  --color-danger-hover: oklch(0.844 0.055 18.307);
-  --color-danger-light: oklch(0.34 0.045 19.386);
-  --color-danger-fg: oklch(0.717 0.124 19.386);
-  --color-danger-border: oklch(0.717 0.124 19.386);
+    --color-danger: oklch(0.717 0.124 19.386);
+    --color-on-danger: oklch(0.329 0.032 274.758);
+    --color-danger-hover: oklch(0.844 0.055 18.307);
+    --color-danger-light: oklch(0.34 0.045 19.386);
+    --color-danger-fg: oklch(0.717 0.124 19.386);
+    --color-danger-border: oklch(0.717 0.124 19.386);
 
-  --color-reward: oklch(0.844 0.08 83.472);
-  --color-on-reward: oklch(0.329 0.032 274.758);
-  --color-reward-hover: oklch(0.844 0.08 83.472);
-  --color-reward-light: oklch(0.364 0.045 83.472);
-  --color-reward-fg: oklch(0.844 0.08 83.472);
-  --color-reward-border: oklch(0.844 0.08 83.472);
-  --color-github-star: oklch(0.844 0.08 83.472);
-  --color-warning-bg: var(--color-reward-light);
-  --color-warning-fg: var(--color-reward-fg);
-  --color-warning-border: var(--color-reward-border);
+    --color-reward: oklch(0.844 0.08 83.472);
+    --color-on-reward: oklch(0.329 0.032 274.758);
+    --color-reward-hover: oklch(0.844 0.08 83.472);
+    --color-reward-light: oklch(0.364 0.045 83.472);
+    --color-reward-fg: oklch(0.844 0.08 83.472);
+    --color-reward-border: oklch(0.844 0.08 83.472);
+    --color-github-star: oklch(0.844 0.08 83.472);
+    --color-warning-bg: var(--color-reward-light);
+    --color-warning-fg: var(--color-reward-fg);
+    --color-warning-border: var(--color-reward-border);
 
-  --color-contribute-bg: var(--color-info-light);
-  --color-contribute-fg: var(--color-info-fg);
-  --color-contribute-border: var(--color-info-border);
-  --color-contribute-hover-bg: oklch(0.399 0.055 265.663);
-  --color-contribute-hover-border: oklch(0.81 0.076 283.74);
+    --color-contribute-bg: var(--color-info-light);
+    --color-contribute-fg: var(--color-info-fg);
+    --color-contribute-border: var(--color-info-border);
+    --color-contribute-hover-bg: oklch(0.399 0.055 265.663);
+    --color-contribute-hover-border: oklch(0.81 0.076 283.74);
 
-  --color-overlay: oklch(0 0 0 / 0.65);
-  --color-shadow: oklch(0 0 0 / 0.45);
-  --color-mask: oklch(1 0 0);
-  --color-selection-bg: oklch(0.765 0.111 311.744 / 0.35);
-  --color-selection-fg: oklch(0.329 0.032 274.758);
+    --color-overlay: oklch(0 0 0 / 0.65);
+    --color-shadow: oklch(0 0 0 / 0.45);
+    --color-mask: oklch(1 0 0);
+    --color-selection-bg: oklch(0.765 0.111 311.744 / 0.35);
+    --color-selection-fg: oklch(0.329 0.032 274.758);
 
-  --color-topic-blue-bg: oklch(0.354 0.045 265.663);
-  --color-topic-blue-border: oklch(0.742 0.104 265.663);
-  --color-topic-blue-hover: oklch(0.81 0.076 283.74);
-  --color-topic-indigo-bg: oklch(0.354 0.045 283.74);
-  --color-topic-indigo-border: oklch(0.81 0.076 283.74);
-  --color-topic-indigo-hover: oklch(0.765 0.111 311.744);
-  --color-topic-green-bg: oklch(0.354 0.045 133.392);
-  --color-topic-green-border: oklch(0.812 0.107 133.392);
-  --color-topic-green-hover: oklch(0.783 0.073 184.645);
-  --color-topic-purple-bg: oklch(0.354 0.045 311.744);
-  --color-topic-purple-border: oklch(0.765 0.111 311.744);
-  --color-topic-purple-hover: oklch(0.85 0.089 336.263);
-  --color-topic-pink-bg: oklch(0.354 0.045 336.263);
-  --color-topic-pink-border: oklch(0.85 0.089 336.263);
-  --color-topic-pink-hover: oklch(0.844 0.055 18.307);
-  --color-topic-amber-bg: oklch(0.354 0.045 83.472);
-  --color-topic-amber-border: oklch(0.844 0.08 83.472);
-  --color-topic-amber-hover: oklch(0.773 0.111 47.726);
-  --color-topic-red-bg: oklch(0.354 0.045 19.386);
-  --color-topic-red-border: oklch(0.717 0.124 19.386);
-  --color-topic-red-hover: oklch(0.844 0.055 18.307);
-  --color-topic-cyan-bg: oklch(0.354 0.045 184.645);
-  --color-topic-cyan-border: oklch(0.783 0.073 184.645);
-  --color-topic-cyan-hover: oklch(0.826 0.059 209.756);
-  --color-topic-orange-bg: oklch(0.354 0.045 47.726);
-  --color-topic-orange-border: oklch(0.773 0.111 47.726);
-  --color-topic-orange-hover: oklch(0.824 0.101 52.629);
+    --color-topic-blue-bg: oklch(0.354 0.045 265.663);
+    --color-topic-blue-border: oklch(0.742 0.104 265.663);
+    --color-topic-blue-hover: oklch(0.81 0.076 283.74);
+    --color-topic-indigo-bg: oklch(0.354 0.045 283.74);
+    --color-topic-indigo-border: oklch(0.81 0.076 283.74);
+    --color-topic-indigo-hover: oklch(0.765 0.111 311.744);
+    --color-topic-green-bg: oklch(0.354 0.045 133.392);
+    --color-topic-green-border: oklch(0.812 0.107 133.392);
+    --color-topic-green-hover: oklch(0.783 0.073 184.645);
+    --color-topic-purple-bg: oklch(0.354 0.045 311.744);
+    --color-topic-purple-border: oklch(0.765 0.111 311.744);
+    --color-topic-purple-hover: oklch(0.85 0.089 336.263);
+    --color-topic-pink-bg: oklch(0.354 0.045 336.263);
+    --color-topic-pink-border: oklch(0.85 0.089 336.263);
+    --color-topic-pink-hover: oklch(0.844 0.055 18.307);
+    --color-topic-amber-bg: oklch(0.354 0.045 83.472);
+    --color-topic-amber-border: oklch(0.844 0.08 83.472);
+    --color-topic-amber-hover: oklch(0.773 0.111 47.726);
+    --color-topic-red-bg: oklch(0.354 0.045 19.386);
+    --color-topic-red-border: oklch(0.717 0.124 19.386);
+    --color-topic-red-hover: oklch(0.844 0.055 18.307);
+    --color-topic-cyan-bg: oklch(0.354 0.045 184.645);
+    --color-topic-cyan-border: oklch(0.783 0.073 184.645);
+    --color-topic-cyan-hover: oklch(0.826 0.059 209.756);
+    --color-topic-orange-bg: oklch(0.354 0.045 47.726);
+    --color-topic-orange-border: oklch(0.773 0.111 47.726);
+    --color-topic-orange-hover: oklch(0.824 0.101 52.629);
 
-  --color-correct-bg: oklch(0.359 0.05 133.392);
-  --color-correct-border: oklch(0.812 0.107 133.392);
-  --color-correct-fg: oklch(0.812 0.107 133.392);
-  --color-incorrect-bg: oklch(0.339 0.045 19.386);
-  --color-incorrect-border: oklch(0.717 0.124 19.386);
-  --color-incorrect-fg: oklch(0.717 0.124 19.386);
-  --color-pending-bg: oklch(0.364 0.045 265.663);
-  --color-pending-border: oklch(0.742 0.104 265.663);
-  --color-pending-fg: oklch(0.742 0.104 265.663);
+    --color-correct-bg: oklch(0.359 0.05 133.392);
+    --color-correct-border: oklch(0.812 0.107 133.392);
+    --color-correct-fg: oklch(0.812 0.107 133.392);
+    --color-incorrect-bg: oklch(0.339 0.045 19.386);
+    --color-incorrect-border: oklch(0.717 0.124 19.386);
+    --color-incorrect-fg: oklch(0.717 0.124 19.386);
+    --color-pending-bg: oklch(0.364 0.045 265.663);
+    --color-pending-border: oklch(0.742 0.104 265.663);
+    --color-pending-fg: oklch(0.742 0.104 265.663);
 }
 
 /* ── Catppuccin Macchiato ── */
 html[data-theme="macchiato"] {
-  --color-surface: oklch(0.279 0.035 276.937);
-  --color-surface-alt: oklch(0.219 0.025 280.657);
-  --color-fg: oklch(0.871 0.048 273.665);
-  --color-fg-secondary: oklch(0.812 0.046 274.267);
-  --color-fg-muted: oklch(0.812 0.046 274.267);
-  --color-border: oklch(0.426 0.039 276.948);
-  --color-card-footer: oklch(0.249 0.03 278.435);
-  --color-card-footer-border: oklch(0.494 0.039 275.683);
+    --color-surface: oklch(0.279 0.035 276.937);
+    --color-surface-alt: oklch(0.219 0.025 280.657);
+    --color-fg: oklch(0.871 0.048 273.665);
+    --color-fg-secondary: oklch(0.812 0.046 274.267);
+    --color-fg-muted: oklch(0.812 0.046 274.267);
+    --color-border: oklch(0.426 0.039 276.948);
+    --color-card-footer: oklch(0.249 0.03 278.435);
+    --color-card-footer-border: oklch(0.494 0.039 275.683);
 
-  --color-accent: oklch(0.772 0.126 303.898);
-  --color-on-accent: oklch(0.279 0.035 276.937);
-  --color-accent-light: oklch(0.219 0.025 280.657);
-  --color-accent-fg: oklch(0.75 0.11 263.81);
-  --color-accent-hover: oklch(0.814 0.083 279.854);
-  --color-accent-border: oklch(0.814 0.083 279.854);
+    --color-accent: oklch(0.772 0.126 303.898);
+    --color-on-accent: oklch(0.279 0.035 276.937);
+    --color-accent-light: oklch(0.219 0.025 280.657);
+    --color-accent-fg: oklch(0.75 0.11 263.81);
+    --color-accent-hover: oklch(0.814 0.083 279.854);
+    --color-accent-border: oklch(0.814 0.083 279.854);
 
-  --color-code: oklch(0.219 0.025 280.657);
-  --color-code-fg: oklch(0.871 0.048 273.665);
-  --color-code-block: oklch(0.219 0.025 280.657);
-  --color-code-block-fg: oklch(0.871 0.048 273.665);
-  --color-code-comment: oklch(0.69 0.043 274.539);
-  --color-code-punctuation: oklch(0.69 0.043 274.539);
-  --color-code-keyword: oklch(0.772 0.126 303.898);
-  --color-code-string: oklch(0.835 0.108 138.15);
-  --color-code-number: oklch(0.799 0.106 49.638);
-  --color-code-function: oklch(0.75 0.11 263.81);
-  --color-code-operator: oklch(0.837 0.072 209.366);
-  --color-code-property: oklch(0.821 0.076 184.1);
-  --color-code-class: oklch(0.861 0.083 336.18);
+    --color-code: oklch(0.219 0.025 280.657);
+    --color-code-fg: oklch(0.871 0.048 273.665);
+    --color-code-block: oklch(0.219 0.025 280.657);
+    --color-code-block-fg: oklch(0.871 0.048 273.665);
+    --color-code-comment: oklch(0.69 0.043 274.539);
+    --color-code-punctuation: oklch(0.69 0.043 274.539);
+    --color-code-keyword: oklch(0.772 0.126 303.898);
+    --color-code-string: oklch(0.835 0.108 138.15);
+    --color-code-number: oklch(0.799 0.106 49.638);
+    --color-code-function: oklch(0.75 0.11 263.81);
+    --color-code-operator: oklch(0.837 0.072 209.366);
+    --color-code-property: oklch(0.821 0.076 184.1);
+    --color-code-class: oklch(0.861 0.083 336.18);
 
-  --color-info: oklch(0.75 0.11 263.81);
-  --color-on-info: oklch(0.279 0.035 276.937);
-  --color-info-hover: oklch(0.814 0.083 279.854);
-  --color-info-light: oklch(0.314 0.045 263.81);
-  --color-info-fg: oklch(0.75 0.11 263.81);
-  --color-info-border: oklch(0.75 0.11 263.81);
+    --color-info: oklch(0.75 0.11 263.81);
+    --color-on-info: oklch(0.279 0.035 276.937);
+    --color-info-hover: oklch(0.814 0.083 279.854);
+    --color-info-light: oklch(0.314 0.045 263.81);
+    --color-info-fg: oklch(0.75 0.11 263.81);
+    --color-info-border: oklch(0.75 0.11 263.81);
 
-  --color-danger: oklch(0.737 0.125 11.194);
-  --color-on-danger: oklch(0.279 0.035 276.937);
-  --color-danger-hover: oklch(0.863 0.048 18.12);
-  --color-danger-light: oklch(0.314 0.045 11.194);
-  --color-danger-fg: oklch(0.737 0.125 11.194);
-  --color-danger-border: oklch(0.737 0.125 11.194);
+    --color-danger: oklch(0.737 0.125 11.194);
+    --color-on-danger: oklch(0.279 0.035 276.937);
+    --color-danger-hover: oklch(0.863 0.048 18.12);
+    --color-danger-light: oklch(0.314 0.045 11.194);
+    --color-danger-fg: oklch(0.737 0.125 11.194);
+    --color-danger-border: oklch(0.737 0.125 11.194);
 
-  --color-reward: oklch(0.879 0.074 84.751);
-  --color-on-reward: oklch(0.279 0.035 276.937);
-  --color-reward-hover: oklch(0.879 0.074 84.751);
-  --color-reward-light: oklch(0.314 0.045 84.751);
-  --color-reward-fg: oklch(0.879 0.074 84.751);
-  --color-reward-border: oklch(0.879 0.074 84.751);
-  --color-github-star: oklch(0.879 0.074 84.751);
-  --color-warning-bg: var(--color-reward-light);
-  --color-warning-fg: var(--color-reward-fg);
-  --color-warning-border: var(--color-reward-border);
+    --color-reward: oklch(0.879 0.074 84.751);
+    --color-on-reward: oklch(0.279 0.035 276.937);
+    --color-reward-hover: oklch(0.879 0.074 84.751);
+    --color-reward-light: oklch(0.314 0.045 84.751);
+    --color-reward-fg: oklch(0.879 0.074 84.751);
+    --color-reward-border: oklch(0.879 0.074 84.751);
+    --color-github-star: oklch(0.879 0.074 84.751);
+    --color-warning-bg: var(--color-reward-light);
+    --color-warning-fg: var(--color-reward-fg);
+    --color-warning-border: var(--color-reward-border);
 
-  --color-contribute-bg: var(--color-info-light);
-  --color-contribute-fg: var(--color-info-fg);
-  --color-contribute-border: var(--color-info-border);
-  --color-contribute-hover-bg: oklch(0.349 0.055 263.81);
-  --color-contribute-hover-border: oklch(0.814 0.083 279.854);
+    --color-contribute-bg: var(--color-info-light);
+    --color-contribute-fg: var(--color-info-fg);
+    --color-contribute-border: var(--color-info-border);
+    --color-contribute-hover-bg: oklch(0.349 0.055 263.81);
+    --color-contribute-hover-border: oklch(0.814 0.083 279.854);
 
-  --color-overlay: oklch(0 0 0 / 0.65);
-  --color-shadow: oklch(0 0 0 / 0.45);
-  --color-mask: oklch(1 0 0);
-  --color-selection-bg: oklch(0.772 0.126 303.898 / 0.35);
-  --color-selection-fg: oklch(0.279 0.035 276.937);
+    --color-overlay: oklch(0 0 0 / 0.65);
+    --color-shadow: oklch(0 0 0 / 0.45);
+    --color-mask: oklch(1 0 0);
+    --color-selection-bg: oklch(0.772 0.126 303.898 / 0.35);
+    --color-selection-fg: oklch(0.279 0.035 276.937);
 
-  --color-topic-blue-bg: oklch(0.304 0.045 263.81);
-  --color-topic-blue-border: oklch(0.75 0.11 263.81);
-  --color-topic-blue-hover: oklch(0.814 0.083 279.854);
-  --color-topic-indigo-bg: oklch(0.304 0.045 279.854);
-  --color-topic-indigo-border: oklch(0.814 0.083 279.854);
-  --color-topic-indigo-hover: oklch(0.772 0.126 303.898);
-  --color-topic-green-bg: oklch(0.304 0.045 138.15);
-  --color-topic-green-border: oklch(0.835 0.108 138.15);
-  --color-topic-green-hover: oklch(0.821 0.076 184.1);
-  --color-topic-purple-bg: oklch(0.304 0.045 303.898);
-  --color-topic-purple-border: oklch(0.772 0.126 303.898);
-  --color-topic-purple-hover: oklch(0.861 0.083 336.18);
-  --color-topic-pink-bg: oklch(0.304 0.045 336.18);
-  --color-topic-pink-border: oklch(0.861 0.083 336.18);
-  --color-topic-pink-hover: oklch(0.863 0.048 18.12);
-  --color-topic-amber-bg: oklch(0.304 0.045 84.751);
-  --color-topic-amber-border: oklch(0.879 0.074 84.751);
-  --color-topic-amber-hover: oklch(0.799 0.106 49.638);
-  --color-topic-red-bg: oklch(0.304 0.045 11.194);
-  --color-topic-red-border: oklch(0.737 0.125 11.194);
-  --color-topic-red-hover: oklch(0.863 0.048 18.12);
-  --color-topic-cyan-bg: oklch(0.304 0.045 184.1);
-  --color-topic-cyan-border: oklch(0.821 0.076 184.1);
-  --color-topic-cyan-hover: oklch(0.837 0.072 209.366);
-  --color-topic-orange-bg: oklch(0.304 0.045 49.638);
-  --color-topic-orange-border: oklch(0.799 0.106 49.638);
-  --color-topic-orange-hover: oklch(0.824 0.101 49.638);
+    --color-topic-blue-bg: oklch(0.304 0.045 263.81);
+    --color-topic-blue-border: oklch(0.75 0.11 263.81);
+    --color-topic-blue-hover: oklch(0.814 0.083 279.854);
+    --color-topic-indigo-bg: oklch(0.304 0.045 279.854);
+    --color-topic-indigo-border: oklch(0.814 0.083 279.854);
+    --color-topic-indigo-hover: oklch(0.772 0.126 303.898);
+    --color-topic-green-bg: oklch(0.304 0.045 138.15);
+    --color-topic-green-border: oklch(0.835 0.108 138.15);
+    --color-topic-green-hover: oklch(0.821 0.076 184.1);
+    --color-topic-purple-bg: oklch(0.304 0.045 303.898);
+    --color-topic-purple-border: oklch(0.772 0.126 303.898);
+    --color-topic-purple-hover: oklch(0.861 0.083 336.18);
+    --color-topic-pink-bg: oklch(0.304 0.045 336.18);
+    --color-topic-pink-border: oklch(0.861 0.083 336.18);
+    --color-topic-pink-hover: oklch(0.863 0.048 18.12);
+    --color-topic-amber-bg: oklch(0.304 0.045 84.751);
+    --color-topic-amber-border: oklch(0.879 0.074 84.751);
+    --color-topic-amber-hover: oklch(0.799 0.106 49.638);
+    --color-topic-red-bg: oklch(0.304 0.045 11.194);
+    --color-topic-red-border: oklch(0.737 0.125 11.194);
+    --color-topic-red-hover: oklch(0.863 0.048 18.12);
+    --color-topic-cyan-bg: oklch(0.304 0.045 184.1);
+    --color-topic-cyan-border: oklch(0.821 0.076 184.1);
+    --color-topic-cyan-hover: oklch(0.837 0.072 209.366);
+    --color-topic-orange-bg: oklch(0.304 0.045 49.638);
+    --color-topic-orange-border: oklch(0.799 0.106 49.638);
+    --color-topic-orange-hover: oklch(0.824 0.101 49.638);
 
-  --color-correct-bg: oklch(0.309 0.05 138.15);
-  --color-correct-border: oklch(0.835 0.108 138.15);
-  --color-correct-fg: oklch(0.835 0.108 138.15);
-  --color-incorrect-bg: oklch(0.309 0.05 11.194);
-  --color-incorrect-border: oklch(0.737 0.125 11.194);
-  --color-incorrect-fg: oklch(0.737 0.125 11.194);
-  --color-pending-bg: oklch(0.314 0.045 263.81);
-  --color-pending-border: oklch(0.75 0.11 263.81);
-  --color-pending-fg: oklch(0.75 0.11 263.81);
+    --color-correct-bg: oklch(0.309 0.05 138.15);
+    --color-correct-border: oklch(0.835 0.108 138.15);
+    --color-correct-fg: oklch(0.835 0.108 138.15);
+    --color-incorrect-bg: oklch(0.309 0.05 11.194);
+    --color-incorrect-border: oklch(0.737 0.125 11.194);
+    --color-incorrect-fg: oklch(0.737 0.125 11.194);
+    --color-pending-bg: oklch(0.314 0.045 263.81);
+    --color-pending-border: oklch(0.75 0.11 263.81);
+    --color-pending-fg: oklch(0.75 0.11 263.81);
 }
 
 /* ── Catppuccin Mocha ── */
 html[data-theme="mocha"] {
-  --color-surface: oklch(0.243 0.03 283.911);
-  --color-surface-alt: oklch(0.183 0.02 284.204);
-  --color-fg: oklch(0.879 0.043 272.277);
-  --color-fg-secondary: oklch(0.817 0.04 272.862);
-  --color-fg-muted: oklch(0.817 0.04 272.862);
-  --color-border: oklch(0.404 0.032 280.152);
-  --color-card-footer: oklch(0.216 0.025 284.065);
-  --color-card-footer-border: oklch(0.477 0.034 278.643);
+    --color-surface: oklch(0.243 0.03 283.911);
+    --color-surface-alt: oklch(0.183 0.02 284.204);
+    --color-fg: oklch(0.879 0.043 272.277);
+    --color-fg-secondary: oklch(0.817 0.04 272.862);
+    --color-fg-muted: oklch(0.817 0.04 272.862);
+    --color-border: oklch(0.404 0.032 280.152);
+    --color-card-footer: oklch(0.216 0.025 284.065);
+    --color-card-footer-border: oklch(0.477 0.034 278.643);
 
-  --color-accent: oklch(0.787 0.119 304.769);
-  --color-on-accent: oklch(0.243 0.03 283.911);
-  --color-accent-light: oklch(0.183 0.02 284.204);
-  --color-accent-fg: oklch(0.766 0.111 259.885);
-  --color-accent-hover: oklch(0.817 0.091 277.309);
-  --color-accent-border: oklch(0.817 0.091 277.309);
+    --color-accent: oklch(0.787 0.119 304.769);
+    --color-on-accent: oklch(0.243 0.03 283.911);
+    --color-accent-light: oklch(0.183 0.02 284.204);
+    --color-accent-fg: oklch(0.766 0.111 259.885);
+    --color-accent-hover: oklch(0.817 0.091 277.309);
+    --color-accent-border: oklch(0.817 0.091 277.309);
 
-  --color-code: oklch(0.183 0.02 284.204);
-  --color-code-fg: oklch(0.879 0.043 272.277);
-  --color-code-block: oklch(0.183 0.02 284.204);
-  --color-code-block-fg: oklch(0.879 0.043 272.277);
-  --color-code-comment: oklch(0.687 0.037 274.725);
-  --color-code-punctuation: oklch(0.687 0.037 274.725);
-  --color-code-keyword: oklch(0.787 0.119 304.769);
-  --color-code-string: oklch(0.858 0.109 142.715);
-  --color-code-number: oklch(0.824 0.101 52.629);
-  --color-code-function: oklch(0.766 0.111 259.885);
-  --color-code-operator: oklch(0.847 0.083 210.255);
-  --color-code-property: oklch(0.858 0.079 182.75);
-  --color-code-class: oklch(0.87 0.075 336.304);
+    --color-code: oklch(0.183 0.02 284.204);
+    --color-code-fg: oklch(0.879 0.043 272.277);
+    --color-code-block: oklch(0.183 0.02 284.204);
+    --color-code-block-fg: oklch(0.879 0.043 272.277);
+    --color-code-comment: oklch(0.687 0.037 274.725);
+    --color-code-punctuation: oklch(0.687 0.037 274.725);
+    --color-code-keyword: oklch(0.787 0.119 304.769);
+    --color-code-string: oklch(0.858 0.109 142.715);
+    --color-code-number: oklch(0.824 0.101 52.629);
+    --color-code-function: oklch(0.766 0.111 259.885);
+    --color-code-operator: oklch(0.847 0.083 210.255);
+    --color-code-property: oklch(0.858 0.079 182.75);
+    --color-code-class: oklch(0.87 0.075 336.304);
 
-  --color-info: oklch(0.766 0.111 259.885);
-  --color-on-info: oklch(0.243 0.03 283.911);
-  --color-info-hover: oklch(0.817 0.091 277.309);
-  --color-info-light: oklch(0.278 0.045 259.885);
-  --color-info-fg: oklch(0.766 0.111 259.885);
-  --color-info-border: oklch(0.766 0.111 259.885);
+    --color-info: oklch(0.766 0.111 259.885);
+    --color-on-info: oklch(0.243 0.03 283.911);
+    --color-info-hover: oklch(0.817 0.091 277.309);
+    --color-info-light: oklch(0.278 0.045 259.885);
+    --color-info-fg: oklch(0.766 0.111 259.885);
+    --color-info-border: oklch(0.766 0.111 259.885);
 
-  --color-danger: oklch(0.756 0.13 2.764);
-  --color-on-danger: oklch(0.243 0.03 283.911);
-  --color-danger-hover: oklch(0.88 0.042 17.975);
-  --color-danger-light: oklch(0.278 0.045 2.764);
-  --color-danger-fg: oklch(0.756 0.13 2.764);
-  --color-danger-border: oklch(0.756 0.13 2.764);
+    --color-danger: oklch(0.756 0.13 2.764);
+    --color-on-danger: oklch(0.243 0.03 283.911);
+    --color-danger-hover: oklch(0.88 0.042 17.975);
+    --color-danger-light: oklch(0.278 0.045 2.764);
+    --color-danger-fg: oklch(0.756 0.13 2.764);
+    --color-danger-border: oklch(0.756 0.13 2.764);
 
-  --color-reward: oklch(0.919 0.07 86.528);
-  --color-on-reward: oklch(0.243 0.03 283.911);
-  --color-reward-hover: oklch(0.919 0.07 86.528);
-  --color-reward-light: oklch(0.278 0.045 86.528);
-  --color-reward-fg: oklch(0.919 0.07 86.528);
-  --color-reward-border: oklch(0.919 0.07 86.528);
-  --color-github-star: oklch(0.919 0.07 86.528);
-  --color-warning-bg: var(--color-reward-light);
-  --color-warning-fg: var(--color-reward-fg);
-  --color-warning-border: var(--color-reward-border);
+    --color-reward: oklch(0.919 0.07 86.528);
+    --color-on-reward: oklch(0.243 0.03 283.911);
+    --color-reward-hover: oklch(0.919 0.07 86.528);
+    --color-reward-light: oklch(0.278 0.045 86.528);
+    --color-reward-fg: oklch(0.919 0.07 86.528);
+    --color-reward-border: oklch(0.919 0.07 86.528);
+    --color-github-star: oklch(0.919 0.07 86.528);
+    --color-warning-bg: var(--color-reward-light);
+    --color-warning-fg: var(--color-reward-fg);
+    --color-warning-border: var(--color-reward-border);
 
-  --color-contribute-bg: var(--color-info-light);
-  --color-contribute-fg: var(--color-info-fg);
-  --color-contribute-border: var(--color-info-border);
-  --color-contribute-hover-bg: oklch(0.313 0.055 259.885);
-  --color-contribute-hover-border: oklch(0.817 0.091 277.309);
+    --color-contribute-bg: var(--color-info-light);
+    --color-contribute-fg: var(--color-info-fg);
+    --color-contribute-border: var(--color-info-border);
+    --color-contribute-hover-bg: oklch(0.313 0.055 259.885);
+    --color-contribute-hover-border: oklch(0.817 0.091 277.309);
 
-  --color-overlay: oklch(0 0 0 / 0.65);
-  --color-shadow: oklch(0 0 0 / 0.45);
-  --color-mask: oklch(1 0 0);
-  --color-selection-bg: oklch(0.787 0.119 304.769 / 0.35);
-  --color-selection-fg: oklch(0.243 0.03 283.911);
+    --color-overlay: oklch(0 0 0 / 0.65);
+    --color-shadow: oklch(0 0 0 / 0.45);
+    --color-mask: oklch(1 0 0);
+    --color-selection-bg: oklch(0.787 0.119 304.769 / 0.35);
+    --color-selection-fg: oklch(0.243 0.03 283.911);
 
-  --color-topic-blue-bg: oklch(0.268 0.045 259.885);
-  --color-topic-blue-border: oklch(0.766 0.111 259.885);
-  --color-topic-blue-hover: oklch(0.817 0.091 277.309);
-  --color-topic-indigo-bg: oklch(0.268 0.045 277.309);
-  --color-topic-indigo-border: oklch(0.817 0.091 277.309);
-  --color-topic-indigo-hover: oklch(0.787 0.119 304.769);
-  --color-topic-green-bg: oklch(0.268 0.045 142.715);
-  --color-topic-green-border: oklch(0.858 0.109 142.715);
-  --color-topic-green-hover: oklch(0.858 0.079 182.75);
-  --color-topic-purple-bg: oklch(0.268 0.045 304.769);
-  --color-topic-purple-border: oklch(0.787 0.119 304.769);
-  --color-topic-purple-hover: oklch(0.87 0.075 336.304);
-  --color-topic-pink-bg: oklch(0.268 0.045 336.304);
-  --color-topic-pink-border: oklch(0.87 0.075 336.304);
-  --color-topic-pink-hover: oklch(0.88 0.042 17.975);
-  --color-topic-amber-bg: oklch(0.268 0.045 86.528);
-  --color-topic-amber-border: oklch(0.919 0.07 86.528);
-  --color-topic-amber-hover: oklch(0.824 0.101 52.629);
-  --color-topic-red-bg: oklch(0.268 0.045 2.764);
-  --color-topic-red-border: oklch(0.756 0.13 2.764);
-  --color-topic-red-hover: oklch(0.88 0.042 17.975);
-  --color-topic-cyan-bg: oklch(0.268 0.045 182.75);
-  --color-topic-cyan-border: oklch(0.858 0.079 182.75);
-  --color-topic-cyan-hover: oklch(0.847 0.083 210.255);
-  --color-topic-orange-bg: oklch(0.268 0.045 52.629);
-  --color-topic-orange-border: oklch(0.824 0.101 52.629);
-  --color-topic-orange-hover: oklch(0.919 0.07 86.528);
+    --color-topic-blue-bg: oklch(0.268 0.045 259.885);
+    --color-topic-blue-border: oklch(0.766 0.111 259.885);
+    --color-topic-blue-hover: oklch(0.817 0.091 277.309);
+    --color-topic-indigo-bg: oklch(0.268 0.045 277.309);
+    --color-topic-indigo-border: oklch(0.817 0.091 277.309);
+    --color-topic-indigo-hover: oklch(0.787 0.119 304.769);
+    --color-topic-green-bg: oklch(0.268 0.045 142.715);
+    --color-topic-green-border: oklch(0.858 0.109 142.715);
+    --color-topic-green-hover: oklch(0.858 0.079 182.75);
+    --color-topic-purple-bg: oklch(0.268 0.045 304.769);
+    --color-topic-purple-border: oklch(0.787 0.119 304.769);
+    --color-topic-purple-hover: oklch(0.87 0.075 336.304);
+    --color-topic-pink-bg: oklch(0.268 0.045 336.304);
+    --color-topic-pink-border: oklch(0.87 0.075 336.304);
+    --color-topic-pink-hover: oklch(0.88 0.042 17.975);
+    --color-topic-amber-bg: oklch(0.268 0.045 86.528);
+    --color-topic-amber-border: oklch(0.919 0.07 86.528);
+    --color-topic-amber-hover: oklch(0.824 0.101 52.629);
+    --color-topic-red-bg: oklch(0.268 0.045 2.764);
+    --color-topic-red-border: oklch(0.756 0.13 2.764);
+    --color-topic-red-hover: oklch(0.88 0.042 17.975);
+    --color-topic-cyan-bg: oklch(0.268 0.045 182.75);
+    --color-topic-cyan-border: oklch(0.858 0.079 182.75);
+    --color-topic-cyan-hover: oklch(0.847 0.083 210.255);
+    --color-topic-orange-bg: oklch(0.268 0.045 52.629);
+    --color-topic-orange-border: oklch(0.824 0.101 52.629);
+    --color-topic-orange-hover: oklch(0.919 0.07 86.528);
 
-  --color-correct-bg: oklch(0.273 0.05 142.715);
-  --color-correct-border: oklch(0.858 0.109 142.715);
-  --color-correct-fg: oklch(0.858 0.109 142.715);
-  --color-incorrect-bg: oklch(0.273 0.05 2.764);
-  --color-incorrect-border: oklch(0.756 0.13 2.764);
-  --color-incorrect-fg: oklch(0.756 0.13 2.764);
-  --color-pending-bg: oklch(0.278 0.045 259.885);
-  --color-pending-border: oklch(0.766 0.111 259.885);
-  --color-pending-fg: oklch(0.766 0.111 259.885);
+    --color-correct-bg: oklch(0.273 0.05 142.715);
+    --color-correct-border: oklch(0.858 0.109 142.715);
+    --color-correct-fg: oklch(0.858 0.109 142.715);
+    --color-incorrect-bg: oklch(0.273 0.05 2.764);
+    --color-incorrect-border: oklch(0.756 0.13 2.764);
+    --color-incorrect-fg: oklch(0.756 0.13 2.764);
+    --color-pending-bg: oklch(0.278 0.045 259.885);
+    --color-pending-border: oklch(0.766 0.111 259.885);
+    --color-pending-fg: oklch(0.766 0.111 259.885);
 }
 
 ::selection {
-  background: var(--color-selection-bg);
-  color: var(--color-selection-fg);
-}
-
-.prose {
-  --tw-prose-body: var(--color-fg-secondary);
-  --tw-prose-headings: var(--color-fg);
-  --tw-prose-lead: var(--color-fg-secondary);
-  --tw-prose-links: var(--color-accent-fg);
-  --tw-prose-bold: var(--color-fg);
-  --tw-prose-counters: var(--color-fg-muted);
-  --tw-prose-bullets: var(--color-border);
-  --tw-prose-hr: var(--color-border);
-  --tw-prose-quotes: var(--color-fg-secondary);
-  --tw-prose-quote-borders: var(--color-border);
-  --tw-prose-captions: var(--color-fg-muted);
-  --tw-prose-code: var(--color-code-fg);
-  --tw-prose-pre-code: var(--color-code-block-fg);
-  --tw-prose-pre-bg: var(--color-code-block);
-  --tw-prose-th-borders: var(--color-border);
-  --tw-prose-td-borders: var(--color-border);
-}
-
-/* ── Question-card Markdown ──
-   The typography plugin is tuned for article-length prose. Question content
-   is denser and mixes prompts, lists, formulas, and code blocks, so keep its
-   rhythm explicit and shared across every Markdown field. */
-.markdown-body {
-  overflow-wrap: break-word;
-  line-height: 1.5;
-}
-
-.markdown-body > :first-child {
-  margin-block-start: 0;
-}
-
-.markdown-body > :last-child {
-  margin-block-end: 0;
-}
-
-.markdown-body :where(p) {
-  margin-block: 0;
-  text-wrap: pretty;
-}
-
-.markdown-body :where(p + p) {
-  margin-block-start: 0.75em;
-}
-
-.markdown-body :where(h1, h2, h3, h4) {
-  font-weight: 700;
-  text-wrap: balance;
-}
-
-.markdown-body :where(h1) {
-  margin-block: 0 0.5em;
-  font-size: 1.5em;
-  line-height: 1.2;
-}
-
-.markdown-body :where(h2) {
-  margin-block: 1em 0.45em;
-  font-size: 1.25em;
-  line-height: 1.25;
-}
-
-.markdown-body :where(h3) {
-  margin-block: 0.9em 0.35em;
-  font-size: 1.125em;
-  line-height: 1.3;
-}
-
-.markdown-body :where(h4) {
-  margin-block: 0.8em 0.3em;
-  font-size: 1em;
-  line-height: 1.35;
-}
-
-.markdown-body :where(ul, ol) {
-  margin-block: 0.75em;
-  padding-inline-start: 1.5em;
-}
-
-.markdown-body :where(li) {
-  margin-block: 0.25em;
-}
-
-.markdown-body :where(li > ul, li > ol) {
-  margin-block: 0.35em;
-}
-
-.markdown-body :where(blockquote) {
-  margin-block: 0.75em;
-  border-inline-start: 0.2em solid var(--color-border);
-  padding-inline-start: 1em;
-  color: var(--color-fg-secondary);
-}
-
-.markdown-body :where(hr) {
-  margin-block: 1.25em;
-  border: 0;
-  border-block-start: 1px solid var(--color-border);
-}
-
-.markdown-body :where(a) {
-  text-decoration-thickness: from-font;
-  text-underline-offset: 0.15em;
-  text-underline-position: from-font;
-}
-
-.markdown-body :where(.markdown-code-block) {
-  max-inline-size: 100%;
-  margin-block: 0.75em;
-}
-
-.markdown-body :where(.markdown-table) {
-  margin-block: 0.75em;
-}
-
-.markdown-body :where(.markdown-code-block pre) {
-  max-inline-size: 100%;
-}
-
-.markdown-body :where(.footnotes) {
-  margin-block-start: 1em;
-  font-size: 0.9em;
-}
-
-.markdown-body :where(.footnotes ol) {
-  margin-block: 0.5em 0;
-}
-
-.markdown-body :where(.footnotes li) {
-  margin-block: 0.35em;
-}
-
-.markdown-body :where(input[type="checkbox"]) {
-  margin-inline-end: 0.5em;
-  vertical-align: middle;
-  accent-color: var(--color-accent);
+    background: var(--color-selection-bg);
+    color: var(--color-selection-fg);
 }
 
 /* ── Floating hero emojis ── */
 @keyframes floatDrift {
-  0%,
-  to {
-    translate: 0;
-  }
-  50% {
-    translate: 0 -10px;
-  }
+    0%,
+    to {
+        translate: 0;
+    }
+    50% {
+        translate: 0 -10px;
+    }
 }
 
 .floating-emoji-mark {
-  position: absolute;
-  display: block;
-  line-height: 1;
-  filter: drop-shadow(0 6px 10px var(--color-shadow));
-  animation: 9s ease-in-out infinite floatDrift;
-  user-select: none;
+    position: absolute;
+    display: block;
+    line-height: 1;
+    filter: drop-shadow(0 6px 10px var(--color-shadow));
+    animation: 9s ease-in-out infinite floatDrift;
+    user-select: none;
 }
 
 .floating-emoji-interactive {
-  pointer-events: auto;
-  touch-action: none;
-  -webkit-user-select: none;
+    pointer-events: auto;
+    touch-action: none;
+    -webkit-user-select: none;
 }
 
 /* ── View transition animation ── */
 ::view-transition-old(root),
 ::view-transition-new(root) {
-  animation-duration: 0.25s;
-  animation-timing-function: cubic-bezier(0.23, 1, 0.32, 1);
+    animation-duration: 0.25s;
+    animation-timing-function: cubic-bezier(0.23, 1, 0.32, 1);
 }
 
 /* ── Theme icon transition ── */
 @keyframes theme-icon-in {
-  from {
-    opacity: 0;
-    transform: scale(0.96);
-  }
-  to {
-    opacity: 1;
-    transform: rotate(0deg) scale(1);
-  }
+    from {
+        opacity: 0;
+        transform: scale(0.96);
+    }
+    to {
+        opacity: 1;
+        transform: rotate(0deg) scale(1);
+    }
 }
 
 .theme-icon {
-  animation: theme-icon-in 0.14s cubic-bezier(0.23, 1, 0.32, 1);
+    animation: theme-icon-in 0.14s cubic-bezier(0.23, 1, 0.32, 1);
 }
 
 /* A shared, restrained hover lift for the app's large navigation cards. */
 .interactive-card {
-  transition:
-    color 0.18s cubic-bezier(0.23, 1, 0.32, 1),
-    background-color 0.18s cubic-bezier(0.23, 1, 0.32, 1),
-    border-color 0.18s cubic-bezier(0.23, 1, 0.32, 1),
-    box-shadow 0.18s cubic-bezier(0.23, 1, 0.32, 1),
-    transform 0.18s cubic-bezier(0.23, 1, 0.32, 1);
+    transition:
+        color 0.18s cubic-bezier(0.23, 1, 0.32, 1),
+        background-color 0.18s cubic-bezier(0.23, 1, 0.32, 1),
+        border-color 0.18s cubic-bezier(0.23, 1, 0.32, 1),
+        box-shadow 0.18s cubic-bezier(0.23, 1, 0.32, 1),
+        transform 0.18s cubic-bezier(0.23, 1, 0.32, 1);
 }
 
 @media (hover: hover) and (pointer: fine) and (prefers-reduced-motion: no-preference) {
-  .interactive-card:hover {
-    transform: translateY(-2px);
-  }
+    .interactive-card:hover {
+        transform: translateY(-2px);
+    }
 }
 
 /* ── Shared modal surface ──
    The animation itself comes from tailwind-animations' `animate-dialog`
    utility. These classes only define the app's surface, spacing and sizes. */
 .modal-dialog {
-  box-sizing: border-box;
-  width: min(32rem, calc(100% - 2rem));
-  max-width: calc(100% - 2rem);
-  max-height: min(86svh, 48rem);
-  margin: auto;
-  overflow-x: hidden;
-  overflow-y: auto;
-  overscroll-behavior: contain;
-  scrollbar-gutter: stable;
-  border: 0;
-  border-radius: 1.5rem;
-  padding: 1.5rem;
-  background-color: var(--color-surface-alt);
-  color: var(--color-fg);
-  --tw-anim-dialog-duration: 240ms;
-  --tw-anim-dialog-backdrop-background: var(--color-overlay);
-  --tw-anim-dialog-backdrop-filter: blur(4px);
-  box-shadow:
-    0 0 0 1px light-dark(oklch(0 0 0 / 0.06), oklch(1 0 0 / 0.08)),
-    0 24px 64px -16px var(--color-shadow),
-    0 8px 24px -12px var(--color-shadow);
+    box-sizing: border-box;
+    width: min(32rem, calc(100% - 2rem));
+    max-width: calc(100% - 2rem);
+    max-height: min(86svh, 48rem);
+    margin: auto;
+    overflow-x: hidden;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    scrollbar-gutter: stable;
+    border: 0;
+    border-radius: 1.5rem;
+    padding: 1.5rem;
+    background-color: var(--color-surface-alt);
+    color: var(--color-fg);
+    --tw-anim-dialog-duration: 240ms;
+    --tw-anim-dialog-backdrop-background: var(--color-overlay);
+    --tw-anim-dialog-backdrop-filter: blur(4px);
+    box-shadow:
+        0 0 0 1px light-dark(oklch(0 0 0 / 0.06), oklch(1 0 0 / 0.08)),
+        0 24px 64px -16px var(--color-shadow),
+        0 8px 24px -12px var(--color-shadow);
 }
 
 .modal-dialog--compact {
-  width: min(24rem, calc(100% - 2rem));
+    width: min(24rem, calc(100% - 2rem));
 }
 
 .modal-dialog--wide {
-  width: min(42rem, calc(100% - 2rem));
+    width: min(42rem, calc(100% - 2rem));
 }
 
 .modal-dialog--settings {
-  width: min(58rem, calc(100% - 2rem));
-  height: min(44rem, calc(100dvh - 2rem));
-  max-height: min(44rem, calc(100dvh - 2rem));
-  overflow: hidden;
-  padding: 0;
+    width: min(58rem, calc(100% - 2rem));
+    height: min(44rem, calc(100dvh - 2rem));
+    max-height: min(44rem, calc(100dvh - 2rem));
+    overflow: hidden;
+    padding: 0;
 }
 
 .settings-menu__scroll {
-  overflow-x: hidden;
-  overflow-y: auto;
-  overscroll-behavior: contain;
-  scrollbar-gutter: stable;
+    overflow-x: hidden;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    scrollbar-gutter: stable;
 }
 
 .modal-dialog__scroll {
-  max-height: min(calc(86svh - 7rem), 41rem);
-  overflow-y: auto;
-  overscroll-behavior: contain;
-  scrollbar-gutter: stable;
+    max-height: min(calc(86svh - 7rem), 41rem);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    scrollbar-gutter: stable;
 }
 
 @media (max-width: 30rem) {
-  .modal-dialog {
-    border-radius: 1.25rem;
-    padding: 1.25rem;
-  }
+    .modal-dialog {
+        border-radius: 1.25rem;
+        padding: 1.25rem;
+    }
 
-  .modal-dialog--settings {
-    width: calc(100% - 1rem);
-    height: min(44rem, calc(100dvh - 1rem));
-    max-height: calc(100dvh - 1rem);
-    padding: 0;
-  }
+    .modal-dialog--settings {
+        width: calc(100% - 1rem);
+        height: min(44rem, calc(100dvh - 1rem));
+        max-height: calc(100dvh - 1rem);
+        padding: 0;
+    }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .floating-emoji-mark,
-  .theme-icon,
-  ::view-transition-old(root),
-  ::view-transition-new(root) {
-    animation: none;
-  }
+    .floating-emoji-mark,
+    .theme-icon,
+    ::view-transition-old(root),
+    ::view-transition-new(root) {
+        animation: none;
+    }
 
-  .interactive-card,
-  .modal-dialog,
-  .modal-dialog::backdrop {
-    transition-duration: 0.01ms !important;
-  }
+    .interactive-card,
+    .modal-dialog,
+    .modal-dialog::backdrop {
+        transition-duration: 0.01ms !important;
+    }
 
-  .modal-dialog {
-    --tw-anim-dialog-duration: 1ms;
-  }
+    .modal-dialog {
+        --tw-anim-dialog-duration: 1ms;
+    }
 
-  .modal-dialog::backdrop {
-    --tw-anim-dialog-backdrop-filter: none;
-  }
+    .modal-dialog::backdrop {
+        --tw-anim-dialog-backdrop-filter: none;
+    }
 }
 
 #root:empty {
-  min-height: 100svh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-family: system-ui, sans-serif;
-  color: var(--color-fg-muted);
+    min-height: 100svh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    font-family: system-ui, sans-serif;
+    color: var(--color-fg-muted);
 }
 
 /* ── Driver.js tour popover theming ── */
 .tour-popover.driver-popover {
-  background-color: var(--color-surface-alt);
-  color: var(--color-fg);
-  border-radius: 0.75rem;
-  padding: 1rem;
-  box-shadow:
-    0 10px 15px -3px var(--color-shadow),
-    0 4px 6px -4px var(--color-shadow);
+    background-color: var(--color-surface-alt);
+    color: var(--color-fg);
+    border-radius: 0.75rem;
+    padding: 1rem;
+    box-shadow:
+        0 10px 15px -3px var(--color-shadow),
+        0 4px 6px -4px var(--color-shadow);
 }
 
 .tour-popover .driver-popover-arrow {
-  border-color: var(--color-surface-alt);
+    border-color: var(--color-surface-alt);
 }
 
 .tour-popover .driver-popover-title {
-  color: var(--color-fg);
-  font-weight: 600;
-  font-size: 1rem;
-  line-height: 1.5;
-  margin-bottom: 0.25rem;
+    color: var(--color-fg);
+    font-weight: 600;
+    font-size: 1rem;
+    line-height: 1.5;
+    margin-bottom: 0.25rem;
 }
 
 .tour-popover .driver-popover-description {
-  color: var(--color-fg-secondary);
-  font-size: 0.875rem;
-  line-height: 1.5;
-  margin-bottom: 0.5rem;
+    color: var(--color-fg-secondary);
+    font-size: 0.875rem;
+    line-height: 1.5;
+    margin-bottom: 0.5rem;
 }
 
 .tour-popover .driver-popover-close-btn {
-  color: var(--color-fg-muted);
-  transition: color 0.15s;
+    color: var(--color-fg-muted);
+    transition: color 0.15s;
 }
 
 .tour-popover .driver-popover-progress-text {
-  color: var(--color-fg-muted);
-  font-size: 0.75rem;
+    color: var(--color-fg-muted);
+    font-size: 0.75rem;
 }
 
 .tour-popover .driver-popover-prev-btn,
 .tour-popover .driver-popover-next-btn {
-  border-radius: 0.5rem;
-  font-size: 0.8125rem;
-  font-weight: 500;
-  padding: 0.375rem 0.75rem;
-  transition:
-    background-color 0.15s,
-    color 0.15s;
-  background-image: none !important;
-  box-shadow: none !important;
-  text-shadow: none !important;
-  border: 1px solid transparent;
+    border-radius: 0.5rem;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    padding: 0.375rem 0.75rem;
+    transition:
+        background-color 0.15s,
+        color 0.15s;
+    background-image: none !important;
+    box-shadow: none !important;
+    text-shadow: none !important;
+    border: 1px solid transparent;
 }
 
 .tour-popover .driver-popover-prev-btn {
-  background-color: var(--color-code);
-  color: var(--color-fg-secondary);
-  border-color: var(--color-border);
+    background-color: var(--color-code);
+    color: var(--color-fg-secondary);
+    border-color: var(--color-border);
 }
 
 .tour-popover .driver-popover-next-btn,
 .tour-popover.driver-popover .driver-popover-next-btn.driver-popover-done-btn {
-  background: var(--color-accent);
-  color: var(--color-on-accent);
-  border-color: var(--color-accent);
+    background: var(--color-accent);
+    color: var(--color-on-accent);
+    border-color: var(--color-accent);
 }
 
 @media (hover: hover) and (pointer: fine) {
-  .tour-popover .driver-popover-close-btn:hover {
-    color: var(--color-fg);
-  }
+    .tour-popover .driver-popover-close-btn:hover {
+        color: var(--color-fg);
+    }
 
-  .tour-popover .driver-popover-prev-btn:hover {
-    background-color: var(--color-border);
-  }
+    .tour-popover .driver-popover-prev-btn:hover {
+        background-color: var(--color-border);
+    }
 
-  .tour-popover .driver-popover-next-btn:hover,
-  .tour-popover.driver-popover
-    .driver-popover-next-btn.driver-popover-done-btn:hover {
-    background: var(--color-accent-hover);
-    border-color: var(--color-accent-hover);
-  }
+    .tour-popover .driver-popover-next-btn:hover,
+    .tour-popover.driver-popover
+        .driver-popover-next-btn.driver-popover-done-btn:hover {
+        background: var(--color-accent-hover);
+        border-color: var(--color-accent-hover);
+    }
 }

--- a/unlighthouse.config.ts
+++ b/unlighthouse.config.ts
@@ -2,6 +2,7 @@ import { defineUnlighthouseConfig } from "unlighthouse/config";
 
 const site =
 	process.env.UNLIGHTHOUSE_SITE?.trim() || "http://127.0.0.1:4173";
+const benchmarkTimestamp = "4102444800000";
 
 export default defineUnlighthouseConfig({
 	site,
@@ -9,11 +10,11 @@ export default defineUnlighthouseConfig({
 	// Keep optional promotional and repository requests out of the benchmark.
 	// These values affect only the isolated Unlighthouse browser context.
 	localStorage: {
-		star_popup_dismissed: String(Date.now()),
+		star_popup_dismissed: benchmarkTimestamp,
 	},
 	sessionStorage: {
 		gh_star_count: "0",
-		gh_star_count_ts: String(Date.now()),
+		gh_star_count_ts: benchmarkTimestamp,
 	},
 	// Each run should produce fresh Lighthouse data instead of restoring a
 	// previous report from Unlighthouse's cache.

--- a/unlighthouse.config.ts
+++ b/unlighthouse.config.ts
@@ -1,0 +1,40 @@
+import { defineUnlighthouseConfig } from "unlighthouse/config";
+
+const site =
+	process.env.UNLIGHTHOUSE_SITE?.trim() || "http://127.0.0.1:4173";
+
+export default defineUnlighthouseConfig({
+	site,
+	outputPath: "./unlighthouse/runs",
+	// Keep optional promotional and repository requests out of the benchmark.
+	// These values affect only the isolated Unlighthouse browser context.
+	localStorage: {
+		star_popup_dismissed: String(Date.now()),
+	},
+	sessionStorage: {
+		gh_star_count: "0",
+		gh_star_count_ts: String(Date.now()),
+	},
+	// Each run should produce fresh Lighthouse data instead of restoring a
+	// previous report from Unlighthouse's cache.
+	cache: false,
+	scanner: {
+		device: "mobile",
+		throttle: true,
+		samples: 3,
+		crawler: true,
+		dynamicSampling: false,
+		maxRoutes: false,
+		sitemap: ["/sitemap.xml"],
+		// The local sitemap is the source of truth for route discovery.
+		robotsTxt: false,
+	},
+	lighthouseOptions: {
+		onlyCategories: ["performance"],
+	},
+	// Keep scans serial so a full local run does not create a burst of
+	// requests to optional third-party services.
+	puppeteerClusterOptions: {
+		maxConcurrency: 1,
+	},
+});


### PR DESCRIPTION
# Resumen

Optimiza la carga inicial y bajo demanda de la aplicación, con especial atención a las rutas de examen y práctica, la internacionalización y el contenido Markdown. También añade benchmarks locales reproducibles con Unlighthouse.

## Cambios

- Divide las rutas de examen y práctica en módulos lazy y precarga sus preguntas, el tour y las dependencias de Markdown necesarias.
- Carga bajo demanda el catálogo de traducciones activo. El cambio de idioma desde Ajustes conserva abierto el modal mientras llega el nuevo catálogo y después actualiza la ruta.
- Separa las traducciones SEO por idioma para que el bundle común no incluya los tres catálogos completos.
- Extrae el CSS de Markdown y Typography de la hoja global. Solo se carga al entrar en examen o práctica.
- Mantiene las fuentes Onest y Cascadia Code como variables, con una única variante Latin y `font-display: swap`.
- Retrasa la carga del seguimiento de sesión hasta que el navegador queda libre.
- Configura Unlighthouse solo para pruebas locales, con caché aislada y sin publicar informes generados.

## Datos de rendimiento

Comparación entre el build previo a esta PR y el build actual:

- Bundle JavaScript común: 439.395 → 363.008 bytes sin comprimir, una reducción del 17,4%.
- CSS global: 119.069 → 98.180 bytes sin comprimir, una reducción del 17,5%.
- Transferencia del CSS global en `/es`: aproximadamente 16,5 → 14,2 KB, una reducción del 13,4%.
- Catálogos de interfaz: solo se carga el idioma activo, con chunks de 24–27 KB. Los catálogos SEO separados pesan 5–6 KB por idioma.

Última ejecución local de Unlighthouse sobre las siete rutas configuradas: media de 90/100. `/es` obtuvo 97/100 y `/es/privacy` 99/100. CLS y TBT fueron 0 en todas las rutas. Las rutas de examen y práctica siguen siendo las más lentas, con LCP entre 3,9 y 4,4 s, por lo que las mediciones deben compararse en el mismo entorno.

## Issue relacionada

No aplica.

## Tipo de cambio

- [ ] Contenido o preguntas
- [ ] Interfaz o accesibilidad
- [x] Rendimiento, SEO, Optimizaciones
- [x] Herramientas o documentación

## Comprobaciones

- [ ] `pnpm check`. Sigue fallando por un formato pendiente en `src/components/KeyboardShortcutsSection.tsx`, que no se ha modificado en esta corrección.
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] React Doctor 0.9.12 en cambios de la PR: 100/100, 0 errores y 0 warnings.
- [x] Preview y navegador: rutas afectadas, carga por idioma y modal de Ajustes.
- [x] `pnpm readme`, no aplica contenido nuevo.

## Revisión específica

- [x] He probado las rutas y los idiomas afectados.
- [ ] He revisado el comportamiento en mobile si el cambio afecta a la interfaz.
- [ ] He comprobado teclado y nombres accesibles si el cambio afecta a controles.
- [x] He revisado title, description, Open Graph y sitemap si el cambio afecta al SEO.

## Capturas o notas para revisar

Para repetir los benchmarks: ejecuta `pnpm build`, `pnpm perf:preview` y después `pnpm perf:baseline:json`. Los resultados se generan en `unlighthouse/runs/ci-result.json` y no se versionan.

El escaneo completo de React Doctor marca una advertencia sobre `@fontsource-variable/cascadia-code`, pero la dependencia sí se usa desde `src/styles.css`; es un falso positivo del análisis de dependencias CSS.

## Checklist

- [x] No he incluido secretos ni archivos generados innecesarios.
- [x] He actualizado la documentación relacionada.
- [x] Esta PR está lista para revisión.





<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR reduces initial application payloads by lazily loading route modules, translation catalogs, SEO strings, Markdown resources, and session tracking. It also adds reproducible local Unlighthouse benchmarks and the required dependency-build configuration.

- Splits exam and practice route implementations into lazy modules and adds resource preloading.
- Loads interface and SEO translation catalogs per language.
- Moves Markdown styling and dependencies out of the common bundle.
- Adds local Unlighthouse scripts, configuration, documentation, and dependency policy.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/i18n/context.tsx | Coordinates asynchronously loaded catalogs with route language changes; the previously reported stale-catalog transition is resolved. |
| pnpm-workspace.yaml | Permits required Puppeteer and vue-demi build scripts using valid boolean policy values. |
| src/i18n/translation-loader.ts | Lazily imports and caches the three interface translation catalogs behind validated language inputs. |
| src/seo/translations.ts | Lazily imports and caches language-specific SEO catalogs used by validated metadata callers. |
| unlighthouse.config.ts | Defines isolated, local-only performance scans for the configured representative routes. |
| package.json | Adds exactly pinned Unlighthouse tooling and scripts for preview, baseline, and full scans. |

</details>

<sub>Reviews (3): Last reviewed commit: ["perf(i18n): skip loading animation for c..."](https://github.com/teenbiscuits/pasame-examenes/commit/ab19980387949fbc9465cb8522cfc03d079e82d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57745884)</sub>

<!-- /greptile_comment -->