### PR TITLE
Preserve exam attempts when resetting progress

### DIFF
--- a/src/data/store.ts
+++ b/src/data/store.ts
@@ -25,8 +25,27 @@ export function saveAttempt(subjectId: string, attempt: ExamAttempt) {
 export function clearTopicProgress(subjectId: string): number {
 	try {
 		const attempts = getAttempts(subjectId);
-		localStorage.removeItem(`exam-attempts:${subjectId}`);
-		return attempts.length;
+		const practiceAttempts = attempts.filter(
+			(attempt) => attempt.mode === "practice",
+		);
+
+		if (practiceAttempts.length === 0) {
+			return 0;
+		}
+
+		const remainingAttempts = attempts.filter(
+			(attempt) => attempt.mode !== "practice",
+		);
+		if (remainingAttempts.length > 0) {
+			localStorage.setItem(
+				`exam-attempts:${subjectId}`,
+				JSON.stringify(remainingAttempts),
+			);
+		} else {
+			localStorage.removeItem(`exam-attempts:${subjectId}`);
+		}
+
+		return practiceAttempts.length;
 	} catch (e) {
 		console.error("Failed to clear topic progress", e);
 		return 0;


### PR DESCRIPTION
# Resumen

Corrige el reinicio de progreso de una asignatura para que elimine únicamente sus intentos de práctica y conserve las simulaciones de examen.

## Cambios

- `clearTopicProgress` identifica y elimina solo los intentos con `mode: "practice"`.
- Los intentos de simulación de examen se conservan en `localStorage`.
- La clave de intentos se elimina únicamente cuando no quedan intentos.
- La función devuelve el número real de intentos de práctica eliminados.
- Si no hay intentos de práctica, los datos permanecen sin cambios y devuelve `0`.

## Issue relacionada

Closes #147

## Tipo de cambio

- [x] Corrección de comportamiento
- [ ] Contenido o preguntas
- [ ] Interfaz o accesibilidad
- [ ] Rendimiento, SEO, optimizaciones
- [ ] Herramientas o documentación

## Comprobaciones

- [ ] `pnpm check` — falla por un problema de formato preexistente en `src/components/KeyboardShortcutsSection.tsx`, fuera del alcance de esta PR.
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm build`
- [ ] `pnpm run doctor` — no aplica a este cambio aislado de persistencia.
- [x] Verificación funcional con `localStorage` simulado: las prácticas se eliminan, las simulaciones se conservan y el contador coincide.
- [x] `pnpm readme` no aplica: no se ha añadido ni modificado ninguna asignatura.

## Revisión específica

- [x] No afecta a rutas, idiomas, interfaz, mobile, teclado ni SEO.
- [x] El cambio no modifica el catálogo ni la selección de fuentes.
- [x] No requiere capturas: afecta exclusivamente a la persistencia en `localStorage`.

## Checklist

- [x] No he incluido secretos ni archivos generados innecesarios.
- [x] La documentación del dominio ya describe el comportamiento esperado; no requiere cambios.
- [x] Esta PR está lista para revisión.


<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Updates subject progress reset behavior so only practice attempts are removed while exam attempts remain stored.
- Separates practice attempts from retained attempts by mode.
- Rewrites the subject’s storage entry when retained attempts remain.
- Removes the storage key when every stored attempt was practice.
- Returns zero without modifying storage when there is no practice progress to clear.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the selective reset behavior remaining consistent with progress calculation and caller refresh semantics.

Practice progress is calculated exclusively from practice-mode attempts, and the updated reset removes exactly those records while preserving exam-mode history without leaving stale visible progress.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/data/store.ts | The reset function now selectively removes practice attempts while preserving other attempt modes, with return semantics consistent with its sole UI caller. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: preserve exam attempts when resetti..."](https://github.com/teenbiscuits/pasame-examenes/commit/c83072781196889ba46b7d516f9cff6336d71e8d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58442472)</sub>

**Context used:**

- Knowledge Base — [Session state and progress](https://app.greptile.com/pablopl/-/custom-context/knowledge-base/teenbiscuits/pasame-examenes/-/docs/session-state-and-progress.md)

<!-- /greptile_comment -->