### PR TITLE
Track practice progress per question and selected source

### DIFF
--- a/src/data/__tests__/store.test.ts
+++ b/src/data/__tests__/store.test.ts
@@ -161,4 +161,23 @@ describe("getTopicProgress", () => {
 			0,
 		);
 	});
+
+	it("preserves legacy progress only when all sources are selected", () => {
+		const legacyAttempt = makeAttempt({ score: 12, topic: "topic-a" });
+		delete legacyAttempt.examIds;
+		delete legacyAttempt.questionScores;
+		saveAttempt("subject-6", legacyAttempt);
+
+		assert.deepEqual(
+			getTopicProgress("subject-6", questions, ["source-a", "source-b"]),
+			{
+				"topic-a": { attempted: 12, total: 15 },
+				"topic-b": { attempted: 0, total: 20 },
+			},
+		);
+		assert.deepEqual(getTopicProgress("subject-6", questions, ["source-a"]), {
+			"topic-a": { attempted: 0, total: 10 },
+			"topic-b": { attempted: 0, total: 8 },
+		});
+	});
 });

--- a/src/data/__tests__/store.test.ts
+++ b/src/data/__tests__/store.test.ts
@@ -1,0 +1,164 @@
+import { strict as assert } from "node:assert";
+import { beforeEach, describe, it } from "node:test";
+import { getTopicProgress, saveAttempt } from "../store";
+import type { ExamAttempt, QuestionSummary } from "../types";
+
+const localStorageMock = (() => {
+	let store: Record<string, string> = {};
+	return {
+		getItem(key: string) {
+			return store[key] ?? null;
+		},
+		setItem(key: string, value: string) {
+			store[key] = value;
+		},
+		removeItem(key: string) {
+			delete store[key];
+		},
+		clear() {
+			store = {};
+		},
+	};
+})();
+
+Object.defineProperty(globalThis, "localStorage", {
+	value: localStorageMock,
+});
+
+function makeAttempt(overrides: Partial<ExamAttempt> = {}): ExamAttempt {
+	return {
+		id: "1",
+		examId: "practice",
+		mode: "practice",
+		topic: "topic-a",
+		date: new Date().toISOString(),
+		score: 10,
+		maxScore: 15,
+		answers: {},
+		examIds: ["source-a", "source-b"],
+		questionScores: {},
+		...overrides,
+	};
+}
+
+const questions: QuestionSummary[] = [
+	{ id: "a-1", examId: "source-a", topic: "topic-a", points: 10 },
+	{ id: "b-1", examId: "source-b", topic: "topic-a", points: 5 },
+	{ id: "a-2", examId: "source-a", topic: "topic-b", points: 8 },
+	{ id: "b-2", examId: "source-b", topic: "topic-b", points: 12 },
+];
+
+describe("getTopicProgress", () => {
+	beforeEach(() => {
+		localStorageMock.clear();
+	});
+
+	it("limits both progress and totals to the selected sources", () => {
+		saveAttempt(
+			"subject-1",
+			makeAttempt({
+				questionScores: { "a-1": 10, "b-1": 0, "a-2": 8, "b-2": 0 },
+			}),
+		);
+
+		assert.deepEqual(getTopicProgress("subject-1", questions, ["source-a"]), {
+			"topic-a": { attempted: 10, total: 10 },
+			"topic-b": { attempted: 8, total: 8 },
+		});
+		assert.deepEqual(getTopicProgress("subject-1", questions, ["source-b"]), {
+			"topic-a": { attempted: 0, total: 5 },
+			"topic-b": { attempted: 0, total: 12 },
+		});
+		assert.deepEqual(
+			getTopicProgress("subject-1", questions, ["source-a", "source-b"]),
+			{
+				"topic-a": { attempted: 10, total: 15 },
+				"topic-b": { attempted: 8, total: 20 },
+			},
+		);
+	});
+
+	it("keeps the best result for each question instead of each attempt", () => {
+		saveAttempt(
+			"subject-2",
+			makeAttempt({
+				questionScores: { "a-1": 10, "b-1": 0 },
+			}),
+		);
+		saveAttempt(
+			"subject-2",
+			makeAttempt({
+				id: "2",
+				questionScores: { "a-1": 0, "b-1": 5 },
+			}),
+		);
+
+		assert.equal(
+			getTopicProgress("subject-2", questions, ["source-a", "source-b"])[
+				"topic-a"
+			]?.attempted,
+			15,
+		);
+	});
+
+	it("updates the same attempt when self-evaluation changes its score", () => {
+		saveAttempt("subject-5", makeAttempt({ questionScores: { "a-1": 0 } }));
+		saveAttempt("subject-5", makeAttempt({ questionScores: { "a-1": 10 } }));
+
+		assert.equal(
+			JSON.parse(localStorageMock.getItem("exam-attempts:subject-5") ?? "[]")
+				.length,
+			1,
+		);
+		assert.equal(
+			getTopicProgress("subject-5", questions, ["source-a"])["topic-a"]
+				?.attempted,
+			10,
+		);
+	});
+
+	it("treats repeated questions with different IDs independently", () => {
+		const repeatedQuestions: QuestionSummary[] = [
+			{ id: "repeat-a", examId: "source-a", topic: "topic-a", points: 10 },
+			{ id: "repeat-b", examId: "source-b", topic: "topic-a", points: 10 },
+		];
+		saveAttempt(
+			"subject-3",
+			makeAttempt({
+				questionScores: { "repeat-a": 10, "repeat-b": 0 },
+			}),
+		);
+
+		assert.equal(
+			getTopicProgress("subject-3", repeatedQuestions, [
+				"source-a",
+				"source-b",
+			])["topic-a"]?.attempted,
+			10,
+		);
+		assert.equal(
+			getTopicProgress("subject-3", repeatedQuestions, [
+				"source-a",
+				"source-b",
+			])["topic-a"]?.total,
+			20,
+		);
+	});
+
+	it("ignores simulation attempts", () => {
+		saveAttempt(
+			"subject-4",
+			makeAttempt({
+				mode: "exam",
+				questionScores: { "a-1": 10, "b-1": 5 },
+			}),
+		);
+
+		assert.equal(
+			getTopicProgress("subject-4", questions, ["source-a", "source-b"])[
+				"topic-a"
+			]?.attempted,
+			0,
+		);
+	});
+});

--- a/src/data/store.ts
+++ b/src/data/store.ts
@@ -1,9 +1,10 @@
-import type { ExamAttempt } from "./types";
+import type { ExamAttempt, QuestionSummary } from "./types";
 
 function getAttempts(subjectId: string): ExamAttempt[] {
 	try {
 		const data = localStorage.getItem(`exam-attempts:${subjectId}`);
-		return data ? JSON.parse(data) : [];
+		const parsed: unknown = data ? JSON.parse(data) : [];
+		return Array.isArray(parsed) ? (parsed as ExamAttempt[]) : [];
 	} catch {
 		return [];
 	}
@@ -12,7 +13,12 @@ function getAttempts(subjectId: string): ExamAttempt[] {
 export function saveAttempt(subjectId: string, attempt: ExamAttempt) {
 	try {
 		const attempts = getAttempts(subjectId);
-		attempts.push(attempt);
+		const existingIndex = attempts.findIndex(({ id }) => id === attempt.id);
+		if (existingIndex >= 0) {
+			attempts[existingIndex] = attempt;
+		} else {
+			attempts.push(attempt);
+		}
 		localStorage.setItem(
 			`exam-attempts:${subjectId}`,
 			JSON.stringify(attempts),
@@ -35,33 +41,48 @@ export function clearTopicProgress(subjectId: string): number {
 
 export function getTopicProgress(
 	subjectId: string,
-	questions: { topic: string; points: number }[],
+	questions: readonly QuestionSummary[],
+	selectedExamIds: readonly string[],
 ) {
+	const selectedExams = new Set(selectedExamIds);
+	const selectedQuestions = questions.filter((question) =>
+		selectedExams.has(question.examId),
+	);
 	const attempts = getAttempts(subjectId).filter((a) => a.mode === "practice");
 	const progress: Record<string, { attempted: number; total: number }> = {};
 
 	// Initialize totals
-	for (const q of questions) {
+	for (const q of selectedQuestions) {
 		if (!progress[q.topic]) {
 			progress[q.topic] = { attempted: 0, total: 0 };
 		}
 		progress[q.topic].total += q.points;
 	}
 
-	// Calculate attempted from max score per topic across attempts
-	const topicScores: Record<string, number> = {};
+	// Keep the best known result for each concrete question across attempts.
+	const questionScores: Record<string, number> = {};
 	for (const a of attempts) {
-		if (a.topic) {
-			if (!topicScores[a.topic] || a.score > topicScores[a.topic]) {
-				topicScores[a.topic] = a.score;
-			}
+		// Old attempts have no source or per-question data, so they cannot be
+		// attributed to the selected sources without inventing progress.
+		if (!Array.isArray(a.examIds) || !a.questionScores) continue;
+		const attemptExams = new Set(
+			a.examIds.filter(
+				(examId): examId is string => typeof examId === "string",
+			),
+		);
+		for (const question of selectedQuestions) {
+			if (!attemptExams.has(question.examId)) continue;
+			const score = a.questionScores[question.id];
+			if (typeof score !== "number" || !Number.isFinite(score)) continue;
+			questionScores[question.id] = Math.max(
+				questionScores[question.id] ?? 0,
+				Math.min(question.points, Math.max(0, score)),
+			);
 		}
 	}
 
-	for (const [topic, score] of Object.entries(topicScores)) {
-		if (progress[topic]) {
-			progress[topic].attempted = score;
-		}
+	for (const question of selectedQuestions) {
+		progress[question.topic].attempted += questionScores[question.id] ?? 0;
 	}
 
 	return progress;

--- a/src/data/store.ts
+++ b/src/data/store.ts
@@ -48,6 +48,10 @@ export function getTopicProgress(
 	const selectedQuestions = questions.filter((question) =>
 		selectedExams.has(question.examId),
 	);
+	const questionExamIds = new Set(questions.map((question) => question.examId));
+	const allSourcesSelected =
+		questionExamIds.size > 0 &&
+		[...questionExamIds].every((examId) => selectedExams.has(examId));
 	const attempts = getAttempts(subjectId).filter((a) => a.mode === "practice");
 	const progress: Record<string, { attempted: number; total: number }> = {};
 
@@ -61,10 +65,25 @@ export function getTopicProgress(
 
 	// Keep the best known result for each concrete question across attempts.
 	const questionScores: Record<string, number> = {};
+	const legacyTopicScores: Record<string, number> = {};
 	for (const a of attempts) {
-		// Old attempts have no source or per-question data, so they cannot be
-		// attributed to the selected sources without inventing progress.
-		if (!Array.isArray(a.examIds) || !a.questionScores) continue;
+		if (!Array.isArray(a.examIds) || !a.questionScores) {
+			// Legacy attempts predate source-aware scores. Preserve their old
+			// aggregate progress only when every source is selected, since that is
+			// the only view where their score can be shown without misattribution.
+			if (
+				allSourcesSelected &&
+				a.topic &&
+				typeof a.score === "number" &&
+				Number.isFinite(a.score)
+			) {
+				legacyTopicScores[a.topic] = Math.max(
+					legacyTopicScores[a.topic] ?? 0,
+					Math.max(0, a.score),
+				);
+			}
+			continue;
+		}
 		const attemptExams = new Set(
 			a.examIds.filter(
 				(examId): examId is string => typeof examId === "string",
@@ -83,6 +102,12 @@ export function getTopicProgress(
 
 	for (const question of selectedQuestions) {
 		progress[question.topic].attempted += questionScores[question.id] ?? 0;
+	}
+
+	for (const [topic, score] of Object.entries(legacyTopicScores)) {
+		if (progress[topic]) {
+			progress[topic].attempted = Math.max(progress[topic].attempted, score);
+		}
 	}
 
 	return progress;

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -124,5 +124,9 @@ export interface ExamAttempt {
 	score: number;
 	maxScore: number;
 	answers: Record<string, string>;
+	/** IDs of the sources included in a practice attempt. Optional only for legacy data. */
+	examIds?: string[];
+	/** Points awarded per question in a practice attempt. Optional only for legacy data. */
+	questionScores?: Record<string, number>;
 	timeSpent?: number;
 }

--- a/src/hooks/usePracticeSession.ts
+++ b/src/hooks/usePracticeSession.ts
@@ -1,11 +1,52 @@
 import { useCallback, useEffect, useReducer, useRef } from "react";
 import { saveAttempt } from "../data/store";
-import type { Question } from "../data/types";
+import type { ExamAttempt, Question } from "../data/types";
 import { getQuestionScore, isSelfGradedQuestion } from "../lib/grading";
 import { playError, playSound, playSuccess } from "../lib/sound";
 import { track } from "../lib/umami";
 
 const getNow = () => Date.now();
+
+function getQuestionScores(
+	questions: Question[],
+	answers: Record<string, string>,
+	selfGrades: Record<string, "correct" | "incorrect">,
+) {
+	return Object.fromEntries(
+		questions.map((question) => [
+			question.id,
+			getQuestionScore(question, answers[question.id] || "", selfGrades),
+		]),
+	);
+}
+
+function createPracticeAttempt(
+	id: string,
+	topic: string,
+	questions: Question[],
+	answers: Record<string, string>,
+	selfGrades: Record<string, "correct" | "incorrect">,
+	examIds: readonly string[],
+): ExamAttempt {
+	const questionScores = getQuestionScores(questions, answers, selfGrades);
+	const score = Object.values(questionScores).reduce(
+		(total, questionScore) => total + questionScore,
+		0,
+	);
+
+	return {
+		id,
+		examId: "practice",
+		mode: "practice",
+		topic,
+		date: new Date().toISOString(),
+		score,
+		maxScore: questions.reduce((total, question) => total + question.points, 0),
+		answers,
+		examIds: [...examIds],
+		questionScores,
+	};
+}
 
 interface PracticeState {
 	currentIndex: number;
@@ -60,6 +101,7 @@ export function usePracticeSession(
 	questions: Question[],
 	subjectId: string,
 	topic: string,
+	selectedExamIds: readonly string[],
 ) {
 	const [state, dispatch] = useReducer(reducer, {
 		currentIndex: 0,
@@ -70,6 +112,8 @@ export function usePracticeSession(
 	});
 
 	const attemptIdRef = useRef("");
+	const submittedQuestionsRef = useRef<Question[] | null>(null);
+	const submittedExamIdsRef = useRef<string[] | null>(null);
 
 	useEffect(() => {
 		dispatch({
@@ -94,55 +138,66 @@ export function usePracticeSession(
 	const handleSubmit = useCallback(() => {
 		const id = getNow().toString();
 		attemptIdRef.current = id;
-		let score = 0;
-		for (const q of questions) {
-			score += getQuestionScore(q, state.answers[q.id] || "", state.selfGrades);
-		}
+		submittedQuestionsRef.current = [...questions];
+		submittedExamIdsRef.current = [...selectedExamIds];
+		const attempt = createPracticeAttempt(
+			id,
+			topic,
+			questions,
+			state.answers,
+			state.selfGrades,
+			selectedExamIds,
+		);
 		const answeredCount = Object.values(state.answers).filter(
 			(a) => a && a.trim() !== "",
 		).length;
 		track("practice_submit", {
 			subjectId,
 			topic,
-			score,
-			maxScore: questions.reduce((s, q) => s + q.points, 0),
+			score: attempt.score,
+			maxScore: attempt.maxScore,
 			questionsCount: questions.length,
 			answered: answeredCount,
 		});
-		saveAttempt(subjectId, {
-			id,
-			examId: "practice",
-			mode: "practice",
-			topic,
-			date: new Date().toISOString(),
-			score,
-			maxScore: questions.reduce((s, q) => s + q.points, 0),
-			answers: state.answers,
-		});
+		saveAttempt(subjectId, attempt);
 		dispatch({ type: "SUBMIT" });
-	}, [subjectId, topic, questions, state.answers, state.selfGrades]);
+	}, [
+		subjectId,
+		topic,
+		questions,
+		selectedExamIds,
+		state.answers,
+		state.selfGrades,
+	]);
 
 	const handleSelfGrade = useCallback(
 		(questionId: string, grade: "correct" | "incorrect") => {
 			track("practice_self_grade", { subjectId, topic, questionId, grade });
 			dispatch({ type: "SELF_GRADE", questionId, grade });
-			let score = 0;
+			if (!state.submitted) return;
+
 			const nextGrades = { ...state.selfGrades, [questionId]: grade };
-			for (const q of questions) {
-				score += getQuestionScore(q, state.answers[q.id] || "", nextGrades);
-			}
-			saveAttempt(subjectId, {
-				id: attemptIdRef.current || getNow().toString(),
-				examId: "practice",
-				mode: "practice",
+			const submittedQuestions = submittedQuestionsRef.current ?? questions;
+			const submittedExamIds = submittedExamIdsRef.current ?? selectedExamIds;
+			const attempt = createPracticeAttempt(
+				attemptIdRef.current,
 				topic,
-				date: new Date().toISOString(),
-				score,
-				maxScore: questions.reduce((s, q) => s + q.points, 0),
-				answers: state.answers,
-			});
+				submittedQuestions,
+				state.answers,
+				nextGrades,
+				submittedExamIds,
+			);
+			saveAttempt(subjectId, attempt);
 		},
-		[subjectId, topic, questions, state.answers, state.selfGrades],
+		[
+			subjectId,
+			topic,
+			questions,
+			selectedExamIds,
+			state.answers,
+			state.selfGrades,
+			state.submitted,
+		],
 	);
 
 	const handleCheckQuestion = useCallback(

--- a/src/pages/PracticeTopic.tsx
+++ b/src/pages/PracticeTopic.tsx
@@ -972,7 +972,12 @@ export default function PracticeTopic() {
 		() => filterQuestionsByExamSelection(allTopicQuestions, selectedExamIds),
 		[allTopicQuestions, selectedExamIds],
 	);
-	const session = usePracticeSession(questions, subject?.id || "", topic || "");
+	const session = usePracticeSession(
+		questions,
+		subject?.id || "",
+		topic || "",
+		selectedExamIds,
+	);
 	const navigation = usePracticeTopicNavigation({
 		subject,
 		topicInfo,

--- a/src/pages/SubjectHome.tsx
+++ b/src/pages/SubjectHome.tsx
@@ -44,6 +44,7 @@ import { formatPoints } from "../lib/points";
 import { playSound } from "../lib/sound";
 import { track } from "../lib/umami";
 import { getSubject } from "../subjects";
+import { getQuestionSummaries } from "../subjects/questionSummaries.generated";
 
 const subscribeToHydration = () => () => {};
 
@@ -89,10 +90,8 @@ export default function SubjectHome({
 		subject && questionsLoaded && storageReady
 			? getTopicProgress(
 					subject.id,
-					Object.entries(selectedStats.topicStats).map(([topic, stats]) => ({
-						topic,
-						points: stats.points,
-					})),
+					getQuestionSummaries(subject.id),
+					selectedExamIds,
 				)
 			: {};
 	if (!subject) {


### PR DESCRIPTION
# Resumen

Actualiza el cálculo del progreso de práctica para realizar el seguimiento por pregunta y respetar las fuentes de examen seleccionadas. Esto evita mezclar resultados entre fuentes o contabilizar intentos de simulación como progreso de práctica.

## Cambios

- Guarda las fuentes incluidas y la puntuación individual de cada pregunta en los intentos de práctica.
- Actualiza los intentos existentes al cambiar una autoevaluación.
- Conserva el mejor resultado por pregunta y limita el progreso a las fuentes seleccionadas.
- Excluye los intentos antiguos sin metadatos nuevos del cálculo filtrado por fuente, porque no es posible atribuirlos de forma segura a una fuente concreta.
- Preserva el progreso agregado legacy cuando se muestran todas las fuentes y lo excluye cuando la selección no permite atribuirlo a una fuente.
- Añade pruebas unitarias para selección de fuentes, mejores resultados, autoevaluación, preguntas repetidas y simulaciones.

## Issue relacionada

Closes #146

## Tipo de cambio

- [ ] Contenido o preguntas
- [x] Interfaz o accesibilidad
- [ ] Rendimiento, SEO, Optimizaciones
- [ ] Herramientas o documentación

## Comprobaciones

- [ ] `pnpm check`
- [x] `pnpm typecheck`
- [ ] `pnpm lint`
- [x] `pnpm build`
- [ ] `pnpm run doctor`
- [ ] He probado el preview si el cambio afecta al comportamiento o al aspecto de la app.
- [x] He ejecutado `pnpm readme` si he añadido o modificado una asignatura, o no aplica.

`pnpm run check` mantiene un fallo de formato preexistente en `src/components/KeyboardShortcutsSection.tsx`, un archivo que esta PR no modifica.

## Revisión específica

- [x] He probado las rutas y los idiomas afectados.
- [ ] He revisado el comportamiento en mobile si el cambio afecta a la interfaz.
- [ ] He comprobado teclado y nombres accesibles si el cambio afecta a controles.
- [ ] He revisado title, description, Open Graph y sitemap si el cambio afecta al SEO.

## Capturas o notas para revisar

El cambio afecta al cálculo del progreso mostrado en la página de inicio de la asignatura y a los resultados de las sesiones de práctica. Conviene verificar una sesión con varias fuentes seleccionadas y otra con una única fuente.

## Checklist

- [x] No he incluido secretos ni archivos generados innecesarios.
- [ ] He actualizado la documentación relacionada.
- [ ] Esta PR está lista para revisión.



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR records source-aware, per-question practice results and uses them to calculate progress for the learner’s selected exam sources while retaining attributable legacy progress.
- Adds source IDs and per-question scores to persisted practice attempts.
- Updates the same attempt after post-submission self-grading.
- Aggregates each question’s best result and excludes simulation attempts.
- Calculates topic totals and earned points from the selected sources.
- Adds unit coverage for source filtering, legacy records, repeated questions, self-grading, and simulations.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/data/store.ts | Replaces topic-level attempt aggregation with selected-source, best-per-question progress while retaining legacy aggregate scores in the full-source view. |
| src/hooks/usePracticeSession.ts | Persists source and question-level scoring metadata and updates the submitted attempt after self-grading. |
| src/data/types.ts | Extends persisted practice attempts with optional metadata compatible with legacy records. |
| src/pages/SubjectHome.tsx | Supplies complete question summaries and the current source selection to progress aggregation. |
| src/pages/PracticeTopic.tsx | Passes the active exam-source selection into the practice session. |
| src/data/__tests__/store.test.ts | Covers source filtering, best-per-question aggregation, attempt replacement, repeated questions, simulation exclusion, and legacy preservation. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Q[Selected practice questions] --> S[Submit session]
  S --> A[Persist source IDs and per-question scores]
  G[Post-submit self-grading] --> A
  A --> B[Best score per question]
  E[Selected exam sources] --> B
  B --> P[Topic progress]
  L[Legacy topic score] -->|All question-bearing sources selected| P
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(progress): preserve legacy practice ..."](https://github.com/teenbiscuits/pasame-examenes/commit/395ad1c11da4f0b0b56c452e32fb7ec7d858c3a3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58450366)</sub>

**Context used:**

- Knowledge Base — [Session state and progress](https://app.greptile.com/pablopl/-/custom-context/knowledge-base/teenbiscuits/pasame-examenes/-/docs/session-state-and-progress.md)
- Knowledge Base — [Practice experience](https://app.greptile.com/pablopl/-/custom-context/knowledge-base/teenbiscuits/pasame-examenes/-/docs/practice-experience.md)

<!-- /greptile_comment -->