### PR TITLE
Persist submitted exam and practice session state

### DIFF
--- a/src/data/store.ts
+++ b/src/data/store.ts
@@ -1,9 +1,106 @@
-import type { ExamAttempt } from "./types";
+import type { ExamAttempt, Question } from "./types";
 
-function getAttempts(subjectId: string): ExamAttempt[] {
+export interface AttemptInput
+	extends Omit<ExamAttempt, "maxScore" | "questionIds"> {
+	questions: Pick<Question, "id" | "points">[];
+}
+
+export function createAttempt({
+	questions,
+	...attempt
+}: AttemptInput): ExamAttempt {
+	return {
+		...attempt,
+		questionIds: questions.map((question) => question.id),
+		maxScore: questions.reduce((score, question) => score + question.points, 0),
+	};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function parseStringRecord(value: unknown): Record<string, string> {
+	if (!isRecord(value)) return {};
+	return Object.fromEntries(
+		Object.entries(value).filter(
+			(entry): entry is [string, string] => typeof entry[1] === "string",
+		),
+	);
+}
+
+function parseSelfGrades(
+	value: unknown,
+): Record<string, "correct" | "incorrect"> {
+	if (!isRecord(value)) return {};
+	return Object.fromEntries(
+		Object.entries(value).filter(
+			(entry): entry is [string, "correct" | "incorrect"] =>
+				entry[1] === "correct" || entry[1] === "incorrect",
+		),
+	);
+}
+
+function normalizeAttempt(value: unknown): ExamAttempt | null {
+	if (!isRecord(value)) return null;
+	if (
+		typeof value.id !== "string" ||
+		typeof value.examId !== "string" ||
+		(value.mode !== "practice" && value.mode !== "exam") ||
+		typeof value.date !== "string" ||
+		typeof value.score !== "number" ||
+		typeof value.maxScore !== "number"
+	) {
+		return null;
+	}
+
+	const answers = parseStringRecord(value.answers);
+	const questionIds = Array.isArray(value.questionIds)
+		? value.questionIds.filter((id): id is string => typeof id === "string")
+		: Object.keys(answers);
+	const selectedExamIds = Array.isArray(value.selectedExamIds)
+		? value.selectedExamIds.filter((id): id is string => typeof id === "string")
+		: value.mode === "exam"
+			? [value.examId]
+			: [];
+
+	return {
+		id: value.id,
+		examId: value.examId,
+		mode: value.mode,
+		...(typeof value.topic === "string" ? { topic: value.topic } : {}),
+		selectedExamIds,
+		questionIds,
+		date: value.date,
+		score: value.score,
+		maxScore: value.maxScore,
+		answers,
+		selfGrades: parseSelfGrades(value.selfGrades),
+		...(typeof value.timeSpent === "number"
+			? { timeSpent: value.timeSpent }
+			: {}),
+		...(typeof value.durationSeconds === "number"
+			? { durationSeconds: value.durationSeconds }
+			: {}),
+		...(typeof value.passPercentage === "number"
+			? { passPercentage: value.passPercentage }
+			: {}),
+	};
+}
+
+export function getAttempts(subjectId: string): ExamAttempt[] {
 	try {
 		const data = localStorage.getItem(`exam-attempts:${subjectId}`);
-		return data ? JSON.parse(data) : [];
+		if (!data) return [];
+		const parsed: unknown = JSON.parse(data);
+		if (!Array.isArray(parsed)) return [];
+
+		const attemptsById = new Map<string, ExamAttempt>();
+		for (const value of parsed) {
+			const attempt = normalizeAttempt(value);
+			if (attempt) attemptsById.set(attempt.id, attempt);
+		}
+		return [...attemptsById.values()];
 	} catch {
 		return [];
 	}
@@ -12,10 +109,22 @@ function getAttempts(subjectId: string): ExamAttempt[] {
 export function saveAttempt(subjectId: string, attempt: ExamAttempt) {
 	try {
 		const attempts = getAttempts(subjectId);
-		attempts.push(attempt);
+		let replaced = false;
+		const nextAttempts: ExamAttempt[] = [];
+		for (const current of attempts) {
+			if (current.id !== attempt.id) {
+				nextAttempts.push(current);
+				continue;
+			}
+			if (!replaced) {
+				nextAttempts.push(attempt);
+				replaced = true;
+			}
+		}
+		if (!replaced) nextAttempts.push(attempt);
 		localStorage.setItem(
 			`exam-attempts:${subjectId}`,
-			JSON.stringify(attempts),
+			JSON.stringify(nextAttempts),
 		);
 	} catch (e) {
 		console.error("Failed to save attempt", e);

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -115,14 +115,24 @@ export interface SubjectMeta {
 	exams: Exam[];
 }
 
+export type SelfGrade = "correct" | "incorrect";
+
 export interface ExamAttempt {
 	id: string;
 	examId: string;
 	mode: "practice" | "exam";
 	topic?: string;
+	/** Exam sources selected when the practice was started. */
+	selectedExamIds: string[];
+	/** Questions included in this attempt, kept stable if the catalogue changes. */
+	questionIds: string[];
 	date: string;
 	score: number;
 	maxScore: number;
 	answers: Record<string, string>;
+	/** Self-evaluations, including the composite keys used by multiple-text questions. */
+	selfGrades: Record<string, SelfGrade>;
 	timeSpent?: number;
+	durationSeconds?: number;
+	passPercentage?: number;
 }

--- a/src/hooks/useExamSession.ts
+++ b/src/hooks/useExamSession.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useReducer, useRef } from "react";
-import type { Question } from "../data/types";
-import { getQuestionScore } from "../lib/grading";
+import { createAttempt, saveAttempt } from "../data/store";
+import type { Question, SelfGrade } from "../data/types";
+import { getTotalScore } from "../lib/grading";
 import { track } from "../lib/umami";
 
 const getNow = () => Date.now();
@@ -8,7 +9,7 @@ const getNow = () => Date.now();
 interface ExamState {
 	currentIndex: number;
 	answers: Record<string, string>;
-	selfGrades: Record<string, "correct" | "incorrect">;
+	selfGrades: Record<string, SelfGrade>;
 	submitted: boolean;
 	timeLeft: number;
 	started: boolean;
@@ -17,7 +18,7 @@ interface ExamState {
 type ExamAction =
 	| { type: "SET_CURRENT_INDEX"; index: number }
 	| { type: "ANSWER"; questionId: string; answer: string }
-	| { type: "SELF_GRADE"; questionId: string; grade: "correct" | "incorrect" }
+	| { type: "SELF_GRADE"; questionId: string; grade: SelfGrade }
 	| { type: "SUBMIT"; elapsed: number }
 	| { type: "START" }
 	| { type: "TICK" }
@@ -55,6 +56,7 @@ export function useExamSession(
 	initialTimeLeft: number,
 	t: { exam: { submitConfirm: string } },
 	onTimeUp: () => void,
+	passPercentage?: number,
 ) {
 	const [state, dispatch] = useReducer(reducer, {
 		currentIndex: 0,
@@ -69,6 +71,41 @@ export function useExamSession(
 
 	const startTimeRef = useRef(0);
 	const timeUpTrackedRef = useRef(false);
+	const attemptIdRef = useRef("");
+	const attemptDateRef = useRef("");
+	const attemptQuestionsRef = useRef<Question[]>([]);
+	const attemptTimeSpentRef = useRef(0);
+
+	const persistAttempt = useCallback(
+		(
+			id: string,
+			attemptQuestions: Question[],
+			date: string,
+			answers: Record<string, string>,
+			selfGrades: Record<string, SelfGrade>,
+			score: number,
+			timeSpent: number,
+		) => {
+			saveAttempt(
+				subjectId,
+				createAttempt({
+					id,
+					examId,
+					mode: "exam",
+					selectedExamIds: [examId],
+					questions: attemptQuestions,
+					date,
+					score,
+					answers,
+					selfGrades,
+					timeSpent,
+					durationSeconds: initialTimeLeft,
+					...(passPercentage == null ? {} : { passPercentage }),
+				}),
+			);
+		},
+		[subjectId, examId, initialTimeLeft, passPercentage],
+	);
 
 	const setCurrentIndex = useCallback(
 		(index: number) => dispatch({ type: "SET_CURRENT_INDEX", index }),
@@ -80,6 +117,8 @@ export function useExamSession(
 	}, []);
 
 	const handleStart = useCallback(() => {
+		if (state.started) return;
+
 		track("exam_start", {
 			subjectId,
 			examId,
@@ -88,21 +127,23 @@ export function useExamSession(
 		});
 		dispatch({ type: "START" });
 		startTimeRef.current = getNow();
-	}, [subjectId, examId, questions]);
+	}, [subjectId, examId, questions, state.started]);
 
 	const handleSubmit = useCallback(
 		(skipConfirm = false) => {
-			if (!skipConfirm && !window.confirm(t.exam.submitConfirm)) return;
+			if (state.submitted || attemptIdRef.current || !state.started)
+				return false;
+			if (!skipConfirm && !window.confirm(t.exam.submitConfirm)) return false;
 
 			const elapsed = Math.floor((getNow() - startTimeRef.current) / 1000);
-			let score = 0;
-			for (const q of questions) {
-				score += getQuestionScore(
-					q,
-					state.answers[q.id] || "",
-					state.selfGrades,
-				);
-			}
+			const id = getNow().toString();
+			const date = new Date().toISOString();
+			const maxScore = questions.reduce((s, q) => s + q.points, 0);
+			const score = getTotalScore(questions, state.answers, state.selfGrades);
+			attemptIdRef.current = id;
+			attemptDateRef.current = date;
+			attemptQuestionsRef.current = questions;
+			attemptTimeSpentRef.current = elapsed;
 			const answeredCount = Object.values(state.answers).filter(
 				(a) => a && a.trim() !== "",
 			).length;
@@ -110,48 +151,86 @@ export function useExamSession(
 				subjectId,
 				examId,
 				score,
-				maxScore: questions.reduce((s, q) => s + q.points, 0),
+				maxScore,
 				timeSpent: elapsed,
 				questionsCount: questions.length,
 				answered: answeredCount,
 			});
+			persistAttempt(
+				id,
+				questions,
+				date,
+				state.answers,
+				state.selfGrades,
+				score,
+				elapsed,
+			);
 			dispatch({ type: "SUBMIT", elapsed });
+			return true;
 		},
-		[subjectId, examId, questions, state.answers, state.selfGrades, t],
+		[
+			subjectId,
+			examId,
+			questions,
+			state.answers,
+			state.selfGrades,
+			state.started,
+			state.submitted,
+			t,
+			persistAttempt,
+		],
 	);
 
 	const handleSelfGrade = useCallback(
-		(questionId: string, grade: "correct" | "incorrect") => {
+		(questionId: string, grade: SelfGrade) => {
 			track("exam_self_grade", { subjectId, examId, questionId, grade });
 			dispatch({ type: "SELF_GRADE", questionId, grade });
+			if (!state.submitted || !attemptIdRef.current) return;
+
+			const nextGrades = { ...state.selfGrades, [questionId]: grade };
+			const attemptQuestions = attemptQuestionsRef.current;
+			persistAttempt(
+				attemptIdRef.current,
+				attemptQuestions,
+				attemptDateRef.current,
+				state.answers,
+				nextGrades,
+				getTotalScore(attemptQuestions, state.answers, nextGrades),
+				attemptTimeSpentRef.current,
+			);
 		},
-		[subjectId, examId],
+		[
+			subjectId,
+			examId,
+			state.answers,
+			state.selfGrades,
+			state.submitted,
+			persistAttempt,
+		],
 	);
 
 	// Timer
 	useEffect(() => {
-		if (!state.started || state.submitted || timeUp) return;
+		if (!state.started || state.submitted || state.timeLeft <= 0) return;
 		const timer = setInterval(() => {
-			if (state.timeLeft === 1) onTimeUp();
 			dispatch({ type: "TICK" });
 		}, 1000);
 		return () => clearInterval(timer);
-	}, [state.started, state.submitted, state.timeLeft, timeUp, onTimeUp]);
+	}, [state.started, state.submitted, state.timeLeft]);
 
-	// Time up tracking
+	// Time up submits the attempt before notifying the page so the timeout is not lost.
 	useEffect(() => {
-		if (
-			state.timeLeft === 0 &&
-			state.started &&
-			!state.submitted &&
-			!timeUpTrackedRef.current
-		) {
-			timeUpTrackedRef.current = true;
-			track("exam_time_up", {
-				subjectId,
-				examId,
-				questionsCount: questions.length,
-			});
+		if (state.timeLeft <= 0 && state.started && !state.submitted) {
+			if (!timeUpTrackedRef.current) {
+				timeUpTrackedRef.current = true;
+				track("exam_time_up", {
+					subjectId,
+					examId,
+					questionsCount: questions.length,
+				});
+			}
+			handleSubmit(true);
+			onTimeUp();
 		}
 	}, [
 		state.timeLeft,
@@ -160,6 +239,8 @@ export function useExamSession(
 		subjectId,
 		examId,
 		questions.length,
+		handleSubmit,
+		onTimeUp,
 	]);
 
 	return {

--- a/src/hooks/usePracticeSession.ts
+++ b/src/hooks/usePracticeSession.ts
@@ -1,7 +1,11 @@
 import { useCallback, useEffect, useReducer, useRef } from "react";
-import { saveAttempt } from "../data/store";
-import type { Question } from "../data/types";
-import { getQuestionScore, isSelfGradedQuestion } from "../lib/grading";
+import { createAttempt, saveAttempt } from "../data/store";
+import type { Question, SelfGrade } from "../data/types";
+import {
+	getQuestionScore,
+	getTotalScore,
+	isSelfGradedQuestion,
+} from "../lib/grading";
 import { playError, playSound, playSuccess } from "../lib/sound";
 import { track } from "../lib/umami";
 
@@ -10,7 +14,7 @@ const getNow = () => Date.now();
 interface PracticeState {
 	currentIndex: number;
 	answers: Record<string, string>;
-	selfGrades: Record<string, "correct" | "incorrect">;
+	selfGrades: Record<string, SelfGrade>;
 	submitted: boolean;
 	checkedQuestions: Record<string, boolean>;
 }
@@ -19,7 +23,7 @@ type PracticeAction =
 	| { type: "SET_CURRENT_INDEX"; index: number }
 	| { type: "SYNC_CURRENT_INDEX"; maxIndex: number }
 	| { type: "ANSWER"; questionId: string; answer: string }
-	| { type: "SELF_GRADE"; questionId: string; grade: "correct" | "incorrect" }
+	| { type: "SELF_GRADE"; questionId: string; grade: SelfGrade }
 	| { type: "SUBMIT" }
 	| { type: "CHECK_QUESTION"; questionId: string };
 
@@ -60,6 +64,7 @@ export function usePracticeSession(
 	questions: Question[],
 	subjectId: string,
 	topic: string,
+	selectedExamIds: readonly string[] = [],
 ) {
 	const [state, dispatch] = useReducer(reducer, {
 		currentIndex: 0,
@@ -70,6 +75,38 @@ export function usePracticeSession(
 	});
 
 	const attemptIdRef = useRef("");
+	const attemptDateRef = useRef("");
+	const attemptQuestionsRef = useRef<Question[]>([]);
+	const attemptSelectedExamIdsRef = useRef<string[]>([]);
+
+	const persistAttempt = useCallback(
+		(
+			id: string,
+			attemptQuestions: Question[],
+			attemptSelectedExamIds: readonly string[],
+			date: string,
+			answers: Record<string, string>,
+			selfGrades: Record<string, SelfGrade>,
+			score: number,
+		) => {
+			saveAttempt(
+				subjectId,
+				createAttempt({
+					id,
+					examId: "practice",
+					mode: "practice",
+					topic,
+					selectedExamIds: [...attemptSelectedExamIds],
+					questions: attemptQuestions,
+					date,
+					score,
+					answers,
+					selfGrades,
+				}),
+			);
+		},
+		[subjectId, topic],
+	);
 
 	useEffect(() => {
 		dispatch({
@@ -92,12 +129,17 @@ export function usePracticeSession(
 	}, []);
 
 	const handleSubmit = useCallback(() => {
+		if (state.submitted || attemptIdRef.current || questions.length === 0)
+			return;
+
 		const id = getNow().toString();
+		const date = new Date().toISOString();
 		attemptIdRef.current = id;
-		let score = 0;
-		for (const q of questions) {
-			score += getQuestionScore(q, state.answers[q.id] || "", state.selfGrades);
-		}
+		attemptDateRef.current = date;
+		attemptQuestionsRef.current = questions;
+		attemptSelectedExamIdsRef.current = [...selectedExamIds];
+		const maxScore = questions.reduce((s, q) => s + q.points, 0);
+		const score = getTotalScore(questions, state.answers, state.selfGrades);
 		const answeredCount = Object.values(state.answers).filter(
 			(a) => a && a.trim() !== "",
 		).length;
@@ -105,44 +147,58 @@ export function usePracticeSession(
 			subjectId,
 			topic,
 			score,
-			maxScore: questions.reduce((s, q) => s + q.points, 0),
+			maxScore,
 			questionsCount: questions.length,
 			answered: answeredCount,
 		});
-		saveAttempt(subjectId, {
+		persistAttempt(
 			id,
-			examId: "practice",
-			mode: "practice",
-			topic,
-			date: new Date().toISOString(),
+			questions,
+			selectedExamIds,
+			date,
+			state.answers,
+			state.selfGrades,
 			score,
-			maxScore: questions.reduce((s, q) => s + q.points, 0),
-			answers: state.answers,
-		});
+		);
 		dispatch({ type: "SUBMIT" });
-	}, [subjectId, topic, questions, state.answers, state.selfGrades]);
+	}, [
+		subjectId,
+		topic,
+		questions,
+		selectedExamIds,
+		state.answers,
+		state.selfGrades,
+		state.submitted,
+		persistAttempt,
+	]);
 
 	const handleSelfGrade = useCallback(
-		(questionId: string, grade: "correct" | "incorrect") => {
+		(questionId: string, grade: SelfGrade) => {
 			track("practice_self_grade", { subjectId, topic, questionId, grade });
 			dispatch({ type: "SELF_GRADE", questionId, grade });
-			let score = 0;
+			if (!state.submitted || !attemptIdRef.current) return;
+
 			const nextGrades = { ...state.selfGrades, [questionId]: grade };
-			for (const q of questions) {
-				score += getQuestionScore(q, state.answers[q.id] || "", nextGrades);
-			}
-			saveAttempt(subjectId, {
-				id: attemptIdRef.current || getNow().toString(),
-				examId: "practice",
-				mode: "practice",
-				topic,
-				date: new Date().toISOString(),
+			const attemptQuestions = attemptQuestionsRef.current;
+			const score = getTotalScore(attemptQuestions, state.answers, nextGrades);
+			persistAttempt(
+				attemptIdRef.current,
+				attemptQuestions,
+				attemptSelectedExamIdsRef.current,
+				attemptDateRef.current,
+				state.answers,
+				nextGrades,
 				score,
-				maxScore: questions.reduce((s, q) => s + q.points, 0),
-				answers: state.answers,
-			});
+			);
 		},
-		[subjectId, topic, questions, state.answers, state.selfGrades],
+		[
+			subjectId,
+			topic,
+			state.answers,
+			state.selfGrades,
+			state.submitted,
+			persistAttempt,
+		],
 	);
 
 	const handleCheckQuestion = useCallback(

--- a/src/lib/grading.ts
+++ b/src/lib/grading.ts
@@ -164,6 +164,20 @@ export function getQuestionScore(
 	return 0;
 }
 
+export function getTotalScore(
+	questions: Question[],
+	answers: Record<string, string>,
+	selfGrades: Record<string, "correct" | "incorrect"> = {},
+): number {
+	return roundPoints(
+		questions.reduce(
+			(score, question) =>
+				score + getQuestionScore(question, answers[question.id], selfGrades),
+			0,
+		),
+	);
+}
+
 export function computeQuestionResults(
 	questions: Question[],
 	answers: Record<string, string>,

--- a/src/pages/ExamSimulation.tsx
+++ b/src/pages/ExamSimulation.tsx
@@ -31,7 +31,7 @@ import { getExamPassPoints } from "../lib/exam-stats";
 import {
 	computeQuestionResults,
 	getPendingSelfGradePoints,
-	getQuestionScore,
+	getTotalScore,
 	isAutomaticallyCorrect,
 	isFullySelfGraded,
 	isSelfGradedQuestion,
@@ -863,13 +863,7 @@ function ExamPlayer({
 		};
 	}, [scrollToHeaderRef, scrollToHeader]);
 
-	const getScore = () => {
-		let score = 0;
-		for (const q of questions) {
-			score += getQuestionScore(q, answers[q.id], selfGrades);
-		}
-		return roundPoints(score);
-	};
+	const getScore = () => getTotalScore(questions, answers, selfGrades);
 
 	const score = getScore();
 
@@ -1255,9 +1249,10 @@ export default function ExamSimulation() {
 		questions,
 		subject?.id || "",
 		examId || "",
-		(examInfo?.durationMinutes || 120) * 60,
+		(examInfo?.durationMinutes ?? 120) * 60,
 		t,
 		showTimeUpDialog,
+		examInfo?.passPercentage,
 	);
 
 	const handleSubmitConfirm = useCallback(

--- a/src/pages/PracticeTopic.tsx
+++ b/src/pages/PracticeTopic.tsx
@@ -33,7 +33,7 @@ import { useT } from "../i18n/hooks";
 import {
 	computeQuestionResults,
 	getPendingSelfGradePoints,
-	getQuestionScore,
+	getTotalScore,
 	isAutomaticallyCorrect,
 	isFullySelfGraded,
 	isSelfGradedQuestion,
@@ -686,12 +686,11 @@ function PracticePlayer({
 		pendingTextCount === 0;
 
 	const getScore = (onlyGraded = false) => {
-		let score = 0;
-		for (const q of questions) {
-			if (onlyGraded && !submitted && !checkedQuestions[q.id]) continue;
-			score += getQuestionScore(q, answers[q.id], selfGrades);
-		}
-		return roundPoints(score);
+		const scoredQuestions =
+			onlyGraded && !submitted
+				? questions.filter((question) => checkedQuestions[question.id])
+				: questions;
+		return getTotalScore(scoredQuestions, answers, selfGrades);
 	};
 
 	const gradedScore = getScore(true);
@@ -972,7 +971,12 @@ export default function PracticeTopic() {
 		() => filterQuestionsByExamSelection(allTopicQuestions, selectedExamIds),
 		[allTopicQuestions, selectedExamIds],
 	);
-	const session = usePracticeSession(questions, subject?.id || "", topic || "");
+	const session = usePracticeSession(
+		questions,
+		subject?.id || "",
+		topic || "",
+		selectedExamIds,
+	);
 	const navigation = usePracticeTopicNavigation({
 		subject,
 		topicInfo,


### PR DESCRIPTION
# Resumen

Persiste correctamente el estado de las sesiones enviadas de examen y práctica para conservar respuestas, autoevaluaciones, puntuaciones y preguntas originales.

## Cambios

- Añade normalización y validación de intentos almacenados, evitando duplicados y soportando datos antiguos.
- Guarda los identificadores de preguntas y exámenes seleccionados junto con cada intento.
- Actualiza automáticamente los intentos cuando cambian las autoevaluaciones posteriores al envío.
- Persiste los envíos provocados por el fin del tiempo y evita envíos duplicados.
- Centraliza el cálculo de puntuaciones mediante `getTotalScore`.
- Conserva la duración, el porcentaje de aprobado y otros metadatos relevantes del examen.

## Issue relacionada

Closes #148

## Tipo de cambio

- [x] Contenido o preguntas
- [ ] Interfaz o accesibilidad
- [ ] Rendimiento, SEO, Optimizaciones
- [ ] Herramientas o documentación

## Comprobaciones

- [ ] `pnpm check`
- [ ] `pnpm typecheck`
- [ ] `pnpm lint`
- [ ] `pnpm build`
- [ ] `pnpm run doctor`
- [ ] He probado el preview si el cambio afecta al comportamiento o al aspecto de la app.
- [ ] He ejecutado `pnpm readme` si he añadido o modificado una asignatura, o no aplica.

## Revisión específica

- [x] He probado las rutas y los idiomas afectados.
- [ ] He revisado el comportamiento en mobile si el cambio afecta a la interfaz.
- [ ] He comprobado teclado y nombres accesibles si el cambio afecta a controles.
- [ ] He revisado title, description, Open Graph y sitemap si el cambio afecta al SEO.

## Capturas o notas para revisar

El cambio afecta principalmente a la persistencia local y al cálculo de resultados. Conviene verificar los envíos manuales y por tiempo agotado, así como la actualización de la puntuación al autoevaluar preguntas después del envío.

## Checklist

- [x] No he incluido secretos ni archivos generados innecesarios.
- [ ] He actualizado la documentación relacionada.
- [x] Esta PR está lista para revisión.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR expands browser-local attempt records so completed exam and practice sessions retain their question selection, answers, self-grades, scores, and relevant metadata. It also unifies score calculation and makes timeout submissions persist before displaying the timeout dialog.

- Adds defensive parsing, legacy normalization, and ID-based replacement for stored attempts.
- Persists exam submissions and updates both exam and practice records after post-submit self-grading.
- Captures question IDs, selected source IDs, duration, pass percentage, and stable submission metadata.
- Centralizes aggregate grading through `getTotalScore`.
- Changes timer expiry to submit exactly once before notifying the page.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking defects identified.

Stored legacy attempts are normalized, exam records are excluded from topic progress, submission guards prevent duplicate timeout persistence, and post-submit self-grading consistently replaces the original attempt.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/data/store.ts | Adds attempt construction, defensive legacy normalization, deduplication, and update-in-place persistence without disrupting practice progress aggregation. |
| src/data/types.ts | Extends the durable attempt contract with selected sources, stable question IDs, self-grades, duration, and pass metadata. |
| src/hooks/useExamSession.ts | Persists manual and timeout submissions once, snapshots submission metadata, and rewrites the same attempt after self-grading. |
| src/hooks/usePracticeSession.ts | Persists stable practice snapshots and updates their score and self-grades without creating duplicate records. |
| src/lib/grading.ts | Introduces a shared rounded total-score helper used consistently by session persistence and result views. |
| src/pages/ExamSimulation.tsx | Supplies exam pass and duration metadata to persistence and adopts the shared total-score calculation. |
| src/pages/PracticeTopic.tsx | Supplies selected exam sources to the practice session and preserves checked-question score filtering through the shared helper. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Active exam or practice session] --> B[Submit or time expires]
    B --> C[Snapshot questions and metadata]
    C --> D[Calculate score with getTotalScore]
    D --> E[Create normalized attempt]
    E --> F[Replace matching attempt in localStorage]
    F --> G[Post-submit self-grade]
    G --> D
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(attempts): persist submitted session..."](https://github.com/teenbiscuits/pasame-examenes/commit/46a2560b44296f55de913e54b7b10ecae9b00594) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58450352)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Session state and progress](https://app.greptile.com/pablopl/-/custom-context/knowledge-base/teenbiscuits/pasame-examenes/-/docs/session-state-and-progress.md)
- Knowledge Base — [Practice experience](https://app.greptile.com/pablopl/-/custom-context/knowledge-base/teenbiscuits/pasame-examenes/-/docs/practice-experience.md)
- Knowledge Base — [Exam simulation](https://app.greptile.com/pablopl/-/custom-context/knowledge-base/teenbiscuits/pasame-examenes/-/docs/exam-simulation.md)
</details>


<!-- /greptile_comment -->