### PR TITLE
Añade aviso de partidos y estado de disponibilidad

### DIFF
--- a/src/components/AppChrome.tsx
+++ b/src/components/AppChrome.tsx
@@ -14,6 +14,7 @@ import { useTheme } from "../theme/hooks";
 import AppUpdateToast from "./AppUpdateToast";
 import Footer from "./Footer";
 import Header from "./Header";
+import MatchWarningBanner from "./MatchWarningBanner";
 import SessionTracker from "./SessionTracker";
 import StarPopup from "./StarPopup";
 
@@ -36,6 +37,7 @@ export default function AppChrome({ children }: { children: ReactNode }) {
 				>
 					{t.header.skipToContent}
 				</a>
+				<MatchWarningBanner />
 				<Header />
 				<main id="main-content" tabIndex={-1} className="flex-grow">
 					{children}

--- a/src/components/MatchWarningBanner.tsx
+++ b/src/components/MatchWarningBanner.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useState } from "react";
+import { Alarm } from "reicon-react";
+import { useT } from "../i18n/hooks";
+
+const MATCH_STATUS_ENDPOINT = "/api/match-status";
+const CHECK_DELAY_MS = 5000;
+const CHECK_INTERVAL_MS = 5 * 60 * 1000;
+
+type IdleWindow = Window & {
+	requestIdleCallback?: (
+		callback: () => void,
+		options?: { timeout: number },
+	) => number;
+	cancelIdleCallback?: (id: number) => void;
+};
+
+function isMatchStatus(value: unknown): value is { blocked: boolean } {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"blocked" in value &&
+		typeof value.blocked === "boolean"
+	);
+}
+
+export default function MatchWarningBanner() {
+	const t = useT();
+	const [isBlocked, setIsBlocked] = useState(false);
+
+	useEffect(() => {
+		let cancelled = false;
+		let intervalId: number | undefined;
+
+		const checkMatchStatus = async () => {
+			try {
+				const response = await fetch(MATCH_STATUS_ENDPOINT, {
+					cache: "no-store",
+				});
+				if (!response.ok) throw new Error(`HTTP ${response.status}`);
+
+				const result: unknown = await response.json();
+				if (!isMatchStatus(result)) throw new Error("Invalid match status");
+
+				if (!cancelled) setIsBlocked(result.blocked);
+			} catch {
+				// This auxiliary warning should never affect the rest of the app.
+			}
+		};
+
+		const startChecks = () => {
+			void checkMatchStatus();
+			intervalId = window.setInterval(() => {
+				void checkMatchStatus();
+			}, CHECK_INTERVAL_MS);
+		};
+
+		const browserWindow = window as IdleWindow;
+		let idleId: number | undefined;
+		const delayId = window.setTimeout(() => {
+			if (browserWindow.requestIdleCallback) {
+				idleId = browserWindow.requestIdleCallback(startChecks, {
+					timeout: CHECK_DELAY_MS,
+				});
+			} else {
+				startChecks();
+			}
+		}, CHECK_DELAY_MS);
+
+		return () => {
+			cancelled = true;
+			window.clearTimeout(delayId);
+			if (idleId !== undefined) {
+				browserWindow.cancelIdleCallback?.(idleId);
+			}
+			if (intervalId !== undefined) window.clearInterval(intervalId);
+		};
+	}, []);
+
+	if (!isBlocked) return null;
+
+	return (
+		<div
+			role="status"
+			aria-live="polite"
+			aria-atomic="true"
+			className="border-warning-border bg-warning-bg text-warning-fg border-b"
+		>
+			<div className="mx-auto flex max-w-6xl items-start justify-center gap-2 px-4 py-2.5 text-center text-sm leading-relaxed sm:items-center sm:py-2">
+				<Alarm
+					size={16}
+					aria-hidden="true"
+					className="mt-0.5 shrink-0 sm:mt-0"
+				/>
+				<p>
+					{t.header.matchWarning}{" "}
+					<a
+						href="https://hayahora.futbol/"
+						target="_blank"
+						rel="noopener noreferrer"
+						className="font-semibold underline decoration-current underline-offset-4 hover:no-underline focus-visible:ring-2 focus-visible:ring-warning-fg focus-visible:outline-none"
+					>
+						{t.header.matchWarningMore}
+					</a>
+				</p>
+			</div>
+		</div>
+	);
+}

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -111,6 +111,9 @@ export const en = {
 		star: "Star",
 		starOnGithub: "Star on GitHub",
 		skipToContent: "Skip to main content",
+		matchWarning:
+			"A football match is being played today, so this site may be slower because of La Liga!",
+		matchWarningMore: "More information",
 	},
 	settings: {
 		title: "Settings",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -113,6 +113,9 @@ export const es: Translations = {
 		star: "Estrella",
 		starOnGithub: "Dar una estrella en GitHub",
 		skipToContent: "Ir al contenido principal",
+		matchWarning:
+			"¡Hoy se juega un partido de fútbol, así que esta web es más lenta por culpa de La Liga!",
+		matchWarningMore: "Más información",
 	},
 	settings: {
 		title: "Ajustes",

--- a/src/i18n/gl.ts
+++ b/src/i18n/gl.ts
@@ -114,6 +114,9 @@ export const gl: Translations = {
 		star: "Estrela",
 		starOnGithub: "Dar unha estrela en GitHub",
 		skipToContent: "Ir ao contido principal",
+		matchWarning:
+			"Hoxe xógase un partido de fútbol, polo que esta web pode ir máis lenta por culpa de La Liga!",
+		matchWarningMore: "Máis información",
 	},
 	settings: {
 		title: "Axustes",

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -20,6 +20,7 @@ import { Route as LangSplatRouteImport } from './routes/$lang.$'
 import { Route as LangSubjectIdRouteImport } from './routes/$lang.$subjectId'
 import { Route as LangPrivacyRouteImport } from './routes/$lang.privacy'
 import { Route as SubjectIdPracticeRouteImport } from './routes/$subjectId_.practice'
+import { Route as ApiMatchStatusRouteImport } from './routes/api.match-status'
 import { Route as LangSubjectIdPracticeRouteImport } from './routes/$lang.$subjectId_.practice'
 import { Route as SubjectIdExamExamIdRouteImport } from './routes/$subjectId_.exam.$examId'
 import { Route as SubjectIdPracticeTopicRouteImport } from './routes/$subjectId_.practice_.$topic'
@@ -82,6 +83,11 @@ const SubjectIdPracticeRoute = SubjectIdPracticeRouteImport.update({
   path: '/$subjectId/practice',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiMatchStatusRoute = ApiMatchStatusRouteImport.update({
+  id: '/api/match-status',
+  path: '/api/match-status',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const LangSubjectIdPracticeRoute = LangSubjectIdPracticeRouteImport.update({
   id: '/$subjectId_/practice',
   path: '/$subjectId/practice',
@@ -126,6 +132,7 @@ export interface FileRoutesByFullPath {
   '/$lang/$subjectId': typeof LangSubjectIdRoute
   '/$lang/privacy': typeof LangPrivacyRoute
   '/$subjectId/practice': typeof SubjectIdPracticeRoute
+  '/api/match-status': typeof ApiMatchStatusRoute
   '/$lang/': typeof LangIndexRoute
   '/$lang/$subjectId/practice': typeof LangSubjectIdPracticeRoute
   '/$subjectId/exam/$examId': typeof SubjectIdExamExamIdRoute
@@ -143,6 +150,7 @@ export interface FileRoutesByTo {
   '/$lang/$subjectId': typeof LangSubjectIdRoute
   '/$lang/privacy': typeof LangPrivacyRoute
   '/$subjectId/practice': typeof SubjectIdPracticeRoute
+  '/api/match-status': typeof ApiMatchStatusRoute
   '/$lang': typeof LangIndexRoute
   '/$lang/$subjectId/practice': typeof LangSubjectIdPracticeRoute
   '/$subjectId/exam/$examId': typeof SubjectIdExamExamIdRoute
@@ -162,6 +170,7 @@ export interface FileRoutesById {
   '/$lang/$subjectId': typeof LangSubjectIdRoute
   '/$lang/privacy': typeof LangPrivacyRoute
   '/$subjectId_/practice': typeof SubjectIdPracticeRoute
+  '/api/match-status': typeof ApiMatchStatusRoute
   '/$lang/': typeof LangIndexRoute
   '/$lang/$subjectId_/practice': typeof LangSubjectIdPracticeRoute
   '/$subjectId_/exam/$examId': typeof SubjectIdExamExamIdRoute
@@ -182,6 +191,7 @@ export interface FileRouteTypes {
     | '/$lang/$subjectId'
     | '/$lang/privacy'
     | '/$subjectId/practice'
+    | '/api/match-status'
     | '/$lang/'
     | '/$lang/$subjectId/practice'
     | '/$subjectId/exam/$examId'
@@ -199,6 +209,7 @@ export interface FileRouteTypes {
     | '/$lang/$subjectId'
     | '/$lang/privacy'
     | '/$subjectId/practice'
+    | '/api/match-status'
     | '/$lang'
     | '/$lang/$subjectId/practice'
     | '/$subjectId/exam/$examId'
@@ -217,6 +228,7 @@ export interface FileRouteTypes {
     | '/$lang/$subjectId'
     | '/$lang/privacy'
     | '/$subjectId_/practice'
+    | '/api/match-status'
     | '/$lang/'
     | '/$lang/$subjectId_/practice'
     | '/$subjectId_/exam/$examId'
@@ -233,6 +245,7 @@ export interface RootRouteChildren {
   SitemapDotxmlRoute: typeof SitemapDotxmlRoute
   Char123INDEXNOW_KEYChar125DottxtRoute: typeof Char123INDEXNOW_KEYChar125DottxtRoute
   SubjectIdPracticeRoute: typeof SubjectIdPracticeRoute
+  ApiMatchStatusRoute: typeof ApiMatchStatusRoute
   SubjectIdExamExamIdRoute: typeof SubjectIdExamExamIdRoute
   SubjectIdPracticeTopicRoute: typeof SubjectIdPracticeTopicRoute
 }
@@ -316,6 +329,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SubjectIdPracticeRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/match-status': {
+      id: '/api/match-status'
+      path: '/api/match-status'
+      fullPath: '/api/match-status'
+      preLoaderRoute: typeof ApiMatchStatusRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/$lang/$subjectId_/practice': {
       id: '/$lang/$subjectId_/practice'
       path: '/$subjectId/practice'
@@ -384,6 +404,7 @@ const rootRouteChildren: RootRouteChildren = {
   SitemapDotxmlRoute: SitemapDotxmlRoute,
   Char123INDEXNOW_KEYChar125DottxtRoute: Char123INDEXNOW_KEYChar125DottxtRoute,
   SubjectIdPracticeRoute: SubjectIdPracticeRoute,
+  ApiMatchStatusRoute: ApiMatchStatusRoute,
   SubjectIdExamExamIdRoute: SubjectIdExamExamIdRoute,
   SubjectIdPracticeTopicRoute: SubjectIdPracticeTopicRoute,
 }

--- a/src/routes/api.match-status.ts
+++ b/src/routes/api.match-status.ts
@@ -1,0 +1,37 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+const BLOCKED_LIST_URL = "https://hayahora.futbol/estado/blocked-any.txt";
+const UPSTREAM_TIMEOUT_MS = 5000;
+
+function hasBlockedEntries(content: string): boolean {
+	return content.split(/\r?\n/).some((line) => line.trim().length > 0);
+}
+
+export const Route = createFileRoute("/api/match-status")({
+	server: {
+		handlers: {
+			GET: async () => {
+				try {
+					const response = await fetch(BLOCKED_LIST_URL, {
+						cache: "no-store",
+						headers: { Accept: "text/plain" },
+						signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
+					});
+					if (!response.ok) throw new Error(`HTTP ${response.status}`);
+
+					return Response.json(
+						{ blocked: hasBlockedEntries(await response.text()) },
+						{
+							headers: { "Cache-Control": "no-store" },
+						},
+					);
+				} catch {
+					return new Response(null, {
+						status: 502,
+						headers: { "Cache-Control": "no-store" },
+					});
+				}
+			},
+		},
+	},
+});


### PR DESCRIPTION
# Resumen

Añade un aviso global cuando hay un partido de fútbol que puede afectar al rendimiento de la web por la carga de La Liga.

## Cambios

- Añade `MatchWarningBanner` al chrome principal de la aplicación.
- Consulta periódicamente el endpoint `/api/match-status` después de un breve retraso y durante tiempos de inactividad del navegador.
- Añade el endpoint que consulta la lista externa de partidos bloqueados con timeout y respuestas `502` ante errores.
- Incluye traducciones en español, gallego e inglés.
- El aviso usa semántica accesible (`role="status"`, `aria-live`) y enlaza a más información.
- Se actualiza el árbol de rutas generado para incluir el nuevo endpoint.

## Issue relacionada

No aplica.

## Tipo de cambio

- [ ] Contenido o preguntas
- [x] Interfaz o accesibilidad
- [ ] Rendimiento, SEO, Optimizaciones
- [ ] Herramientas o documentación

## Comprobaciones

- [ ] `pnpm check`
- [ ] `pnpm typecheck`
- [ ] `pnpm lint`
- [ ] `pnpm build`
- [ ] `pnpm run doctor`
- [ ] He probado el preview si el cambio afecta al comportamiento o al aspecto de la app.
- [ ] He ejecutado `pnpm readme` si he añadido o modificado una asignatura, o no aplica.

## Revisión específica

- [x] He probado las rutas y los idiomas afectados.
- [ ] He revisado el comportamiento en mobile si el cambio afecta a la interfaz.
- [ ] He comprobado teclado y nombres accesibles si el cambio afecta a controles.
- [ ] He revisado title, description, Open Graph y sitemap si el cambio afecta al SEO.

## Capturas o notas para revisar

El aviso depende de `https://hayahora.futbol/estado/blocked-any.txt`. Si la consulta externa falla, el endpoint devuelve `502` y el aviso no interrumpe el funcionamiento de la aplicación.

## Checklist

- [x] No he incluido secretos ni archivos generados innecesarios.
- [ ] He actualizado la documentación relacionada.
- [x] Esta PR está lista para revisión.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Añade un aviso global y localizado sobre posibles ralentizaciones durante partidos, respaldado por un nuevo endpoint que consulta periódicamente una lista externa.
- Monta el aviso en el chrome principal y lo actualiza cada cinco minutos.
- Incorpora traducciones en español, gallego e inglés.
- Registra la nueva ruta `/api/match-status` y gestiona fallos del proveedor mediante respuestas 502.
</details>


<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with non-blocking improvements recommended for stale-status handling and bounding uncached upstream work.

The banner and endpoint are functionally integrated, but failed refreshes preserve obsolete positive state and the public proxy maps every request to a fresh external fetch.

**Files Needing Attention:** src/components/MatchWarningBanner.tsx, src/routes/api.match-status.ts

<details open><summary><h3>Security Review</h3></summary>

El endpoint público reenvía cada solicitud como una consulta externa sin caché ni limitación visible, lo que permite amplificar ráfagas de tráfico y trabajo del servidor.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/components/MatchWarningBanner.tsx | Implements delayed periodic polling and accessible banner rendering, but failed refreshes can retain stale positive status. |
| src/routes/api.match-status.ts | Adds the external-status proxy with timeout and response validation, while forwarding every request upstream without caching or coalescing. |
| src/components/AppChrome.tsx | Mounts the new banner globally before the header. |
| src/i18n/en.ts | Adds English copy for the warning and information link. |
| src/i18n/es.ts | Adds Spanish copy for the warning and information link. |
| src/i18n/gl.ts | Adds Galician copy for the warning and information link. |
| src/routeTree.gen.ts | Registers the generated route types and root child for the new API endpoint. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant B as Browser
    participant C as MatchWarningBanner
    participant A as /api/match-status
    participant U as hayahora.futbol
    B->>C: Mount application chrome
    C->>C: Wait for delay/idle callback
    loop Every 5 minutes
        C->>A: GET status
        A->>U: Uncached GET blocked-any.txt
        alt Upstream succeeds
            U-->>A: Plain-text list
            A-->>C: "{ blocked: boolean }"
            C->>C: Update banner state
        else Upstream fails or times out
            A-->>C: 502
            C->>C: Preserve previous state
        end
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/components/MatchWarningBanner.tsx:45-47
**Stale positive status persists**

After a successful blocked response, any later network, upstream, or payload error is swallowed without clearing or expiring `isBlocked`. The long-lived banner therefore continues telling users that a match is affecting the site until another successful poll or a full remount.

### Issue 2
src/routes/api.match-status.ts:15-19
**Requests amplify upstream traffic**

If many sessions poll concurrently or an automated client repeatedly calls this public route, every request starts a separate uncached upstream fetch that can remain active for five seconds. This amplifies traffic and serverless work instead of bounding or coalescing access to the fixed external resource.

**How this was verified:** The handler uses `cache: "no-store"` for every upstream fetch, returns non-cacheable responses, and has no endpoint-specific throttling or coalescing in the repository configuration.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add match warning banner"](https://github.com/teenbiscuits/pasame-examenes/commit/bac410bff5e35e5e4f3171a90dfc0eb088ddab53) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58450407)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->